### PR TITLE
Update themable background styles on selectable menu items in navigation

### DIFF
--- a/packages/terra-application-links/CHANGELOG.md
+++ b/packages/terra-application-links/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Changed
+* Adjusted themable styles for selected item background color/image styles
 
 3.5.0 - (April 30, 2018)
 ------------------

--- a/packages/terra-application-links/src/tabs/ApplicationTabs.scss
+++ b/packages/terra-application-links/src/tabs/ApplicationTabs.scss
@@ -174,13 +174,14 @@
     }
 
     &[aria-current='true'] {
+      background-color: var(--terra-application-tabs-collapsed-selected-background-color, #f4f4f4);
       background-size: 100%;
       border-left: var(--terra-application-tabs-collapsed-selected-border-left, 0.5rem solid #007cc3);
       font-weight: var(--terra-application-tabs-collapsed-selected-font-weight, 600);
       padding-left: var(--terra-application-tabs-collapsed-selected-padding-left, 0.7143rem);
 
       &::before {
-        background-color: var(--terra-application-tabs-collapsed-selected-background-color, #f4f4f4);
+        background-image: var(--terra-application-tabs-collapsed-selected-background-image);
         content: '';
         height: 100%;
         left: 0;

--- a/packages/terra-navigation-side-menu/CHANGELOG.md
+++ b/packages/terra-navigation-side-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Changed
+* Adjusted themable styles for selected item background color/image styles
 
 1.2.0 - (April 30, 2018)
 ------------------

--- a/packages/terra-navigation-side-menu/src/MenuItem.scss
+++ b/packages/terra-navigation-side-menu/src/MenuItem.scss
@@ -34,13 +34,14 @@
     }
 
     &.is-selected {
+      background-color: var(--terra-navigation-side-menu-item-selected-background-color, #f4f4f4);
       border-left: var(--terra-navigation-side-menu-item-selected-border-left, 0.5rem solid #007cc3);
       color: var(--terra-navigation-side-menu-item-selected-color);
       font-weight: var(--terra-navigation-side-menu-item-selected-font-weight, 600);
       padding-left: var(--terra-navigation-side-menu-item-selected-padding-left, 0.7143rem);
 
       &::before {
-        background-color: var(--terra-navigation-side-menu-item-selected-background-color, #f4f4f4);
+        background-image: var(--terra-navigation-side-menu-item-selected-background-image);
         content: '';
         height: 100%;
         left: 0;


### PR DESCRIPTION
### Summary
This change resolves the aXe tests erroneously logging contrast issues as the background color now get's set on a DOM element instead of the pseudo-element. Styles for background-image have been left on the pseudo-element to work around layering issue with background-images and focus styles.