### PR TITLE
 Fixes issue #2074 DatetimePicker throws NPE if manually entered valid datetime is outside of allotted datetime range

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ Cerner Corporation
 - Shetty Akarsh [@@ShettyAkarsh]
 - Alex Bezek [@alex-bezek]
 - Supreeth MR [@supreethmr]
+- Shetty Akarsh [@ShettyAkarsh]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -47,3 +48,4 @@ Cerner Corporation
 [@ShettyAkarsh]: https://github.com/ShettyAkarsh
 [@alex-bezek]: https://github.com/alex-bezek
 [@supreethmr]: https://github.com/supreethmr
+[@ShettyAkarsh]: https://github.com/ShettyAkarsh

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Throws NPE if manually entered valid date is outside of allotted datetime range.
 
 3.5.0 - (February 5, 2019)
 ------------------

--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -230,7 +230,7 @@ class DateTimePicker extends React.Component {
 
   handleTimeChange(event, time) {
     this.timeValue = time;
-    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat);
+    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat) && this.isDateTimeWithinRange(this.convertDateTimeStringToMomentObject(this.dateValue, this.timeValue));
     const validTime = DateTimeUtils.isValidTime(this.timeValue);
     const previousDateTime = this.state.dateTime ? this.state.dateTime.clone() : null;
 
@@ -305,13 +305,17 @@ class DateTimePicker extends React.Component {
   }
 
   validateDefaultDate() {
+    return this.isDateTimeWithinRange(this.state.dateTime);
+  }
+
+  isDateTimeWithinRange(newDateTime) {
     let isAcceptable = true;
 
-    if (DateUtil.isDateOutOfRange(this.state.dateTime, DateUtil.createSafeDate(this.props.minDateTime), DateUtil.createSafeDate(this.props.maxDateTime))) {
+    if (DateUtil.isDateOutOfRange(newDateTime, DateUtil.createSafeDate(this.props.minDateTime), DateUtil.createSafeDate(this.props.maxDateTime))) {
       isAcceptable = false;
     }
 
-    if (DateUtil.isDateExcluded(this.state.dateTime, this.props.excludeDates)) {
+    if (DateUtil.isDateExcluded(newDateTime, this.props.excludeDates)) {
       isAcceptable = false;
     }
 
@@ -344,6 +348,10 @@ class DateTimePicker extends React.Component {
 
   handleOnRequestClose() {
     this.setState({ isTimeClarificationOpen: false });
+  }
+
+  convertDateTimeStringToMomentObject(date, time) {
+    return DateTimeUtils.updateTime(DateUtil.createSafeDate(DateUtil.convertToISO8601(date, this.state.dateFormat)), time);
   }
 
   renderTimeClarification() {

--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -230,7 +230,7 @@ class DateTimePicker extends React.Component {
 
   handleTimeChange(event, time) {
     this.timeValue = time;
-    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat) && this.isDateTimeWithinRange(this.convertDateTimeStringToMomentObject(this.dateValue, this.timeValue));
+    const validDate = DateTimeUtils.isValidDate(this.dateValue, this.state.dateFormat) && this.isDateTimeWithinRange(DateTimeUtils.convertDateTimeStringToMomentObject(this.dateValue, this.timeValue, this.state.dateFormat));
     const validTime = DateTimeUtils.isValidTime(this.timeValue);
     const previousDateTime = this.state.dateTime ? this.state.dateTime.clone() : null;
 
@@ -348,10 +348,6 @@ class DateTimePicker extends React.Component {
 
   handleOnRequestClose() {
     this.setState({ isTimeClarificationOpen: false });
-  }
-
-  convertDateTimeStringToMomentObject(date, time) {
-    return DateTimeUtils.updateTime(DateUtil.createSafeDate(DateUtil.convertToISO8601(date, this.state.dateFormat)), time);
   }
 
   renderTimeClarification() {

--- a/packages/terra-date-time-picker/src/DateTimeUtils.js
+++ b/packages/terra-date-time-picker/src/DateTimeUtils.js
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone';
+import DateUtil from 'terra-date-picker/lib/DateUtil';
 
 class DateTimeUtils {
   static createSafeDate(date) {
@@ -108,6 +109,10 @@ class DateTimeUtils {
 
   static getStandardTZDisplay() {
     return moment('2017-01-01').tz(moment.tz.guess()).format('z');
+  }
+
+  static convertDateTimeStringToMomentObject(date, time, dateformat) {
+    return DateTimeUtils.updateTime(DateUtil.createSafeDate(DateUtil.convertToISO8601(date, dateformat)), time);
   }
 }
 

--- a/packages/terra-date-time-picker/tests/jest/DateTimePicker.test.jsx
+++ b/packages/terra-date-time-picker/tests/jest/DateTimePicker.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { IntlProvider } from 'react-intl';
 import DateTimePicker from '../../lib/DateTimePicker';
 import messages from '../../translations/en-US.json';
+import dateInputMessages from '../../node_modules/terra-date-picker/translations/en-US.json';
+import timeInputMessages from '../../node_modules/terra-time-input/translations/en-US.json';
 
 const locale = 'en-US';
 
@@ -115,4 +117,20 @@ it('should render a disabled date time picker', () => {
       <DateTimePicker name="date-time-input" disabled utcOffset={0} />
     </IntlProvider>));
   expect(datePicker).toMatchSnapshot();
+});
+
+it('Should not throw any errors while date value is outside of the Min, Max range and new time value is being entered ', () => {
+  const allMessages = Object.assign(messages, dateInputMessages, timeInputMessages);
+  const datePicker = mount((
+    <IntlProvider locale={locale} messages={allMessages}>
+      <DateTimePicker name="date-time-input" maxDateTime="2017-04-01T10:30" minDateTime="2017-04-10T10:30" />
+    </IntlProvider>));
+  const dateInput = datePicker.find({ name: 'terra-date-input', type: 'text' }).at(0);
+  dateInput.simulate('change', { target: { value: '04/12/2017' } });
+  expect(() => {
+    const hourInput = datePicker.find({ name: 'terra-time-hour-input' }).at(0);
+    hourInput.simulate('change', { target: { value: '21' } });
+    const minuteInput = datePicker.find({ name: 'terra-time-minute-input' }).at(0);
+    minuteInput.simulate('change', { target: { value: '30' } });
+  }).not.toThrowError();
 });

--- a/packages/terra-date-time-picker/tests/jest/DateTimePicker.test.jsx
+++ b/packages/terra-date-time-picker/tests/jest/DateTimePicker.test.jsx
@@ -121,10 +121,13 @@ it('should render a disabled date time picker', () => {
 
 it('Should not throw any errors while date value is outside of the Min, Max range and new time value is being entered ', () => {
   const allMessages = Object.assign(messages, dateInputMessages, timeInputMessages);
+
   const datePicker = mount((
     <IntlProvider locale={locale} messages={allMessages}>
       <DateTimePicker name="date-time-input" maxDateTime="2017-04-01T10:30" minDateTime="2017-04-10T10:30" />
-    </IntlProvider>));
+    </IntlProvider>
+  ));
+
   const dateInput = datePicker.find({ name: 'terra-date-input', type: 'text' }).at(0);
   dateInput.simulate('change', { target: { value: '04/12/2017' } });
   expect(() => {


### PR DESCRIPTION
### Summary
Resolves the NPE error when user tries to enter time along with valid date outside of the allotted datetime range.

The fix is to validate whether the date entered is within the datetime range after the date value is validated.

Resolves #2074