### PR TITLE
Add weddriver.io test functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ target
 **/aggregated-translations/*.*
 lib
 props-table
+**/__snapshots__/screen
+**/__snapshots__/diff
+errorScreenshots

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "postpublish": "npm run dependency-markdown && git add --all && git commit -m 'Updated DEPENDENCIES.md files'",
     "start": "webpack-dev-server --config node_modules/terra-site/src/config/webpack.config --progress",
     "start:express": "node scripts/express/app.js",
-    "test": "jest && nightwatch"
+    "test": "jest && nightwatch && wdio",
+    "wdio": "wdio"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -91,6 +92,7 @@
     "gh-pages": "^0.12.0",
     "glob": "^7.1.1",
     "identity-obj-proxy": "^3.0.0",
+    "ip": "^1.1.5",
     "jest": "^21.0.2",
     "lerna": "^2.1.2",
     "link-parent-bin": "^0.1.3",
@@ -109,8 +111,11 @@
     "stylelint-scss": "^2.0.0",
     "stylelint-suitcss": "^1.0.0",
     "terra-props-table": "^1.0.0",
-    "terra-site": "^2.0.0-RC.2",
+    "terra-site": "^2.0.0-RC.3",
     "terra-toolkit": "^2.7.0",
+    "wdio-mocha-framework": "^0.5.11",
+    "wdio-visual-regression-service": "^0.8.0",
+    "webdriverio": "4.9.9",
     "webpack": "^3.6.0",
     "webpack-dev-server": "2.7.1",
     "xfc": "^1.2.1"

--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+###Fixed
+* Nightwatch tests raw route now sets the size of the layout.
 
 1.1.0 - (January 23, 2018)
 ------------------

--- a/packages/terra-layout/examples/test-examples/LayoutLongText.jsx
+++ b/packages/terra-layout/examples/test-examples/LayoutLongText.jsx
@@ -6,6 +6,7 @@ import TestContent from './test-content/TestContent';
 
 const LayoutLongText = () => (
   <Layout
+    style={{ height: '768px', width: '100%', position: 'relative' }}
     key="layout-long-text"
     header={<TestHeader />}
     menu={<TestMenu />}

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,0 +1,43 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const wdioConf = require('terra-toolkit/lib/wdio/conf');
+const WebpackDevService = require('terra-toolkit/lib/wdio/services/index').WebpackDevService;
+const localIP = require('ip');
+const path = require('path');
+const webpackConfig = require('./node_modules/terra-site/src/config/webpack.config.js');
+
+const webpackPort = 8080;
+
+// Flex specs search between local pacakge and repo
+let specs = path.join('tests', 'wdio', '**', '*-spec.js');
+if (__dirname === process.cwd()) {
+  specs = path.join('packages', '*', specs);
+}
+
+const config = {
+  ...wdioConf.config,
+
+  baseUrl: `http://${localIP.address()}:${webpackPort}`,
+  specs,
+
+  // Travis only has 1 browser instace, set maxInstances to 1 to prevent timeouts
+  maxInstances: process.env.CI ? 1 : wdioConf.config.maxInstances,
+  seleniumDocker: {
+    enabled: !process.env.TRAVIS,
+  },
+
+  // Ignore deprecation warnings. When chrome supports /actions API we'll update to use those.
+  deprecationWarnings: false,
+
+  webpackPort,
+  webpackConfig,
+
+  beforeHook() {
+    // Being Terra tests are executed on an SPA, a full refresh is required
+    // in order to reset the site. This ensures customProperty tests and any
+    // other dom modifications are cleared before starting a test.
+    global.browser.refresh();
+  },
+};
+
+config.services = wdioConf.config.services.concat([WebpackDevService]);
+exports.config = config;


### PR DESCRIPTION
### Summary
Add base configuration of web driver to the framework package.

Thanks for contributing to Terra. 
@cerner/terra
