### PR TITLE
 Fixes issue #2074 DatetimePicker throws NPE if manually entered valid datetime is outside of allotted datetime range

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@ Cerner Corporation
 - Jaime Mackey [@jmsv6d]
 - Noah Benham [@noahbenham]
 - Cody Price [@dev-cprice]
-- Shetty Akarsh [@@ShettyAkarsh]
+- Shetty Akarsh [@ShettyAkarsh]
 - Alex Bezek [@alex-bezek]
 - Supreeth MR [@supreethmr]
 

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Throws NPE if manually entered valid date is outside of allotted datetime range.
+
 ### Changed
 * Migrate package to the terra-framework repository
 

--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -230,7 +230,7 @@ class DateTimePicker extends React.Component {
 
   handleTimeChange(event, time) {
     this.timeValue = time;
-    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat);
+    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat) && this.isDateTimeWithinRange(this.convertDateTimeStringToMomentObject(this.dateValue, this.timeValue));
     const validTime = DateTimeUtils.isValidTime(this.timeValue);
     const previousDateTime = this.state.dateTime ? this.state.dateTime.clone() : null;
 
@@ -305,18 +305,23 @@ class DateTimePicker extends React.Component {
   }
 
   validateDefaultDate() {
+    return this.isDateTimeWithinRange(this.state.dateTime);
+  }
+
+  isDateTimeWithinRange(newDateTime) {
     let isAcceptable = true;
 
-    if (DateUtil.isDateOutOfRange(this.state.dateTime, DateUtil.createSafeDate(this.props.minDateTime), DateUtil.createSafeDate(this.props.maxDateTime))) {
+    if (DateUtil.isDateOutOfRange(newDateTime, DateUtil.createSafeDate(this.props.minDateTime), DateUtil.createSafeDate(this.props.maxDateTime))) {
       isAcceptable = false;
     }
 
-    if (DateUtil.isDateExcluded(this.state.dateTime, this.props.excludeDates)) {
+    if (DateUtil.isDateExcluded(newDateTime, this.props.excludeDates)) {
       isAcceptable = false;
     }
 
     return isAcceptable;
   }
+
 
   handleDaylightSavingButtonClick(event) {
     this.setState({ isTimeClarificationOpen: false });
@@ -344,6 +349,10 @@ class DateTimePicker extends React.Component {
 
   handleOnRequestClose() {
     this.setState({ isTimeClarificationOpen: false });
+  }
+
+  convertDateTimeStringToMomentObject(date, time) {
+    return DateTimeUtils.updateTime(DateUtil.createSafeDate(DateUtil.convertToISO8601(date, this.state.dateFormat)), time);
   }
 
   renderTimeClarification() {


### PR DESCRIPTION
### Summary
Resolves the NPE error when user tries to enter time along with valid date outside of the allotted datetime range.

The fix is to validate whether the date entered is within the datetime range after the date value is validated.

Resolves #2074