### PR TITLE
Application Name Component

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,8 +4,10 @@ Cerner Corporation
 - Matt Henkes [@mjhenkes]
 - Emily Rohrbough [@emilyrohrbough]
 - Dave Kasper [@dkasper-was-taken]
+- Derek Yu [@yuderekyu]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@dkasper-was-taken]: https://github.com/dkasper-was-taken
+[@yuderekyu]: https://github.com/yuderekyu

--- a/packages/terra-framework-application-name/.npmignore
+++ b/packages/terra-framework-application-name/.npmignore
@@ -1,0 +1,6 @@
+*.log
+node_modules
+src
+target
+reports
+tests

--- a/packages/terra-framework-application-name/.npmignore
+++ b/packages/terra-framework-application-name/.npmignore
@@ -1,6 +1,4 @@
 *.log
 node_modules
-src
 target
 reports
-tests

--- a/packages/terra-framework-application-name/.npmrc
+++ b/packages/terra-framework-application-name/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/terra-framework-application-name/CHANGELOG.md
+++ b/packages/terra-framework-application-name/CHANGELOG.md
@@ -1,0 +1,6 @@
+ChangeLog
+=========
+
+Unreleased
+-----------------
+* Initial stable release

--- a/packages/terra-framework-application-name/LICENSE
+++ b/packages/terra-framework-application-name/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/packages/terra-framework-application-name/NOTICE
+++ b/packages/terra-framework-application-name/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2018 Cerner Innovation, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/terra-framework-application-name/README.md
+++ b/packages/terra-framework-application-name/README.md
@@ -1,0 +1,25 @@
+# Terra Framework Application Name
+
+
+[![NPM version](http://img.shields.io/npm/v/terra-framework-application-name.svg)](https://www.npmjs.org/package/terra-framework-application-name)
+[![Build Status](https://travis-ci.org/cerner/terra-framework.svg?branch=master)](https://travis-ci.org/cerner/terra-framework)
+
+{insert description}
+
+- [Getting Started](#getting-started)
+- [Documentation](https://github.com/cerner/terra-framework/tree/master/packages/terra-framework-application-name/docs)
+- [LICENSE](#license)
+
+## Getting Started
+
+- Install from [npmjs](https://www.npmjs.com): `npm install terra-framework-application-name`
+
+## LICENSE
+
+Copyright 2017 Cerner Innovation, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+&nbsp;&nbsp;&nbsp;&nbsp;http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/terra-framework-application-name/docs/README.md
+++ b/packages/terra-framework-application-name/docs/README.md
@@ -1,0 +1,28 @@
+# Terra Framework Application Name
+
+{insert description}
+
+## Getting Started
+
+- Install with [npmjs](https://www.npmjs.com):
+  - `npm install terra-framework-application-name`
+
+## Usage
+
+```jsx
+import React from 'react';
+import ApplicationName from 'terra-framework-application-name';
+
+<ApplicationName {props...} />
+```
+
+## Component Features
+
+<!-- Uncomment supported features.
+ * [Cross-Browser Support](https://github.com/cerner/terra-core/wiki/Component-Features#cross-browser-support)
+ * [Responsive Support](https://github.com/cerner/terra-core/wiki/Component-Features#responsive-support)
+ * [Mobile Support](https://github.com/cerner/terra-core/wiki/Component-Features#mobile-support)
+ * [Internationalization Support](https://github.com/cerner/terra-core/wiki/Component-Features#internationalization-i18n-support)
+ * [Localization Support](https://github.com/cerner/terra-core/wiki/Component-Features#localization-support)
+ * [LTR/RTL Support](https://github.com/cerner/terra-core/wiki/Component-Features#ltr--rtl-support)
+ -->

--- a/packages/terra-framework-application-name/package.json
+++ b/packages/terra-framework-application-name/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "terra-framework-application-name",
+  "main": "lib/ApplicationName.js",
+  "version": "0.0.0",
+  "description": "{insert description}",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cerner/terra-framework.git"
+  },
+  "keywords": [
+    "Cerner",
+    "Terra",
+    "Framework",
+    "terra-framework-application-name",
+    "ApplicationName",
+    "UI"
+  ],
+  "author": "Cerner Corporation",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/cerner/terra-framework/issues"
+  },
+  "homepage": "https://github.com/cerner/terra-framework#readme",
+  "devDependencies": {
+    "terra-props-table": "^1.10.1"
+  },
+  "peerDependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "terra-base": "^2.0.0"
+  },
+  "dependencies": {
+    "classnames": "^2.2.5",
+    "prop-types": "^15.5.8",
+    "terra-base": "^2.0.0"
+  },
+  "scripts": {
+    "compile": "npm run compile:clean && npm run compile:build",
+    "compile:clean": "rimraf lib",
+    "compile:build": "babel src --out-dir lib --copy-files",
+    "lint": "npm run lint:js && npm run lint:scss",
+    "lint:js": "eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
+    "lint:scss": "stylelint src/**/*.scss",
+    "props-table": "props-table ./src/ApplicationName.jsx --out-dir ./docs/props-table",
+    "test": "npm run test:jest && npm run test:nightwatch",
+    "test:jest": "jest ./tests/jest/* --config ../../jestconfig.json",
+    "test:nightwatch": "nightwatch -c ../../nightwatch.conf.js"
+  }
+}

--- a/packages/terra-framework-application-name/src/ApplicationName.jsx
+++ b/packages/terra-framework-application-name/src/ApplicationName.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import 'terra-base/lib/baseStyles';
+import styles from './ApplicationName.scss';
+
+const cx = classNames.bind(styles);
+
+const propTypes = {
+ /*
+ * Content to be displayed as the name
+ */
+  name: PropTypes.string,
+};
+
+const defaultProps = {
+  name: 'default',
+};
+
+const ApplicationName = ({ name, ...customProps }) => {
+  const attributes = Object.assign({}, customProps);
+  const ApplicationNameClassNames = cx([
+    'application-name',
+    attributes.className,
+  ]);
+
+  return (<div {...attributes} className={ApplicationNameClassNames} />)
+};
+
+ApplicationName.propTypes = propTypes;
+ApplicationName.defaultProps = defaultProps;
+
+export default ApplicationName;

--- a/packages/terra-framework-application-name/src/ApplicationName.scss
+++ b/packages/terra-framework-application-name/src/ApplicationName.scss
@@ -1,0 +1,5 @@
+:local {
+  .application-name {
+
+  }
+}

--- a/packages/terra-framework-application-name/tests/jest/ApplicationName.test.jsx
+++ b/packages/terra-framework-application-name/tests/jest/ApplicationName.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ApplicationName from '../../src/ApplicationName';
+
+describe('ApplicationName', () => {
+  const defaultRender = <ApplicationName />;
+
+  // Snapshot Tests
+  it('should render a default component', () => {
+    const wrapper = shallow(defaultRender);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  // Prop Tests
+  it('should use the default value when no value is given', () => {
+    const wrapper = shallow(defaultRender);
+    expect(wrapper.find('.application-name').text()).toEqual('defualt');
+  });
+
+  // Structure Tests
+  it('should have the class application-name', () => {
+    const wrapper = shallow(defaultRender);
+    expect(wrapper.prop('className')).toContain('application-name');
+  });
+});

--- a/packages/terra-framework-application-name/tests/nightwatch/ApplicationNameTestRoutes.jsx
+++ b/packages/terra-framework-application-name/tests/nightwatch/ApplicationNameTestRoutes.jsx
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { Route } from 'react-router';
+import ApplicationNameTests from './ApplicationNameTests';
+
+// Test Cases
+import DefaultApplicationName from './DefaultApplicationName';
+
+const routes = (
+  <div>
+    <Route path="/tests/application-name-tests" component={ApplicationNameTests} />
+    <Route path="/tests/application-name-tests/default" component={DefaultApplicationName} />
+  </div>
+);
+
+export default routes;

--- a/packages/terra-framework-application-name/tests/nightwatch/ApplicationNameTests.jsx
+++ b/packages/terra-framework-application-name/tests/nightwatch/ApplicationNameTests.jsx
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { Link } from 'react-router';
+
+const ApplicationNameTests = () => (
+  <div>
+    <ul>
+      <li><Link to="/tests/application-name-tests/default">ApplicationName - Default</Link></li>
+    </ul>
+  </div>
+);
+
+export default ApplicationNameTests;

--- a/packages/terra-framework-application-name/tests/nightwatch/DefaultApplicationName.jsx
+++ b/packages/terra-framework-application-name/tests/nightwatch/DefaultApplicationName.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import ApplicationName from '../../lib/ApplicationName';
+
+export default () => <ApplicationName />;

--- a/packages/terra-framework-application-name/tests/nightwatch/application-name-spec.js
+++ b/packages/terra-framework-application-name/tests/nightwatch/application-name-spec.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-unused-expressions */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const resizeTo = require('terra-toolkit/lib/nightwatch/responsive-helpers').resizeTo;
+
+module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous'], {
+  'Displays a default application-name': (browser) => {
+    browser
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/application-name-tests/default`)
+      .expect.element('.application-name').to.be.present;
+  },
+});

--- a/packages/terra-framework-site/src/examples/application-name/Index.jsx
+++ b/packages/terra-framework-site/src/examples/application-name/Index.jsx
@@ -1,0 +1,22 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import PropsTable from 'terra-props-table';
+import Markdown from 'terra-markdown';
+import ReadMe from 'terra-framework-application-name/docs/README.md';
+import { version } from 'terra-framework-application-name/package.json';
+
+// Component Source
+// eslint-disable-next-line import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions
+import ApplicationNameSrc from '!raw-loader!terra-framework-application-name/src/ApplicationName';
+
+// Example Files
+
+const ApplicationNameExamples = () => (
+  <div>
+    <div id="version">Version: {version}</div>
+    <Markdown id="readme" src={ReadMe} />
+    <PropsTable id="props" src={ApplicationNameSrc} />
+  </div>
+);
+
+export default ApplicationNameExamples;


### PR DESCRIPTION
### Summary
Initial skeleton for the Application Name component (generated by `generator-terra-module`). This component will be used in the higher order Navigation component to display/switch between applications a consumer has access to.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
