### PR TITLE
Remove CSS 'initial' Value

### DIFF
--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Fixed
+* Removed usage of CSS `initial` value because Internet Explorer does not support it
 
 1.2.0 - (July 3, 2018)
 ------------------

--- a/packages/terra-notification-dialog/src/NotificationDialog.scss
+++ b/packages/terra-notification-dialog/src/NotificationDialog.scss
@@ -113,7 +113,7 @@
     width: 100%;
 
     > button {
-      flex: var(--terra-notification-dialog-actions-button-flex, initial);
+      flex: var(--terra-notification-dialog-actions-button-flex, 0 1 auto);
       flex-shrink: 1;
       margin-bottom: var(--terra-notification-dialog-actions-button-margin-bottom, 0.4rem);
       margin-left: var(--terra-notification-dialog-actions-button-margin-left, 0.4rem);


### PR DESCRIPTION
### Summary
`initial` values are not supported by Internet Explorer so it was changed to it's equivalent.

Sync with https://github.com/cerner/terra-core/issues/1667 
Thanks for contributing to Terra. 
@cerner/terra 

Deployment Link
https://terra-framework-deploye-pr-218.herokuapp.com/#/components/terra-notification-dialog/notification-dialog/notification-dialog
