### PR TITLE
Update demo styles to be themable

### DIFF
--- a/packages/terra-application-layout/CHANGELOG.md
+++ b/packages/terra-application-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Changed demo mock colors to be themable
 
 4.5.0 - (March 12, 2019)
 ------------------

--- a/packages/terra-application-layout/src/terra-dev-site/test/common/ExtensionsExample.jsx
+++ b/packages/terra-application-layout/src/terra-dev-site/test/common/ExtensionsExample.jsx
@@ -1,5 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
+import classNames from 'classnames/bind';
+import demoStyles from './demoStyles.scss';
+
+const cx = classNames.bind(demoStyles);
 
 const ApplicationHeaderDefault = ({ ...customProps }) => {
   if (customProps.layoutConfig.size !== 'large') {
@@ -11,7 +15,7 @@ const ApplicationHeaderDefault = ({ ...customProps }) => {
   }
 
   return (
-    <div style={{ color: '#fff' }}>
+    <div className={cx(['demo-extensions'])}>
       Test Extensions Large
     </div>
   );

--- a/packages/terra-application-layout/src/terra-dev-site/test/common/demoStyles.scss
+++ b/packages/terra-application-layout/src/terra-dev-site/test/common/demoStyles.scss
@@ -1,0 +1,5 @@
+:local {
+  .demo-extensions {
+    color: var(--terra-application-layout-demo-extensions-color, #fff);
+  }
+}

--- a/packages/terra-application-links/CHANGELOG.md
+++ b/packages/terra-application-links/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Changed demo mock background colors to be themable
 
 5.5.0 - (March 12, 2019)
 ------------------

--- a/packages/terra-application-links/src/terra-dev-site/test/application-links/ApplicationTabsDefault.test.jsx
+++ b/packages/terra-application-links/src/terra-dev-site/test/application-links/ApplicationTabsDefault.test.jsx
@@ -2,20 +2,14 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import ApplicationTabs from '../../../tabs/ApplicationTabs';
 import testLinkConfig from '../common/testLinkConfig';
-
-const demoheaderstyles = {
-  width: '100%',
-  backgroundColor: '#1c5f92',
-  height: '49px',
-  position: 'relative',
-};
+import demoStyles from './demoStyles.scss';
 
 export default () => (
   <MemoryRouter
     initialEntries={testLinkConfig.map(link => link.path)}
     initialIndex={0}
   >
-    <div style={demoheaderstyles}>
+    <div className={demoStyles['demo-header']}>
       <ApplicationTabs id="test-tabs" links={testLinkConfig} />
     </div>
   </MemoryRouter>

--- a/packages/terra-application-links/src/terra-dev-site/test/application-links/demoStyles.scss
+++ b/packages/terra-application-links/src/terra-dev-site/test/application-links/demoStyles.scss
@@ -1,0 +1,8 @@
+:local {
+  .demo-header {
+    background-color: var(--terra-application-links-demo-header-background-color, #1c5f92);
+    height: 49px;
+    position: relative;
+    width: 100%;
+  }
+}

--- a/packages/terra-application-name/CHANGELOG.md
+++ b/packages/terra-application-name/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Updated doc site example images with alt text to correct Section 508 warnings
+* Changed demo mock background colors to be themable
 
 3.2.0 - (February 26, 2019)
 ------------------

--- a/packages/terra-application-name/src/terra-dev-site/test/application-name/ApplicationHeaderNameDefault.test.jsx
+++ b/packages/terra-application-name/src/terra-dev-site/test/application-name/ApplicationHeaderNameDefault.test.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import Image from 'terra-image';
+import classNames from 'classnames/bind';
 import ApplicationHeaderName from '../../../ApplicationHeaderName';
+import demoStyles from './demoStyles.scss';
+
+const cx = classNames.bind(demoStyles);
 
 export default () => (
-  <div style={{ backgroundColor: 'green' }}>
+  <div className={cx(['demo-background-color'])}>
     <ApplicationHeaderName
       id="default"
       title="Title"

--- a/packages/terra-application-name/src/terra-dev-site/test/application-name/ApplicationHeaderNameTruncated.test.jsx
+++ b/packages/terra-application-name/src/terra-dev-site/test/application-name/ApplicationHeaderNameTruncated.test.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import Image from 'terra-image';
+import classNames from 'classnames/bind';
 import ApplicationHeaderName from '../../../ApplicationHeaderName';
+import demoStyles from './demoStyles.scss';
+
+const cx = classNames.bind(demoStyles);
 
 export default () => (
-  <div style={{ backgroundColor: 'green', width: '150px' }}>
+  <div className={cx(['demo-background-color', 'demo-truncate-width'])}>
     <ApplicationHeaderName
       id="truncated"
       title="TitleTitleTitleTitleTitleTitleTitle"

--- a/packages/terra-application-name/src/terra-dev-site/test/application-name/ApplicationMenuNameWrapping.test.jsx
+++ b/packages/terra-application-name/src/terra-dev-site/test/application-name/ApplicationMenuNameWrapping.test.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import Image from 'terra-image';
+import classNames from 'classnames/bind';
 import ApplicationMenuName from '../../../ApplicationMenuName';
+import demoStyles from './demoStyles.scss';
+
+const cx = classNames.bind(demoStyles);
 
 export default () => (
-  <div style={{ width: '150px', backgroundColor: 'green' }}>
+  <div className={cx(['demo-background-color', 'demo-truncate-width'])}>
     <ApplicationMenuName
       id="wrapping"
       title="Title TitleTitleTitleTitleTitle Title Title Title Title Title"

--- a/packages/terra-application-name/src/terra-dev-site/test/application-name/demoStyles.scss
+++ b/packages/terra-application-name/src/terra-dev-site/test/application-name/demoStyles.scss
@@ -1,0 +1,9 @@
+:local {
+  .demo-background-color {
+    background-color: var(--terra-application-name-demo-background-color, #008000);
+  }
+
+  .demo-truncate-width {
+    width: 150px;
+  }
+}


### PR DESCRIPTION
### Summary
While working on a theme that changes the text color for some of the application components, noticed some accessibility errors from wdio/axe-core that the colors were not accessible. After looking into the wdio errors, found out that the text color was themable but it was placed on a hard-coded background color used in the wdio test files. 

This PR updates those hard-coded colors to be themable, allowing for the ability to theme them to complement if the text or background color for these components is also updated in a theme.