### PR TITLE
Add terra-layout-slide-panel-transition custom property

### DIFF
--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Added
 * New CSS custom property: `--terra-layout-slide-panel-squish-panel-border-right-width`
+* New CSS custom property: `--terra-layout-slide-panel-transition`
 
 ### Changed
 * Remove use of componentWillReceiveProps

--- a/packages/terra-layout/src/LayoutSlidePanel.module.scss
+++ b/packages/terra-layout/src/LayoutSlidePanel.module.scss
@@ -15,7 +15,7 @@
   }
 
   .is-animated {
-    transition: left 0.15s ease;
+    transition: var(--terra-layout-slide-panel-transition);
   }
 
   .content {

--- a/packages/terra-layout/src/LayoutSlidePanel.module.scss
+++ b/packages/terra-layout/src/LayoutSlidePanel.module.scss
@@ -15,7 +15,7 @@
   }
 
   .is-animated {
-    transition: var(--terra-layout-slide-panel-transition);
+    transition: var(--terra-layout-slide-panel-transition, none);
   }
 
   .content {


### PR DESCRIPTION
### Summary
Made transition property themable so if teams want the layout slide panel to transition in, they can theme it to do so. By default, there will be no transition.