### PR TITLE
Increase UserData CSS Class Specificity

### DIFF
--- a/packages/terra-application-layout/CHANGELOG.md
+++ b/packages/terra-application-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Increase specificity of UserData photo CSS class
 
 3.2.0 - (January 2, 2019)
 ------------------

--- a/packages/terra-application-layout/src/user/UserData.module.scss
+++ b/packages/terra-application-layout/src/user/UserData.module.scss
@@ -4,13 +4,13 @@
     display: flex;
     flex: 1 1 auto;
     justify-content: flex-start;
-  }
 
-  .photo {
-    flex: 0 0 auto;
-    height: var(--terra-application-user-data-photo-height, 3.571rem);
-    margin-right: var(--terra-application-user-data-photo, 0.5714rem);
-    width: var(--terra-application-user-data-photo-width, 3.571rem);
+    .photo {
+      flex: 0 0 auto;
+      height: var(--terra-application-user-data-photo-height, 3.571rem);
+      margin-right: var(--terra-application-user-data-photo, 0.5714rem);
+      width: var(--terra-application-user-data-photo-width, 3.571rem);
+    }
   }
 
   .user-info {


### PR DESCRIPTION
### Summary
There are instances where the UserData stylesheet is loaded twice. This causes issues in the examples, where we pass in an Avatar component. 

In some cases, the style load order is `UserData`->`Avatar`->`UserData`. In other cases, the style load order is `UserData`->`Avatar`. 

This change increases specificity of the `photo` class. Now, UserData photo styles will always override Avatar styles. This will make builds stable for now, but we still need to dig into the root of this issue.
