### PR TITLE
Fix travis & Fix lint error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
     - stage: danger lint and jest
       script:
         - 'wget -q -O docker-compose.yml https://raw.github.com/cerner/terra-toolkit/master/config/docker/ci-docker-compose.yml'
-        - "travis_wait docker-compose run -e DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN -e TRAVIS=$TRAVIS -e CI=$CI -e HAS_JOSH_K_SEAL_OF_APPROVAL=$HAS_JOSH_K_SEAL_OF_APPROVAL -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG test-chrome bash -c 'npm run danger; npm run lint; npm run jest'"
+        - "travis_wait docker-compose run -e DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN -e TRAVIS=$TRAVIS -e CI=$CI -e HAS_JOSH_K_SEAL_OF_APPROVAL=$HAS_JOSH_K_SEAL_OF_APPROVAL -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG test-chrome bash -c 'npm run danger && npm run lint && npm run jest'"
     - stage: wdio
       script:
         - 'wget -q -O docker-compose.yml https://raw.github.com/cerner/terra-toolkit/master/config/docker/ci-docker-compose.yml'

--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Lint error
 
 4.13.1 - (November 15, 2018)
 ------------------

--- a/packages/terra-hookshot/src/HookshotContent.jsx
+++ b/packages/terra-hookshot/src/HookshotContent.jsx
@@ -43,7 +43,7 @@ const propTypes = {
 
 // shim for SVGElement classList for IE 10 / IE 11
 // More info: https://github.com/Pomax/react-onclickoutside#ie-does-not-support-classlist-for-svg-elements
-if (typeof SVGElement !== "undefined" && !('classList' in SVGElement.prototype)) {
+if (typeof SVGElement !== 'undefined' && !('classList' in SVGElement.prototype)) {
   Object.defineProperty(SVGElement.prototype, 'classList', {
     get() {
       return {


### PR DESCRIPTION
### Summary
Using `npm run danger; npm run lint; npm run jest` instead of `npm run danger && npm run lint && npm run jest` doesn't fail the build. The `;` will execute the next script regardless of exit code.