### PR TITLE
Update Wdio Test Timeouts

### DIFF
--- a/packages/terra-aggregator/CHANGELOG.md
+++ b/packages/terra-aggregator/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Removed local timeout values from wdio tests
 
 3.19.0 - (December 5, 2018)
 ------------------

--- a/packages/terra-aggregator/tests/wdio/aggregator-spec.js
+++ b/packages/terra-aggregator/tests/wdio/aggregator-spec.js
@@ -31,7 +31,7 @@ describe('Aggregator', () => {
 
       browser.click('#test-aggregator #section1');
 
-      browser.waitForVisible('[class*="slide-group"] .close-disclosure', 1000);
+      browser.waitForVisible('[class*="slide-group"] .close-disclosure');
 
       browser.click('#test-aggregator #section1');
     });
@@ -46,7 +46,7 @@ describe('Aggregator', () => {
 
       browser.click('#test-aggregator #section1');
 
-      browser.waitForVisible('[class*="slide-group"] .close-disclosure', 1000);
+      browser.waitForVisible('[class*="slide-group"] .close-disclosure');
 
       browser.click('[class*="slide-group"] .close-disclosure');
     });


### PR DESCRIPTION
### Summary
Removes the local timeouts from wdio tests in favor of global timer.

Closes [cerner/terra-core#1756](https://github.com/cerner/terra-core/issues/1756)