### PR TITLE
Update jest snapshot

### DIFF
--- a/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
+++ b/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
@@ -110,7 +110,11 @@ exports[`ModalManager should disclose content in Modal 1`] = `
                 <FocusTrap
                   _createFocusTrap={[Function]}
                   active={true}
-                  focusTrapOptions={Object {}}
+                  focusTrapOptions={
+                    Object {
+                      "fallbackFocus": [Function],
+                    }
+                  }
                   paused={false}
                   tag="div"
                 >


### PR DESCRIPTION
### Summary
We [added a fallback behavior to how focus trap works in abstract modal](https://github.com/cerner/terra-core/pull/2112) which has triggered a jest snapshot failure in framework.