### PR TITLE
Clean up un-needed globals

### DIFF
--- a/packages/terra-aggregator/tests/wdio/aggregator-spec.js
+++ b/packages/terra-aggregator/tests/wdio/aggregator-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before, beforeEach, expect */
-
 describe('Aggregator', () => {
   before(() => browser.setViewportSize(Terra.viewports('large')[0]));
 

--- a/packages/terra-application-header-layout/tests/wdio/application-header-spec.js
+++ b/packages/terra-application-header-layout/tests/wdio/application-header-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, beforeEach, expect */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('Application Header Layout', () => {

--- a/packages/terra-application-layout/tests/wdio/application-header-spec.js
+++ b/packages/terra-application-layout/tests/wdio/application-header-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('small', 'large');
 
 describe('ApplicationHeader', () => {

--- a/packages/terra-application-layout/tests/wdio/application-layout-spec.js
+++ b/packages/terra-application-layout/tests/wdio/application-layout-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, beforeEach */
-
 const viewports = Terra.viewports('small', 'large');
 
 describe('ApplicationLayout', () => {

--- a/packages/terra-application-layout/tests/wdio/application-menu-spec.js
+++ b/packages/terra-application-layout/tests/wdio/application-menu-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra */
-
 const viewports = Terra.viewports('small', 'large');
 
 describe('ApplicationMenu', () => {

--- a/packages/terra-application-layout/tests/wdio/routing-menu-spec.js
+++ b/packages/terra-application-layout/tests/wdio/routing-menu-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, beforeEach */
-
 const viewports = Terra.viewports('small');
 
 describe('RoutingMenu', () => {

--- a/packages/terra-application-links/tests/wdio/application-tabs-spec.js
+++ b/packages/terra-application-links/tests/wdio/application-tabs-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra */
-
 const viewports = Terra.viewports('small', 'large');
 
 describe('ApplicationTabs', () => {

--- a/packages/terra-application-menu-layout/tests/wdio/application-menu-spec.js
+++ b/packages/terra-application-menu-layout/tests/wdio/application-menu-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('Application Menu', () => {

--- a/packages/terra-application-name/tests/wdio/application-header-name-spec.js
+++ b/packages/terra-application-name/tests/wdio/application-header-name-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('ApplicationHeaderName', () => {

--- a/packages/terra-application-name/tests/wdio/application-menu-name-spec.js
+++ b/packages/terra-application-name/tests/wdio/application-menu-name-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('ApplicationMenuName', () => {

--- a/packages/terra-application-utility/tests/wdio/application-header-utility-spec.js
+++ b/packages/terra-application-utility/tests/wdio/application-header-utility-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('ApplicationHeaderUtility', () => {

--- a/packages/terra-application-utility/tests/wdio/application-menu-utility-spec.js
+++ b/packages/terra-application-utility/tests/wdio/application-menu-utility-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra */
-
 const viewports = Terra.viewports('tiny', 'medium');
 
 describe('ApplicationMenuUtility', () => {

--- a/packages/terra-application-utility/tests/wdio/header-utility-menu-spec.js
+++ b/packages/terra-application-utility/tests/wdio/header-utility-menu-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra */
 describe('HeaderUtilityMenu', () => {
   beforeEach(() => {
     browser.url('/#/raw/tests/terra-application-utility/application-utility/default-header-utility-menu');

--- a/packages/terra-application-utility/tests/wdio/menu-utility-menu-spec.js
+++ b/packages/terra-application-utility/tests/wdio/menu-utility-menu-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra */
 describe('MenuUtilityMenu', () => {
   beforeEach(() => {
     browser.url('/#/raw/tests/terra-application-utility/application-utility/default-menu-utility-menu');

--- a/packages/terra-brand-footer/tests/wdio/brand-footer-spec.js
+++ b/packages/terra-brand-footer/tests/wdio/brand-footer-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const viewports = Terra.viewports('tiny', 'large');
 
 const rules = { bypass: { enabled: false } };

--- a/packages/terra-dialog-modal/tests/wdio/dialog-modal-spec.js
+++ b/packages/terra-dialog-modal/tests/wdio/dialog-modal-spec.js
@@ -1,4 +1,3 @@
-/* global before, browser, Terra */
 const selector = '#root';
 
 Terra.viewports('tiny', 'medium', 'large').forEach((viewport) => {

--- a/packages/terra-hookshot/tests/wdio/hookshot-combinations-spec.js
+++ b/packages/terra-hookshot/tests/wdio/hookshot-combinations-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 // 81 Attachment Variants Combinin Target and Content Attachements
 describe('Hookshot targetAttachment and contentAttachment combinations', () => {
   before(() => browser.setViewportSize(Terra.viewports('small')[0]));

--- a/packages/terra-hookshot/tests/wdio/hookshot-spec.js
+++ b/packages/terra-hookshot/tests/wdio/hookshot-spec.js
@@ -1,4 +1,4 @@
-/* global browser, Terra, before, after */
+/* global after */
 
 describe('Hookshot', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));

--- a/packages/terra-infinite-list/tests/wdio/infinite-list-spec.js
+++ b/packages/terra-infinite-list/tests/wdio/infinite-list-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('small');
 
 describe('InfiniteList', () => {

--- a/packages/terra-layout/tests/wdio/layout-slide-panel-spec.js
+++ b/packages/terra-layout/tests/wdio/layout-slide-panel-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Toggle the slide panel and hidden styles', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
   beforeEach(() => {

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, before, beforeEach, expect */
 const viewports = Terra.viewports('tiny', 'large');
 const selector = '#root';
 

--- a/packages/terra-navigation-layout/tests/wdio/navigation-layout-spec.js
+++ b/packages/terra-navigation-layout/tests/wdio/navigation-layout-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('tiny', 'small', 'medium', 'large', 'huge');
 const selector = '#test-root';
 

--- a/packages/terra-navigation-side-menu/tests/wdio/navigation-side-menu-spec.js
+++ b/packages/terra-navigation-side-menu/tests/wdio/navigation-side-menu-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 describe('Default navigation side menu display', () => {
   before(() => browser.setViewportSize(Terra.viewports('medium')[0]));
   beforeEach(() => {

--- a/packages/terra-notification-dialog/tests/wdio/notification-dialog-spec.js
+++ b/packages/terra-notification-dialog/tests/wdio/notification-dialog-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra */
 const selector = '#root';
 
 Terra.viewports('tiny', 'medium', 'large').forEach((viewport) => {

--- a/packages/terra-popup/tests/wdio/popup-spec.js
+++ b/packages/terra-popup/tests/wdio/popup-spec.js
@@ -1,5 +1,3 @@
-/* global  browser, before, Terra */
-
 describe('Popup', () => {
   describe('Arrow Popup', () => {
     before(() => browser.setViewportSize(Terra.viewports('medium')[0]));

--- a/packages/terra-slide-panel-manager/tests/wdio/slide-panel-manager-spec.js
+++ b/packages/terra-slide-panel-manager/tests/wdio/slide-panel-manager-spec.js
@@ -1,4 +1,3 @@
-/* global browser, Terra, beforeEach, before, expect */
 const viewports = Terra.viewports('tiny', 'large');
 
 viewports.forEach((viewport) => {

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const context = '[data-terra-dev-site-content] *:first-child';
 
 describe('Slide panel', () => {

--- a/packages/terra-theme-provider/tests/wdio/theme-provider-spec.js
+++ b/packages/terra-theme-provider/tests/wdio/theme-provider-spec.js
@@ -1,5 +1,3 @@
-/* global browser, Terra, before */
-
 const viewports = Terra.viewports('tiny', 'medium');
 const selector = '#root';
 


### PR DESCRIPTION
### Summary
eslint-config module defines before, browser, and Terra as globals for test files recursively under a "wdio" directory
