### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,19 +32,11 @@ jobs:
         - >
           mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
           | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
-    - stage: lint
+    - stage: danger lint and jest
       script:
         - 'wget -q -O docker-compose.yml https://raw.github.com/cerner/terra-toolkit/master/config/docker/ci-docker-compose.yml'
-        - "travis_wait docker-compose run -e TRAVIS=$TRAVIS -e CI=$CI test-chrome npm run lint"
-    - stage: jest
-      script:
-        - 'wget -q -O docker-compose.yml https://raw.github.com/cerner/terra-toolkit/master/config/docker/ci-docker-compose.yml'
-        - "travis_wait docker-compose run -e TRAVIS=$TRAVIS -e CI=$CI test-chrome npm run jest"
-    - stage: danger
-      script:
-        - 'wget -q -O docker-compose.yml https://raw.github.com/cerner/terra-toolkit/master/config/docker/ci-docker-compose.yml'
-        - "travis_wait docker-compose run -e DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN -e TRAVIS=$TRAVIS -e CI=$CI -e HAS_JOSH_K_SEAL_OF_APPROVAL=$HAS_JOSH_K_SEAL_OF_APPROVAL -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG test-chrome npm run danger"
-    - stage: test
+        - "travis_wait docker-compose run -e DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN -e TRAVIS=$TRAVIS -e CI=$CI -e HAS_JOSH_K_SEAL_OF_APPROVAL=$HAS_JOSH_K_SEAL_OF_APPROVAL -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG test-chrome bash -c 'npm run danger; npm run lint; npm run jest'"
+    - stage: wdio
       script:
         - 'wget -q -O docker-compose.yml https://raw.github.com/cerner/terra-toolkit/master/config/docker/ci-docker-compose.yml'
         - "travis_wait docker-compose run -e TRAVIS=$TRAVIS -e CI=$CI test-chrome npm run wdio -- --suite suite1"
@@ -82,10 +74,8 @@ jobs:
         - 'rm -f $HOME/docker/*.tar.gz'
 stages:
   - build
-  - lint
-  - danger
-  - jest
-  - test
+  - danger lint and jest
+  - wdio
   - name: deploy
     if: type != pull_request
   - clean up cache


### PR DESCRIPTION
### Summary
Updated travis to run one script for lint, jest and danger. These scripts take seconds to execute, but to run them in parallel takes 5 minutes a piece to run, (if they run at the same time with no other Cerner open source builds occurring at the same time), so this reduces the overall PR build time of framework.