### PR TITLE
Update intl imports in header layout

### DIFF
--- a/packages/terra-application-header-layout/CHANGELOG.md
+++ b/packages/terra-application-header-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Import `injectIntl` and `intlShape` from react-intl instead of terra-base
 
 2.18.0 - (October 16, 2018)
 ------------------

--- a/packages/terra-application-header-layout/package.json
+++ b/packages/terra-application-header-layout/package.json
@@ -26,6 +26,7 @@
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
+    "react-intl": "^2.4.0",
     "terra-base": "^3.24.0"
   },
   "dependencies": {

--- a/packages/terra-application-header-layout/src/ApplicationHeaderLayout.jsx
+++ b/packages/terra-application-header-layout/src/ApplicationHeaderLayout.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import { injectIntl, intlShape } from 'terra-base';
+import { injectIntl, intlShape } from 'react-intl';
 import 'terra-base/lib/baseStyles';
 
 import styles from './ApplicationHeaderLayout.module.scss';


### PR DESCRIPTION
### Summary
This is related to https://github.com/cerner/terra-core/issues/1982

This update pulls in react-intl modules directly from react-intl instead of terra-base. When pulling the modules from terra-base, it was pulling in more code and executing more code than just the react-intl modules that were specified.