### PR TITLE
Upgrade focus-trap-react to ^4.0.1

### DIFF
--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Added
 * Webdriver theme test for --terra-popup-arrow-inner-color
+* Upgrade focus-trap-react version to ^4.0.1
 
 4.14.0 - (September 25, 2018)
 ------------------

--- a/packages/terra-popup/package.json
+++ b/packages/terra-popup/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "focus-trap-react": "^3.1.1",
+    "focus-trap-react": "^4.0.1",
     "prop-types": "^15.5.8",
     "react-portal": "^4.1.2",
     "terra-button": "^2.3.0",


### PR DESCRIPTION
### Summary
Upgrading focus-trap-react to latest stable release.