### PR TITLE
Update popup preventDefault behavior

### DIFF
--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -4,7 +4,12 @@ Changelog
 Unreleased
 ----------
 
-4.19.1 - (December 3, 2018)
+4.19.1 - (December 4, 2018)
+------------------
+### Removed
+* Removed preventDefault prop on PopupContent component. This is handled by react-onClickOutside.
+
+4.19.0 - (December 3, 2018)
 ------------------
 ### Changed
 * Wdio tests changed to use themeCombinationOfCustomProperties

--- a/packages/terra-popup/src/_PopupContent.jsx
+++ b/packages/terra-popup/src/_PopupContent.jsx
@@ -229,7 +229,6 @@ class PopupContent extends React.Component {
           onEsc={onRequestClose}
           onOutsideClick={this.props.onRequestClose}
           onResize={this.handleOnResize}
-          preventDefault
           refCallback={refCallback}
           role="dialog"
         >


### PR DESCRIPTION
### Summary
Remove preventDefault prop on PopupContent. This was preventing events inside the popup content, where we just want to prevent events outside the popup content when it is open. This behavior should be handled by default with react-onclickoutside. 

* Need to cross-browser test / cross-device test this change.