### PR TITLE
Bump responsive-element version

### DIFF
--- a/packages/terra-aggregator/CHANGELOG.md
+++ b/packages/terra-aggregator/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated to use terra-responsive-element v3
 
 3.8.0 - (July 25, 2018)
 ------------------

--- a/packages/terra-aggregator/package.json
+++ b/packages/terra-aggregator/package.json
@@ -44,7 +44,7 @@
     "terra-grid": "^4.0.1",
     "terra-list": "^2.0.1",
     "terra-modal-manager": "^3.7.0",
-    "terra-responsive-element": "^2.0.1",
+    "terra-responsive-element": "^3.0.0",
     "terra-section-header": "^1.16.0",
     "terra-slide-panel-manager": "^2.12.0"
   },

--- a/packages/terra-application-header-layout/src/terra-dev-site/doc/example/HeaderWireframe.jsx
+++ b/packages/terra-application-header-layout/src/terra-dev-site/doc/example/HeaderWireframe.jsx
@@ -42,13 +42,14 @@ const HeaderWireframe = () => {
 
   return (
     <div style={{ height: '60px', position: 'relative', width: '100%' }}>
-      <ResponsiveElement
-        defaultElement={tinyHeader}
-        tiny={tinyHeader}
-        small={smallHeader}
-        medium={mediumHeader}
-        style={{ height: '100%' }}
-      />
+      <div style={{ height: '100%' }}>
+        <ResponsiveElement
+          defaultElement={tinyHeader}
+          tiny={tinyHeader}
+          small={smallHeader}
+          medium={mediumHeader}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated to use terra-responsive-element v3
 
 2.10.0 - (July 25, 2018)
 ------------------

--- a/packages/terra-layout/package.json
+++ b/packages/terra-layout/package.json
@@ -39,7 +39,7 @@
     "terra-doc-template": "^1.1.0",
     "terra-icon": "^2.0.1",
     "terra-overlay": "^2.0.1",
-    "terra-responsive-element": "^2.0.1"
+    "terra-responsive-element": "^3.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ Terra Modal Manager - Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated to use terra-responsive-element v3
 
 3.7.0 - (July 25, 2018)
 ------------------

--- a/packages/terra-modal-manager/package.json
+++ b/packages/terra-modal-manager/package.json
@@ -37,7 +37,7 @@
     "terra-disclosure-manager": "^2.10.0",
     "terra-doc-template": "^1.1.0",
     "terra-heading": "^2.0.1",
-    "terra-responsive-element": "^2.0.1",
+    "terra-responsive-element": "^3.0.0",
     "terra-slide-group": "^2.0.1"
   },
   "scripts": {


### PR DESCRIPTION
### Summary
Missed bumping these to new major version in last update. This corrects the version so using the latest release of terra-ui components will all use terra-responsive-element v3.