### PR TITLE
[terra-disclosure-manager] Removing unused dependencies

### DIFF
--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 ----------
 
+### Removed
+* Removed unused dependencies
+
 4.1.0 - (February 5, 2019)
 ------------------
 ### Changed

--- a/packages/terra-disclosure-manager/package.json
+++ b/packages/terra-disclosure-manager/package.json
@@ -23,15 +23,10 @@
   "homepage": "https://github.com/cerner/terra-framework#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^4.0.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-action-header": "^2.0.0",
-    "terra-button": "^3.3.0",
-    "terra-content-container": "^3.0.0",
     "terra-doc-template": "^2.2.0"
   },
   "scripts": {


### PR DESCRIPTION
### Summary
I'm removing the dependencies that are no longer being used by the package. They were once used by the disclosure manager's examples, but those examples were removed some time ago.

This should result in fewer major version bumps to the package going forward.