### PR TITLE
Fix webpack issue due to referencing src instead of a relative path

### DIFF
--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Fixed
+* Fix webpack issue due to referencing src in the docs examples instead of a relative path which would end up hitting lib which has been transpiled.
 
 1.1.0 - (July 3, 2018)
 ------------------

--- a/packages/terra-dialog-modal/src/terra-dev-site/doc/example/DialogModalWithCustomHeaderAndCustomFooter.jsx
+++ b/packages/terra-dialog-modal/src/terra-dev-site/doc/example/DialogModalWithCustomHeaderAndCustomFooter.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from 'terra-button';
-import DialogModal from '../../../../src/DialogModal';
+import DialogModal from '../../../DialogModal';
 
 const CustomHeaderFooterStyles = {
   border: '2px dashed #4e832b',

--- a/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DialogModalWithCustomHeaderAndCustomFooter.test.jsx
+++ b/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DialogModalWithCustomHeaderAndCustomFooter.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from 'terra-button';
-import DialogModal from '../../../../src/DialogModal';
+import DialogModal from '../../../DialogModal';
 
 const CustomHeaderFooterStyles = {
   border: '2px dashed #4e832b',


### PR DESCRIPTION
Fix webpack issue due to referencing src instead of a relative path which would end up hitting lib which has been transpiled.