### PR TITLE
Update snapshots tests to match new default pattern updated by enzyme.

### DIFF
--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+###Updated
+* Regenerate jest test snapshots to match new version of enzyme-to-json.
 
 2.1.0 - (March 6, 2018)
 ------------------

--- a/packages/terra-layout/tests/jest/__snapshots__/Layout.test.jsx.snap
+++ b/packages/terra-layout/tests/jest/__snapshots__/Layout.test.jsx.snap
@@ -163,7 +163,6 @@ exports[`Layout Menu Disabled should render a Layout when small 1`] = `
     isOpen={false}
     isToggleEnabled={false}
     onToggle={[Function]}
-    panelBehavior="overlay"
     panelContent={null}
     size="small"
   >
@@ -214,7 +213,6 @@ exports[`Layout Menu Disabled should render a Layout when tiny 1`] = `
     isOpen={false}
     isToggleEnabled={false}
     onToggle={[Function]}
-    panelBehavior="overlay"
     panelContent={null}
     size="tiny"
   >
@@ -460,7 +458,6 @@ exports[`Layout Menu Enabled should render a Layout when small 1`] = `
     isOpen={false}
     isToggleEnabled={false}
     onToggle={[Function]}
-    panelBehavior="overlay"
     panelContent={
       <div
         layoutConfig={
@@ -525,7 +522,6 @@ exports[`Layout Menu Enabled should render a Layout when tiny 1`] = `
     isOpen={false}
     isToggleEnabled={false}
     onToggle={[Function]}
-    panelBehavior="overlay"
     panelContent={
       <div
         layoutConfig={
@@ -591,7 +587,6 @@ exports[`Layout should render a Layout with custom props 1`] = `
     isOpen={false}
     isToggleEnabled={false}
     onToggle={[Function]}
-    panelBehavior="overlay"
     panelContent={null}
     size="tiny"
   >
@@ -618,7 +613,6 @@ exports[`Layout should render a Layout without optional props 1`] = `
     isOpen={false}
     isToggleEnabled={false}
     onToggle={[Function]}
-    panelBehavior="overlay"
     panelContent={null}
     size="tiny"
   >


### PR DESCRIPTION
### Summary
Ezyme-to-json 3.3.1 removed defaulted values set in props, so we need to regenerate our snapshots.

Thanks for contributing to Terra. 
@cerner/terra
