### PR TITLE
Windows fix for Jest test error

### DIFF
--- a/jestconfig.js
+++ b/jestconfig.js
@@ -8,8 +8,9 @@ module.exports = {
     './jestsetup.js',
   ],
   testMatch: [
-    `${process.cwd()}/**/jest/**/(*.)(spec|test).js?(x)`,
+    '**/jest/**/(*.)(spec|test).js?(x)',
   ],
+  roots: [process.cwd()],
   snapshotSerializers: [
     './node_modules/enzyme-to-json/serializer',
   ],


### PR DESCRIPTION
### Summary
Added a fix to jestconfig.js in root directory to allow for Jest tests to properly run on Windows.

Resolves [#224](https://github.com/cerner/terra-framework/issues/224)