### PR TITLE
Add .npmignore to Package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-aggregated-translations
-dev-site-config
-screenshots
-errorScreenshots

--- a/packages/terra-aggregator/.npmignore
+++ b/packages/terra-aggregator/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-application-header-layout/.npmignore
+++ b/packages/terra-application-header-layout/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-application-layout/.npmignore
+++ b/packages/terra-application-layout/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-application-links/.npmignore
+++ b/packages/terra-application-links/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-application-menu-layout/.npmignore
+++ b/packages/terra-application-menu-layout/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-application-name/.npmignore
+++ b/packages/terra-application-name/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-application-utility/.npmignore
+++ b/packages/terra-application-utility/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-brand-footer/.npmignore
+++ b/packages/terra-brand-footer/.npmignore
@@ -2,3 +2,7 @@
 node_modules
 target
 reports
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-dialog-modal/.npmignore
+++ b/packages/terra-dialog-modal/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-disclosure-manager/.npmignore
+++ b/packages/terra-disclosure-manager/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-embedded-content-consumer/.npmignore
+++ b/packages/terra-embedded-content-consumer/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-form-validation/.npmignore
+++ b/packages/terra-form-validation/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-hookshot/.npmignore
+++ b/packages/terra-hookshot/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-infinite-list/.npmignore
+++ b/packages/terra-infinite-list/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-layout/.npmignore
+++ b/packages/terra-layout/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-modal-manager/.npmignore
+++ b/packages/terra-modal-manager/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-navigation-layout/.npmignore
+++ b/packages/terra-navigation-layout/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-navigation-side-menu/.npmignore
+++ b/packages/terra-navigation-side-menu/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-notification-dialog/.npmignore
+++ b/packages/terra-notification-dialog/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-popup/.npmignore
+++ b/packages/terra-popup/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-slide-group/.npmignore
+++ b/packages/terra-slide-group/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-slide-panel-manager/.npmignore
+++ b/packages/terra-slide-panel-manager/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-slide-panel/.npmignore
+++ b/packages/terra-slide-panel/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-theme-provider/.npmignore
+++ b/packages/terra-theme-provider/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots

--- a/packages/terra-time-input/.npmignore
+++ b/packages/terra-time-input/.npmignore
@@ -3,3 +3,7 @@ node_modules
 target
 reports
 tests/**/__snapshots__/
+aggregated-translations
+dev-site-config
+screenshots
+errorScreenshots


### PR DESCRIPTION
### Summary

Adds .npmignore file to package to ignore extraneous directories.

Closes [#425](https://github.com/cerner/terra-framework/issues/425)