### PR TITLE
[terra-layout] - Regenerated jest snapshots

### DIFF
--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Regenerated jest snapshots
 
 2.18.0 - (October 16, 2018)
 ------------------

--- a/packages/terra-layout/tests/jest/__snapshots__/LayoutSlidePanel.test.jsx.snap
+++ b/packages/terra-layout/tests/jest/__snapshots__/LayoutSlidePanel.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`LayoutSlidePanel should render when small 1`] = `
       isRelativeToContainer={true}
       isScrollable={false}
       onRequestClose={[Function]}
+      zIndex="100"
     />
     <main
       className="main-container"
@@ -56,6 +57,7 @@ exports[`LayoutSlidePanel should render when tiny 1`] = `
       isRelativeToContainer={true}
       isScrollable={false}
       onRequestClose={[Function]}
+      zIndex="100"
     />
     <main
       className="main-container"
@@ -91,6 +93,7 @@ exports[`LayoutSlidePanel should render with provided props 1`] = `
       isRelativeToContainer={true}
       isScrollable={false}
       onRequestClose={[Function]}
+      zIndex="100"
     />
     <main
       className="main-container"
@@ -121,6 +124,7 @@ exports[`LayoutSlidePanel should render without optional props 1`] = `
       isOpen={false}
       isRelativeToContainer={true}
       isScrollable={false}
+      zIndex="100"
     />
     <main
       className="main-container"


### PR DESCRIPTION
### Summary
The following pull request introduced a default z-index that caused the terra-layout snapshot tests to fail. 

https://github.com/cerner/terra-core/pull/1955

### Additional Details
Regenerated the jest snapshots to account for the z-index

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
