### PR TITLE
Remove terra-heading dependency from terra-modal-manager

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ Cerner Corporation
 - Alex Bezek [@alex-bezek]
 - Supreeth MR [@supreethmr]
 - Shetty Akarsh [@ShettyAkarsh]
+- Gabe Parra    [@gabeparra01]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -49,3 +50,4 @@ Cerner Corporation
 [@alex-bezek]: https://github.com/alex-bezek
 [@supreethmr]: https://github.com/supreethmr
 [@ShettyAkarsh]: https://github.com/ShettyAkarsh
+[@gabeparra01]: https://github.com/gabeparra01

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed dependency terra-heading
 
 5.4.0 - (March 5, 2019)
 ------------------

--- a/packages/terra-modal-manager/package.json
+++ b/packages/terra-modal-manager/package.json
@@ -35,7 +35,6 @@
     "terra-disclosure-manager": "^4.4.0",
     "terra-doc-template": "^2.2.0",
     "terra-form-input": "^2.3.0",
-    "terra-heading": "^3.0.0",
     "terra-responsive-element": "^4.0.0",
     "terra-slide-group": "^3.1.0"
   },


### PR DESCRIPTION
### Summary
The terra-heading dependency is no longer being used in terra-modal-manager and can be removed. Closes #531 