### PR TITLE
Wrapped collapsible menu items in <li> tags

### DIFF
--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Wrapped Collapsible Menu Items in <li>
 
 4.3.0 - (February 5, 2019)
 ------------------

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -70,22 +70,22 @@ class CollapsibleMenuViewItemGroup extends React.Component {
     const { isCollapsibleMenuItem } = this.context;
 
     if (isCollapsibleMenuItem && selectedKeys.length) {
-          return (
-            <li>
-              <Menu.ItemGroup {...customProps} onChange={this.handleOnChange}>
-                {children}
-              </Menu.ItemGroup>
-            </li>
-          );
-        } if (isCollapsibleMenuItem) {
-          return (
-            <li>
-              <List {...customProps} onChange={this.handleOnChange}>
-                {children}
-              </List>
-            </li>
-          );
-        }
+      return (
+        <li>
+          <Menu.ItemGroup {...customProps} onChange={this.handleOnChange}>
+            {children}
+          </Menu.ItemGroup>
+        </li>
+      );
+    } if (isCollapsibleMenuItem) {
+        return (
+          <li>
+            <List {...customProps} onChange={this.handleOnChange}>
+              {children}
+            </List>
+          </li>
+        );
+      }
 
     const buttonGroupClassNames = cx([
       'face-up-item',

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -70,18 +70,22 @@ class CollapsibleMenuViewItemGroup extends React.Component {
     const { isCollapsibleMenuItem } = this.context;
 
     if (isCollapsibleMenuItem && selectedKeys.length) {
-      return (
-        <Menu.ItemGroup {...customProps} onChange={this.handleOnChange}>
-          {children}
-        </Menu.ItemGroup>
-      );
-    } if (isCollapsibleMenuItem) {
-      return (
-        <List {...customProps} onChange={this.handleOnChange}>
-          {children}
-        </List>
-      );
-    }
+          return (
+            <li>
+              <Menu.ItemGroup {...customProps} onChange={this.handleOnChange}>
+                {children}
+              </Menu.ItemGroup>
+            </li>
+          );
+        } if (isCollapsibleMenuItem) {
+          return (
+            <li>
+              <List {...customProps} onChange={this.handleOnChange}>
+                {children}
+              </List>
+            </li>
+          );
+        }
 
     const buttonGroupClassNames = cx([
       'face-up-item',

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -78,14 +78,14 @@ class CollapsibleMenuViewItemGroup extends React.Component {
         </li>
       );
     } if (isCollapsibleMenuItem) {
-        return (
-          <li>
-            <List {...customProps} onChange={this.handleOnChange}>
-              {children}
-            </List>
-          </li>
-        );
-      }
+      return (
+        <li>
+          <List {...customProps} onChange={this.handleOnChange}>
+            {children}
+          </List>
+        </li>
+      );
+    }
 
     const buttonGroupClassNames = cx([
       'face-up-item',

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItemGroup.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItemGroup.test.jsx.snap
@@ -1,95 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should merge custom props 1`] = `
-<List
-  className="Testing"
-  isDivided={false}
-  onChange={[Function]}
->
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-</List>
+<li>
+  <List
+    className="Testing"
+    isDivided={false}
+    onChange={[Function]}
+  >
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+  </List>
+</li>
 `;
 
 exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should merge custom props when selectable 1`] = `
-<MenuItemGroup
-  className="Testing"
-  onChange={[Function]}
->
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    key="key1"
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    key="key2"
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-</MenuItemGroup>
+<li>
+  <MenuItemGroup
+    className="Testing"
+    onChange={[Function]}
+  >
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      key="key1"
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      key="key2"
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+  </MenuItemGroup>
+</li>
 `;
 
 exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should render a menu item group when selectable 1`] = `
-<MenuItemGroup
-  onChange={[Function]}
->
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    key="key1"
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    key="key2"
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-</MenuItemGroup>
+<li>
+  <MenuItemGroup
+    onChange={[Function]}
+  >
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      key="key1"
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      key="key2"
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+  </MenuItemGroup>
+</li>
 `;
 
 exports[`CollapsibleMenuViewItemGroup Collapsible Menu Context should render menu items when selectedKeys is not set 1`] = `
-<List
-  isDivided={false}
-  onChange={[Function]}
->
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-  <CollapsibleMenuViewItem
-    isIconOnly={false}
-    isReversed={false}
-    isSelected={false}
-    shouldCloseOnClick={true}
-    text="Testing"
-  />
-</List>
+<li>
+  <List
+    isDivided={false}
+    onChange={[Function]}
+  >
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+    <CollapsibleMenuViewItem
+      isIconOnly={false}
+      isReversed={false}
+      isSelected={false}
+      shouldCloseOnClick={true}
+      text="Testing"
+    />
+  </List>
+</li>
 `;
 
 exports[`CollapsibleMenuViewItemGroup should merge custom props 1`] = `


### PR DESCRIPTION
### Summary
Wrapped the CollapsibleMenuItems in li tags. Also ensured that doing so would not add any extra spacing (see before & after screenshot).

<img width="1117" alt="before and after change" src="https://user-images.githubusercontent.com/42747444/52431411-cbf4ef80-2acd-11e9-8af0-e5960f06c7c5.png">


Resolves [#396](https://github.com/cerner/terra-framework/issues/396)