### PR TITLE
Fixing relative references in the test files of terra-dialog-modal

### DIFF
--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 -----------------
 ### Fixed
-* Fix webpack issue due to referencing src in the docs examples instead of a relative path which would end up hitting lib which has been transpiled.
+* Fix webpack issue due to referencing src in the docs examples and tests instead of a relative path which would end up hitting lib which has been transpiled.
 
 1.1.0 - (July 3, 2018)
 ------------------

--- a/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DefaultDialogModal.test.jsx
+++ b/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DefaultDialogModal.test.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import Button from 'terra-button';
 import ActionHeader from 'terra-action-header';
 import ActionFooter from 'terra-action-footer';
-import DialogModal from '../../../../src/DialogModal';
-
+import DialogModal from '../../../DialogModal';
 
 class DefaultDialogModal extends React.Component {
   constructor() {

--- a/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DialogModalWithLongText.test.jsx
+++ b/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DialogModalWithLongText.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from 'terra-button';
 import ActionHeader from 'terra-action-header';
 import ActionFooter from 'terra-action-footer';
-import DialogModal from '../../../../src/DialogModal';
+import DialogModal from '../../../DialogModal';
 
 
 class DialogModalWithLongText extends React.Component {


### PR DESCRIPTION
### Summary
Fixing relative references in the test files of terra-dialog-modal
