### PR TITLE
Updated doc page to remove duplicate ids

### DIFF
--- a/packages/terra-slide-panel-manager/CHANGELOG.md
+++ b/packages/terra-slide-panel-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated doc page to remove duplicate ID's
 
 4.4.0 - (March 5, 2019)
 ------------------

--- a/packages/terra-slide-panel-manager/src/terra-dev-site/doc/example/ContentComponent.jsx
+++ b/packages/terra-slide-panel-manager/src/terra-dev-site/doc/example/ContentComponent.jsx
@@ -17,6 +17,7 @@ const cx = classNames.bind(styles);
 const propTypes = {
   disclosureType: PropTypes.string,
   disclosureManager: disclosureManagerShape,
+  panelBehavior: PropTypes.oneOf(['overlay', 'squish']),
 };
 
 const HEIGHT_KEYS = Object.keys(availableDisclosureHeights);
@@ -92,14 +93,14 @@ class ContentComponent extends React.Component {
   renderForm() {
     return (
       <form>
-        <label htmlFor={this.getId('disclosureHeight')}>Pop Content Height</label>
-        <select id={this.getId('disclosureHeight')} name="disclosureHeight" value={this.state.disclosureHeight} onChange={this.handleSelectChange}>
+        <label htmlFor={this.getId(`disclosureHeight${this.props.panelBehavior}`)}>Pop Content Height</label>
+        <select id={this.getId(`disclosureHeight${this.props.panelBehavior}`)} name="disclosureHeight" value={this.state.disclosureHeight} onChange={this.handleSelectChange}>
           {generateOptions(HEIGHT_KEYS)}
         </select>
         <br />
         <br />
-        <label htmlFor={this.getId('disclosureWidth')}>Pop Content Width</label>
-        <select id={this.getId('disclosureWidth')} name="disclosureWidth" value={this.state.disclosureWidth} onChange={this.handleSelectChange}>
+        <label htmlFor={this.getId(`disclosureWidth${this.props.panelBehavior}`)}>Pop Content Width</label>
+        <select id={this.getId(`disclosureWidth${this.props.panelBehavior}`)} name="disclosureWidth" value={this.state.disclosureWidth} onChange={this.handleSelectChange}>
           {generateOptions(WIDTH_KEYS)}
         </select>
         <br />

--- a/packages/terra-slide-panel-manager/src/terra-dev-site/doc/example/SlidePanelManagerExample.jsx
+++ b/packages/terra-slide-panel-manager/src/terra-dev-site/doc/example/SlidePanelManagerExample.jsx
@@ -17,7 +17,7 @@ const propTypes = {
 const SlidePanelManagerExample = ({ behavior }) => (
   <div className={cx('example-wrapper')}>
     <SlidePanelManager panelBehavior={behavior}>
-      <ContentComponent disclosureType="panel" />
+      <ContentComponent panelBehavior={behavior} disclosureType="panel" />
     </SlidePanelManager>
   </div>
 );


### PR DESCRIPTION
### Summary
The doc page for the slide-panel-manager component examples were using duplicate id's which raised a red flag for accessibility warnings, so I made the id's unique for each example.

Resolves [#508](https://github.com/cerner/terra-framework/issues/508)