### PR TITLE
Fix Travis Deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  local_dir: site/build
+  local_dir: build
   on:
     branch: master


### PR DESCRIPTION
### Summary
The site directory doesn't exist. So I think this should fix it

