### PR TITLE
[terra-hookshot] Add behavior to disable onclickoutside if the callback isn't passed.

### DIFF
--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Disable outClickOutside if no callback function is passed.
 
 5.2.0 - (February 26, 2019)
 ------------------

--- a/packages/terra-hookshot/src/Hookshot.jsx
+++ b/packages/terra-hookshot/src/Hookshot.jsx
@@ -290,7 +290,7 @@ class Hookshot extends React.Component {
   }
 
   cloneContent(content) {
-    return React.cloneElement(content, { refCallback: this.wrappedRefCallback(content) });
+    return React.cloneElement(content, { refCallback: this.wrappedRefCallback(content), disableOnClickOutside: !content.props.onClickOutside });
   }
 
   wrappedRefCallback(content) {

--- a/packages/terra-hookshot/src/Hookshot.jsx
+++ b/packages/terra-hookshot/src/Hookshot.jsx
@@ -290,7 +290,7 @@ class Hookshot extends React.Component {
   }
 
   cloneContent(content) {
-    return React.cloneElement(content, { refCallback: this.wrappedRefCallback(content), disableOnClickOutside: !content.props.onClickOutside });
+    return React.cloneElement(content, { refCallback: this.wrappedRefCallback(content), disableOnClickOutside: !content.props.onOutsideClick });
   }
 
   wrappedRefCallback(content) {

--- a/packages/terra-hookshot/src/HookshotContent.jsx
+++ b/packages/terra-hookshot/src/HookshotContent.jsx
@@ -38,6 +38,14 @@ const propTypes = {
    * The function returning the frame html reference.
    */
   refCallback: PropTypes.func,
+  /**
+   * @private The function returning the frame html reference.
+   */
+  enableOnClickOutside: PropTypes.func,
+  /**
+   * @private The function returning the frame html reference.
+   */
+  disableOnClickOutside: PropTypes.func,
 };
 
 
@@ -65,8 +73,11 @@ class HookshotContent extends React.Component {
     this.disableResizeListener = this.disableResizeListener.bind(this);
     this.enableContentResizeListener = this.enableContentResizeListener.bind(this);
     this.disableContentResizeListener = this.disableContentResizeListener.bind(this);
+    this.enableClickOutsideListener = this.enableClickOutsideListener.bind(this);
+    this.disableClickOutsideListener = this.disableClickOutsideListener.bind(this);
     this.updateListeners = this.updateListeners.bind(this);
     this.animationFrameID = null;
+    this.clickOutsideListenerAdded = true; // onClickOutside is on by default
   }
 
   componentDidMount() {
@@ -81,6 +92,7 @@ class HookshotContent extends React.Component {
     this.disableEscListener();
     this.disableResizeListener();
     this.disableContentResizeListener();
+    this.disableClickOutsideListener();
   }
 
   handleResize(event) {
@@ -119,6 +131,26 @@ class HookshotContent extends React.Component {
       this.enableContentResizeListener();
     } else {
       this.disableContentResizeListener();
+    }
+
+    if (this.props.onOutsideClick) {
+      this.enableClickOutsideListener();
+    } else {
+      this.disableClickOutsideListener();
+    }
+  }
+
+  enableClickOutsideListener() {
+    if (!this.clickOutsideListenerAdded) {
+      this.props.enableOnClickOutside();
+      this.clickOutsideListenerAdded = true;
+    }
+  }
+
+  disableClickOutsideListener() {
+    if (this.clickOutsideListenerAdded) {
+      this.props.disableOnClickOutside();
+      this.clickOutsideListenerAdded = false;
     }
   }
 
@@ -205,7 +237,7 @@ class HookshotContent extends React.Component {
     delete customProps.closePortal;
 
     return (
-      <div {...customProps} className={cx(['content', customProps.className])} ref={(element) => { this.contentNode = element; refCallback(element); }}>
+      <div {...customProps} className={cx(['content', customProps.className])} ref={(element) => { this.contentNode = element; if (refCallback) { refCallback(element); } }}>
         {children}
       </div>
     );

--- a/packages/terra-hookshot/src/HookshotContent.jsx
+++ b/packages/terra-hookshot/src/HookshotContent.jsx
@@ -38,14 +38,6 @@ const propTypes = {
    * The function returning the frame html reference.
    */
   refCallback: PropTypes.func,
-  /**
-   * @private The function returning the frame html reference.
-   */
-  enableOnClickOutside: PropTypes.func,
-  /**
-   * @private The function returning the frame html reference.
-   */
-  disableOnClickOutside: PropTypes.func,
 };
 
 
@@ -73,11 +65,8 @@ class HookshotContent extends React.Component {
     this.disableResizeListener = this.disableResizeListener.bind(this);
     this.enableContentResizeListener = this.enableContentResizeListener.bind(this);
     this.disableContentResizeListener = this.disableContentResizeListener.bind(this);
-    this.enableClickOutsideListener = this.enableClickOutsideListener.bind(this);
-    this.disableClickOutsideListener = this.disableClickOutsideListener.bind(this);
     this.updateListeners = this.updateListeners.bind(this);
     this.animationFrameID = null;
-    this.clickOutsideListenerAdded = true; // onClickOutside is on by default
   }
 
   componentDidMount() {
@@ -92,7 +81,6 @@ class HookshotContent extends React.Component {
     this.disableEscListener();
     this.disableResizeListener();
     this.disableContentResizeListener();
-    this.disableClickOutsideListener();
   }
 
   handleResize(event) {
@@ -131,26 +119,6 @@ class HookshotContent extends React.Component {
       this.enableContentResizeListener();
     } else {
       this.disableContentResizeListener();
-    }
-
-    if (this.props.onOutsideClick) {
-      this.enableClickOutsideListener();
-    } else {
-      this.disableClickOutsideListener();
-    }
-  }
-
-  enableClickOutsideListener() {
-    if (!this.clickOutsideListenerAdded) {
-      this.props.enableOnClickOutside();
-      this.clickOutsideListenerAdded = true;
-    }
-  }
-
-  disableClickOutsideListener() {
-    if (this.clickOutsideListenerAdded) {
-      this.props.disableOnClickOutside();
-      this.clickOutsideListenerAdded = false;
     }
   }
 
@@ -237,7 +205,11 @@ class HookshotContent extends React.Component {
     delete customProps.closePortal;
 
     return (
-      <div {...customProps} className={cx(['content', customProps.className])} ref={(element) => { this.contentNode = element; if (refCallback) { refCallback(element); } }}>
+      <div
+        {...customProps}
+        className={cx(['content', customProps.className])}
+        ref={(element) => { this.contentNode = element; if (refCallback) { refCallback(element); } }}
+      >
         {children}
       </div>
     );


### PR DESCRIPTION
### Summary
Add behavior to disable onclickoutside if the callback isn't passed.

Validation of the the select fix can be done on the hookshot doc page. There is currently a circular dependency on form select, long term this should be corrected, but in the short term it can be used.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
