### PR TITLE
Fixed ariaLabel props in NotificationDialog

### DIFF
--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -3,6 +3,7 @@ ChangeLog
 
 Unreleased
 -----------------
+* Fixed naming of aria-label prop being passed to AbstractModal
 
 1.0.0 - (June 19, 2018)
 ----------------

--- a/packages/terra-notification-dialog/src/NotificationDialog.jsx
+++ b/packages/terra-notification-dialog/src/NotificationDialog.jsx
@@ -179,7 +179,7 @@ class NotificationDialog extends React.Component {
 
     return (
       <AbstractModal
-        aria-label="Notification Dialog"
+        ariaLabel="Notification Dialog"
         aria-labelledby="notification-dialog-header"
         aria-describedby={title ? 'notification-dialog-title' : 'notification-dialog-header'}
         role="alertdialog"

--- a/packages/terra-notification-dialog/src/terra-dev-site/test/notification-dialog/NotificationDialogVariant.test.jsx
+++ b/packages/terra-notification-dialog/src/terra-dev-site/test/notification-dialog/NotificationDialogVariant.test.jsx
@@ -8,7 +8,7 @@ const clickOK = () => {
 };
 
 const propTypes = {
-  variant: PropTypes.oneOf(NotificationDialogVariants),
+  variant: PropTypes.oneOf(Object.values(NotificationDialogVariants)),
 };
 
 class NotificationDialogVariant extends React.Component {


### PR DESCRIPTION
### Summary
Fixed the naming of the aria label prop being passed down from `NotificationDialog` to `AbstractModal`.

Closes #207.

### Additional Details
In addition, there was a propType warning for one of the tests. The `propType.oneOf` was being passed an object instead of an array.

Thanks for contributing to Terra. 
@cerner/terra
