### PR TITLE
Removed duplicate terra-base dependencies

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Cerner Corporation
 - Stephen Esser [@StephenEsser]
 - Nathan Faltermeier [@Blackop778]
 - Ben Boersma [@BenBoersma]
+- Alex Brisimitzakis [@AlexBrizi]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -25,3 +26,4 @@ Cerner Corporation
 [@StephenEsser]: https://github.com/StephenEsser
 [@Blackop778]: https://github.com/Blackop778
 [@BenBoersma]: https://github.com/BenBoersma
+[@AlexBrizi]: https://github.com/AlexBrizi

--- a/packages/terra-aggregator/CHANGELOG.md
+++ b/packages/terra-aggregator/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+3.13.0 (September 17, 2018)
+
+### Changed
+* Removed terra-base duplicate from devDependencies
+
 3.12.0 - (September 5, 2018)
 ------------------
 ### Changed

--- a/packages/terra-aggregator/package.json
+++ b/packages/terra-aggregator/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/cerner/terra-framework#readme",
   "devDependencies": {
-    "terra-app-delegate": "^2.7.0",
-    "terra-base": "^3.0.0"
+    "terra-app-delegate": "^2.7.0"
   },
   "peerDependencies": {
     "react": "^16.4.2",

--- a/packages/terra-application-layout/CHANGELOG.md
+++ b/packages/terra-application-layout/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+2.17.0 (September 17, 2018)
+
+### Changed
+* Removed terra-base duplicate from devDependencies
+
 2.16.0 - (September 11, 2018)
 ------------------
 ### Changed

--- a/packages/terra-application-layout/package.json
+++ b/packages/terra-application-layout/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/cerner/terra-framework#readme",
   "devDependencies": {
-    "terra-app-delegate": "^2.7.0",
-    "terra-base": "^3.0.0"
+    "terra-app-delegate": "^2.7.0"
   },
   "peerDependencies": {
     "react": "^16.4.2",

--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+2.16.0 (September 17, 2018)
+
+### Changed
+* Removed terra-base duplicate from dependencies (kept instance in peerDependencies)
+
 2.15.0 - (September 11, 2018)
 ------------------
 ### Changed

--- a/packages/terra-layout/package.json
+++ b/packages/terra-layout/package.json
@@ -33,7 +33,6 @@
     "classnames": "^2.2.5",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.8",
-    "terra-base": "^3.0.0",
     "terra-button": "^2.0.1",
     "terra-content-container": "^2.0.1",
     "terra-doc-template": "^1.1.0",

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+3.12.0 (September 17, 2018)
+
+### Changed
+* Removed terra-base duplicate from devDependencies
+
 3.11.0 - (September 5, 2018)
 ------------------
 ### Changed

--- a/packages/terra-modal-manager/package.json
+++ b/packages/terra-modal-manager/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/cerner/terra-framework#readme",
   "devDependencies": {
-    "terra-app-delegate": "^2.7.0",
-    "terra-base": "^3.0.0"
+    "terra-app-delegate": "^2.7.0"
   },
   "peerDependencies": {
     "react": "^16.4.2",

--- a/packages/terra-navigation-side-menu/CHANGELOG.md
+++ b/packages/terra-navigation-side-menu/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+1.14.0 (September 17, 2018)
+
+### Changed
+* Removed terra-base duplicate from dependencies (kept instance in peerDependencies)
+
 1.13.0 - (September 5, 2018)
 ------------------
 ### Changed

--- a/packages/terra-navigation-side-menu/package.json
+++ b/packages/terra-navigation-side-menu/package.json
@@ -30,7 +30,6 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-action-header": "^1.0.0",
-    "terra-base": "^3.0.0",
     "terra-content-container": "^2.0.1",
     "terra-doc-template": "^1.1.0",
     "terra-icon": "^2.0.1",


### PR DESCRIPTION
### Summary
Removed any instances where terra-base was listed as both a peerDependency and either a dependency or devDependency (kept it as a peerDependency).

Closes [#200](https://github.com/cerner/terra-framework/issues/200)