### PR TITLE
Make Branding Footer Markup more Accessible

### DIFF
--- a/packages/terra-brand-footer/CHANGELOG.md
+++ b/packages/terra-brand-footer/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Make brand footing markup more accessible.
 
 1.10.0 - (September 5, 2018)
 ------------------

--- a/packages/terra-brand-footer/src/BrandFooter.jsx
+++ b/packages/terra-brand-footer/src/BrandFooter.jsx
@@ -125,27 +125,29 @@ const BrandFooter = ({
     navigation = (
       <nav className={cx(['nav', isVertical ? 'nav-vertical' : 'nav-horizontal'])}>
         {processedSections.map(linkGroup => (
-          <ul className={cx('menu')} key={linkGroup.id}>
+          <section className={cx('navigation-section')} key={linkGroup.id}>
             { // When displaying vertically if one column has a header all columns are aligned as if they have a header
               ((containsASectionHeader && isVertical) || linkGroup.headerText) && (
-                <li className={cx('list-header')} key={linkGroup.headerText}>
+                <h3 className={cx('list-header')} key={linkGroup.headerText}>
                   { // Insert a zero width space to act as a placeholder section header that doesn't display but takes vertical space
                     linkGroup.headerText || '\u200B'
                   }
-                </li>
+                </h3>
               )
             }
-            {linkGroup.links && linkGroup.links.map((link) => {
-              const spreadTarget = link.target !== undefined ? { target: link.target } : {};
-              return (
-                <li className={cx('list-item')} key={link.text + link.href}>
-                  <a className={cx('link')} href={link.href} {...spreadTarget}>
-                    {link.text}
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
+            <ul className={cx('menu')}>
+              {linkGroup.links && linkGroup.links.map((link) => {
+                const spreadTarget = link.target !== undefined ? { target: link.target } : {};
+                return (
+                  <li className={cx('list-item')} key={link.text + link.href}>
+                    <a className={cx('link')} href={link.href} {...spreadTarget}>
+                      {link.text}
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
         ))}
       </nav>
     );

--- a/packages/terra-brand-footer/src/BrandFooter.module.scss
+++ b/packages/terra-brand-footer/src/BrandFooter.module.scss
@@ -23,10 +23,17 @@
     align-content: stretch;
     flex-direction: row;
 
-    .menu {
+    .navigation-section {
       flex: 1 1 0%;
       min-width: var(--terra-brand-footer-vertical-nav-link-group-min-width, 240px);
       padding-right: var(--terra-brand-footer-vertical-nav-link-group-padding-right, 1.4285714286rem);
+    }
+
+    .menu {
+      flex: 1 1 0%;
+      margin-bottom: 0;
+      margin-top: 0;
+      width: 100%;
     }
 
     .list-item {
@@ -37,6 +44,8 @@
 
     .list-header {
       display: block;
+      margin-bottom: 0;
+      margin-top: 0;
       padding-bottom: var(--terra-brand-footer-vertical-nav-header-padding-bottom, 0.7142857143rem);
       padding-top: var(--terra-brand-footer-vertical-nav-header-padding-top, 1.4285714286rem);
     }
@@ -45,8 +54,12 @@
   .nav-horizontal {
     flex-direction: column;
 
-    .menu {
+    .navigation-section {
       width: 100%;
+    }
+
+    .menu {
+      display: inline;
     }
 
     .list-item {
@@ -55,8 +68,10 @@
 
     .list-header {
       display: inline-block;
+      margin-bottom: 0;
+      margin-top: 0;
     }
-  
+
     // If there isn't a section header nothing is needed before the link
     .list-item:first-child::before {
       content: '';
@@ -65,13 +80,13 @@
 
     /* stylelint-disable selector-max-compound-selectors */
     // A '/' isn't needed to separate an item from the header it follows
-    .list-header + .list-item::before {
+    .list-header + .menu::before {
       content: '';
       padding-left: 0;
       padding-right: var(--terra-brand-footer-horizontal-nav-first-link-padding-before-right, 0.7142857142857143rem);
     }
     /* stylelint-enable selector-max-compound-selectors */
-  
+
     .list-item::before {
       content: '/';
       padding-bottom: var(--terra-brand-footer-horizontal-nav-link-padding-before-bottom, 0.7142857142857143rem);
@@ -81,12 +96,15 @@
     }
   }
 
-  .menu {
-    list-style: none;
+  .navigation-section {
     margin-bottom: var(--terra-brand-footer-link-group-margin-bottom, 0);
     margin-left: var(--terra-brand-footer-link-group-margin-top, 0);
     margin-right: var(--terra-brand-footer-link-group-margin-left, 0);
     margin-top: var(--terra-brand-footer-link-group-margin-right, 0);
+  }
+
+  .menu {
+    list-style: none;
     padding-left: 0;
     padding-right: 0;
   }

--- a/packages/terra-brand-footer/tests/jest/__snapshots__/BrandFooter.test.jsx.snap
+++ b/packages/terra-brand-footer/tests/jest/__snapshots__/BrandFooter.test.jsx.snap
@@ -26,17 +26,20 @@ exports[`BrandFooter should render a section header 1`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
+      <h3
         className="list-header"
         key="Cerner Links"
       >
         Cerner Links
-      </li>
-    </ul>
+      </h3>
+      <ul
+        className="menu"
+      />
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -59,22 +62,26 @@ exports[`BrandFooter should render the sections prop instead of links prop 1`] =
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Sections Prop linkhttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Sections Prop linkhttps://www.cerner.com/"
         >
-          Sections Prop link
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Sections Prop link
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -97,40 +104,44 @@ exports[`BrandFooter should render with a section header and provided links 1`] 
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
+      <h3
         className="list-header"
         key="Cerner Links"
       >
         Cerner Links
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      </h3>
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -301,74 +312,82 @@ exports[`BrandFooter should render with multiple link groups 1`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
+      <h3
         className="list-header"
         key="Cerner Links"
       >
         Cerner Links
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      </h3>
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
-    <ul
-      className="menu"
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="navigation-section"
       key="1"
     >
-      <li
+      <h3
         className="list-header"
         key="Cerner Links Again"
       >
         Cerner Links Again
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Home Alsohttps://www.cerner.com/"
+      </h3>
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Home Alsohttps://www.cerner.com/"
         >
-          Cerner Home Also
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Code As Wellhttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home Also
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Code As Wellhttps://code.cerner.com/"
         >
-          Cerner Code As Well
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code As Well
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -471,34 +490,38 @@ exports[`BrandFooter should render with provided links 1`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -521,34 +544,38 @@ exports[`BrandFooter should render with provided links and content bottom 1`] = 
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -577,34 +604,38 @@ exports[`BrandFooter should render with provided links and content bottom 2`] = 
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -633,34 +664,38 @@ exports[`BrandFooter should render with provided links and content left 1`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -690,34 +725,38 @@ exports[`BrandFooter should render with provided links and content left 2`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -747,34 +786,38 @@ exports[`BrandFooter should render with provided links and content right 1`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -810,34 +853,38 @@ exports[`BrandFooter should render with provided links and content right 2`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -873,34 +920,38 @@ exports[`BrandFooter should render with provided links, content left, content bo
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -948,34 +999,38 @@ exports[`BrandFooter should render with provided links, content left, content bo
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"
@@ -1023,34 +1078,38 @@ exports[`BrandFooter should render with the links prop 1`] = `
   <nav
     className="nav nav-horizontal"
   >
-    <ul
-      className="menu"
+    <section
+      className="navigation-section"
       key="0"
     >
-      <li
-        className="list-item"
-        key="Cerner Homehttps://www.cerner.com/"
+      <ul
+        className="menu"
       >
-        <a
-          className="link"
-          href="https://www.cerner.com/"
+        <li
+          className="list-item"
+          key="Cerner Homehttps://www.cerner.com/"
         >
-          Cerner Home
-        </a>
-      </li>
-      <li
-        className="list-item"
-        key="Cerner Codehttps://code.cerner.com/"
-      >
-        <a
-          className="link"
-          href="https://code.cerner.com/"
-          target="_blank"
+          <a
+            className="link"
+            href="https://www.cerner.com/"
+          >
+            Cerner Home
+          </a>
+        </li>
+        <li
+          className="list-item"
+          key="Cerner Codehttps://code.cerner.com/"
         >
-          Cerner Code
-        </a>
-      </li>
-    </ul>
+          <a
+            className="link"
+            href="https://code.cerner.com/"
+            target="_blank"
+          >
+            Cerner Code
+          </a>
+        </li>
+      </ul>
+    </section>
   </nav>
   <div
     className="footer-content"


### PR DESCRIPTION
### Summary
Resolves #254

Brand Footer Lists were difficult to read with screen readers, as the heading was part of the list. This pull request puts the links in their own separate list, and then places that inside a section complete with a header.
