### PR TITLE
Fixes circular dependency issue in terra-hookshot due to dependency on terra-form-select . 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,7 +23,7 @@ Cerner Corporation
 - Shetty Akarsh [@@ShettyAkarsh]
 - Alex Bezek [@alex-bezek]
 - Supreeth MR [@supreethmr]
-- Shetty Akarsh [@ShettyAkarsh]
+- Akarsh Shetty [@ShettyAkarsh]
 - Gabe Parra [@gabeparra01]
 - Naveen Kumar Ramamurthy [@nramamurth]
 

--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated the terra-dev-site documentation examples and Removed Dependency on terra-form-select.
 
 5.5.0 - (March 26, 2019)
 ------------------

--- a/packages/terra-hookshot/package.json
+++ b/packages/terra-hookshot/package.json
@@ -36,8 +36,7 @@
     "resize-observer-polyfill": "^1.4.1",
     "terra-button": "^3.3.0",
     "terra-doc-template": "^2.2.0",
-    "terra-form-input": "^2.3.0",
-    "terra-form-select": "^5.0.0"
+    "terra-form-input": "^2.3.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-hookshot/src/terra-dev-site/doc/example/BoundedHookshotExample.jsx
+++ b/packages/terra-hookshot/src/terra-dev-site/doc/example/BoundedHookshotExample.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Button from 'terra-button';
 import InputField from 'terra-form-input/lib/InputField';
-import SelectField from 'terra-form-select/lib/SelectField';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import Hookshot from 'terra-hookshot/lib/Hookshot';
+import HTMLSelect from './HTMLSelectExample';
 
 const ATTACHMENT_POSITIONS = [
   'top start',
@@ -16,13 +16,6 @@ const ATTACHMENT_POSITIONS = [
   'bottom center',
   'bottom end',
 ];
-
-const generateOptions = values => (
-  values.map((currentValue, index) => {
-    const keyValue = index;
-    return <SelectField.Option key={keyValue} value={currentValue} display={currentValue} />;
-  })
-);
 
 const attachmentValues = (attachment) => {
   if (attachment === 'middle start') {
@@ -52,9 +45,6 @@ class HookshotStandard extends React.Component {
     super(props);
     this.handleButtonClick = this.handleButtonClick.bind(this);
     this.handleRequestClose = this.handleRequestClose.bind(this);
-    this.handleAttachementBehaviorChange = this.handleAttachementBehaviorChange.bind(this);
-    this.handleContentAttachmentChange = this.handleContentAttachmentChange.bind(this);
-    this.handleTargetAttachmentChange = this.handleTargetAttachmentChange.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
     this.setParentNode = this.setParentNode.bind(this);
     this.getParentNode = this.getParentNode.bind(this);
@@ -88,18 +78,6 @@ class HookshotStandard extends React.Component {
     this.setState({ isOpen: false });
   }
 
-  handleAttachementBehaviorChange(value) {
-    this.setState({ hookshotAttachmentBehavior: value });
-  }
-
-  handleContentAttachmentChange(value) {
-    this.setState({ hookshotContentAttachment: value });
-  }
-
-  handleTargetAttachmentChange(value) {
-    this.setState({ hookshotTargetAttachment: value });
-  }
-
   handleInputChange(event) {
     this.setState({ [event.target.name]: Number.parseFloat(event.target.value) });
   }
@@ -117,15 +95,8 @@ class HookshotStandard extends React.Component {
 
     return (
       <div>
-        <SelectField
-          label="Attachment Behavior"
-          selectId={getId('hookshotAttachmentBehavior')}
-          selectAttrs={{ name: 'hookshotAttachmentBehavior' }}
-          value={this.state.hookshotAttachmentBehavior}
-          onChange={this.handleAttachementBehaviorChange}
-        >
-          {generateOptions(Hookshot.attachmentBehaviors)}
-        </SelectField>
+        <HTMLSelect labelText="Attachment Behavior" selectName="hookshotAttachmentBehavior" value={Hookshot.attachmentBehaviors[0]} selectOptions={Hookshot.attachmentBehaviors} HookShotName="HookShotBehaviour" idAppendName="BoundedExample" />
+        <br />
         <InputField
           label="Attachment Margin in Px"
           inputId={getId('hookshotAttachmentMargin')}
@@ -134,24 +105,10 @@ class HookshotStandard extends React.Component {
           style={{ width: '200px' }}
           onChange={this.handleInputChange}
         />
-        <SelectField
-          label="Content Attachment"
-          selectId={getId('hookshotContentAttachment')}
-          selectAttrs={{ name: 'hookshotContentAttachment' }}
-          value={this.state.hookshotContentAttachment}
-          onChange={this.handleContentAttachmentChange}
-        >
-          {generateOptions(ATTACHMENT_POSITIONS)}
-        </SelectField>
-        <SelectField
-          label="Target Attachment"
-          selectId={getId('hookshotTargetAttachment')}
-          selectAttrs={{ name: 'hookshotTargetAttachment' }}
-          value={this.state.hookshotTargetAttachment}
-          onChange={this.handleTargetAttachmentChange}
-        >
-          {generateOptions(ATTACHMENT_POSITIONS)}
-        </SelectField>
+        <HTMLSelect labelText="Content Attachment" selectName="hookshotContentAttachment" value={ATTACHMENT_POSITIONS[1]} selectOptions={ATTACHMENT_POSITIONS} HookShotName="HookShotContent" idAppendName="BoundedExample" />
+        <br />
+        <HTMLSelect labelText="Target Attachment" selectName="hookshotTargetAttachment" value={ATTACHMENT_POSITIONS[7]} selectOptions={ATTACHMENT_POSITIONS} HookShotName="HookShotTarget" idAppendName="BoundedExample" />
+        <br />
         <Hookshot
           attachmentBehavior={this.state.hookshotAttachmentBehavior}
           attachmentMargin={this.state.hookshotAttachmentMargin}

--- a/packages/terra-hookshot/src/terra-dev-site/doc/example/CoordsHookshotExample.jsx
+++ b/packages/terra-hookshot/src/terra-dev-site/doc/example/CoordsHookshotExample.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import InputField from 'terra-form-input/lib/InputField';
-import SelectField from 'terra-form-select/lib/SelectField';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import Hookshot from 'terra-hookshot/lib/Hookshot';
+import HTMLSelect from './HTMLSelectExample';
 
 const ATTACHMENT_POSITIONS = [
   'top start',
@@ -15,13 +15,6 @@ const ATTACHMENT_POSITIONS = [
   'bottom center',
   'bottom end',
 ];
-
-const generateOptions = values => (
-  values.map((currentValue, index) => {
-    const keyValue = index;
-    return <SelectField.Option key={keyValue} value={currentValue} display={currentValue} />;
-  })
-);
 
 const attachmentValues = (attachment) => {
   if (attachment === 'middle start') {
@@ -53,8 +46,6 @@ class HookshotStandard extends React.Component {
     this.handleRequestClose = this.handleRequestClose.bind(this);
     this.setParentNode = this.setParentNode.bind(this);
     this.getParentNode = this.getParentNode.bind(this);
-    this.handleAttachementBehaviorChange = this.handleAttachementBehaviorChange.bind(this);
-    this.handleContentAttachmentChange = this.handleContentAttachmentChange.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
     this.state = {
       isOpen: false,
@@ -82,14 +73,6 @@ class HookshotStandard extends React.Component {
     this.setState({ isOpen: false });
   }
 
-  handleAttachementBehaviorChange(value) {
-    this.setState({ hookshotAttachmentBehavior: value });
-  }
-
-  handleContentAttachmentChange(value) {
-    this.setState({ hookshotContentAttachment: value });
-  }
-
   handleInputChange(event) {
     this.setState({ [event.target.name]: Number.parseFloat(event.target.value) });
   }
@@ -108,15 +91,8 @@ class HookshotStandard extends React.Component {
     return (
       /* eslint-disable jsx-a11y/no-static-element-interactions */
       <div>
-        <SelectField
-          label="Attachment Behavior"
-          selectId={getId('hookshotAttachmentBehavior')}
-          selectAttrs={{ name: 'hookshotAttachmentBehavior' }}
-          value={this.state.hookshotAttachmentBehavior}
-          onChange={this.handleAttachementBehaviorChange}
-        >
-          {generateOptions(Hookshot.attachmentBehaviors)}
-        </SelectField>
+        <HTMLSelect labelText="Attachment Behavior" selectName="hookshotAttachmentBehavior" value={Hookshot.attachmentBehaviors[0]} selectOptions={Hookshot.attachmentBehaviors} HookShotName="HookShotBehaviour" idAppendName="CoordsExample" />
+        <br />
         <InputField
           label="Attachment Margin in Px"
           inputId={getId('hookshotAttachmentMargin')}
@@ -125,15 +101,8 @@ class HookshotStandard extends React.Component {
           style={{ width: '200px' }}
           onChange={this.handleInputChange}
         />
-        <SelectField
-          label="Content Attachment"
-          selectId={getId('hookshotContentAttachment')}
-          selectAttrs={{ name: 'hookshotContentAttachment' }}
-          value={this.state.hookshotContentAttachment}
-          onChange={this.handleContentAttachmentChange}
-        >
-          {generateOptions(ATTACHMENT_POSITIONS)}
-        </SelectField>
+        <HTMLSelect labelText="Content Attachment" selectName="hookshotContentAttachment" value={ATTACHMENT_POSITIONS[1]} selectOptions={ATTACHMENT_POSITIONS} HookShotName="HookShotContent" idAppendName="CoordsExample" />
+        <br />
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
         <div
           onClick={this.handleRegionClick}

--- a/packages/terra-hookshot/src/terra-dev-site/doc/example/HTMLSelectExample.jsx
+++ b/packages/terra-hookshot/src/terra-dev-site/doc/example/HTMLSelectExample.jsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Hookshot from '../../../Hookshot';
+import styles from './HTMLSelectExample.module.scss';
+
+
+const propTypes = {
+  /**
+    * Text to be applied to the select label.
+    */
+  labelText: PropTypes.string,
+  /**
+    * Name to be applied to the select.
+    */
+  selectName: PropTypes.string,
+  /**
+    * Value to be binded to the select.
+    */
+  value: PropTypes.string,
+  /**
+    * Options to be displayed in the Hookshot.
+    */
+  selectOptions: PropTypes.arrayOf(PropTypes.string),
+  /**
+    * Name to be applied to the Hookshot.
+    */
+  hookShotName: PropTypes.string,
+  /**
+    * Name to be appended along with compoent name while creating the Id attribute.
+    */
+  idAppendName: PropTypes.string,
+};
+
+const AboveAttachment = {
+  vertical: 'bottom',
+  horizontal: 'start',
+};
+
+const BelowAttachment = {
+  vertical: 'top',
+  horizontal: 'start',
+};
+
+const generateOptions = ({ values }) => (
+  values.map((currentValue, index) => {
+    const keyValue = index;
+    return (
+      <option hidden key={keyValue} value={currentValue}>{currentValue}</option>
+    );
+  })
+);
+
+
+class HTMLSelectExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleSelectClick = this.handleSelectClick.bind(this);
+    this.handleSelectClose = this.handleSelectClose.bind(this);
+    this.handleHTMLSelectValueChange = this.handleHTMLSelectValueChange.bind(this);
+    this.handleListSelect = this.handleListSelect.bind(this);
+    this.setSelectNode = this.setSelectNode.bind(this);
+    this.positionDropdown = this.positionDropdown.bind(this);
+    this.state = {
+      isOpen: false,
+      isAbove: false,
+      htmlSelectValue: this.props.value,
+    };
+  }
+
+  setSelectNode(node) {
+    this.selectNode = node;
+  }
+
+  handleSelectClick() {
+    this.setState(previousState => ({ isOpen: !previousState.isOpen }));
+  }
+
+  handleSelectClose() {
+    this.setState({ isOpen: false });
+  }
+
+  handleHTMLSelectValueChange(event) {
+    this.setState({ htmlSelectValue: event.target.value });
+  }
+
+  handleListSelect(event) {
+    this.setState({ htmlSelectValue: event.target.innerHTML });
+  }
+
+  positionDropdown() {
+    if (!this.state.isOpen) {
+      return;
+    }
+
+    const { height } = this.HookShotNode.getBoundingClientRect();
+    const { bottom, top } = this.selectNode.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - bottom;
+    const canFitBelow = height < spaceBelow || spaceBelow > top;
+    this.setState({ isAbove: !canFitBelow });
+  }
+
+  render() {
+    const selectWidth = this.selectNode === undefined
+      ? '100%'
+      : this.selectNode.offsetWidth;
+
+    const styleClass = (value) => {
+      let className;
+      if (this.state.htmlSelectValue === value) {
+        className = styles.selected;
+      } else {
+        className = styles.liclass;
+      }
+      return className;
+    };
+
+    const getId = name => `${name + this.props.idAppendName}`;
+
+    const addToList = details => (
+      details.map((currentValue, index) => {
+        const keyValue = index;
+        return (
+          <li className={styleClass(currentValue)} role="option" aria-selected key={keyValue} onClick={this.handleListSelect} onKeyDown={this.handleListSelect}>
+            <span className={styles.spanclass}>{currentValue}</span>
+          </li>
+        );
+      })
+    );
+
+    const addToUnorderedList = ({ Contents }) => (
+      <ul className={styles.ulclass} style={{ width: `${selectWidth}px` }}>
+        {addToList(Contents)}
+      </ul>
+    );
+
+    const HookshotContent = (
+      <Hookshot.Content
+        onEsc={this.handleSelectClose}
+        onOutsideClick={this.handleSelectClose}
+        onResize={this.handleSelectClose}
+        onContentResize={this.positionDropdown}
+        refCallback={(ref) => { this.HookShotNode = ref; }}
+      >
+        {addToUnorderedList({ Contents: this.props.selectOptions })}
+      </Hookshot.Content>
+    );
+
+    const HookShotRender = (
+      <Hookshot
+        id={getId(this.props.hookShotName)}
+        name={this.props.hookShotName}
+        isEnabled
+        isOpen={this.state.isOpen}
+        attachmentBehavior="none"
+        contentAttachment={this.state.isAbove ? AboveAttachment : BelowAttachment}
+        targetAttachment={this.state.isAbove ? BelowAttachment : AboveAttachment}
+        targetRef={() => document.getElementById(getId(this.props.selectName))}
+      >
+        {HookshotContent}
+      </Hookshot>
+    );
+
+    return (
+      <div style={{ maxWidth: '72.857rem' }}>
+        <div style={{ height: '23px' }}>
+          <label htmlFor={getId(this.props.selectName)} style={{ fontWeight: 'bold' }}>{this.props.labelText}</label>
+        </div>
+        <select
+          className={styles.selectclass}
+          id={getId(this.props.selectName)}
+          name={this.props.selectName}
+          onMouseDown={(event) => { event.preventDefault(); }}
+          onClick={this.handleSelectClick}
+          value={this.state.htmlSelectValue}
+          onChange={this.handleHTMLSelectValueChange}
+          ref={this.setSelectNode}
+        >
+          {generateOptions({ values: this.props.selectOptions })}
+          {HookShotRender}
+        </select>
+      </div>
+    );
+  }
+}
+
+HTMLSelectExample.propTypes = propTypes;
+
+export default HTMLSelectExample;

--- a/packages/terra-hookshot/src/terra-dev-site/doc/example/HTMLSelectExample.module.scss
+++ b/packages/terra-hookshot/src/terra-dev-site/doc/example/HTMLSelectExample.module.scss
@@ -1,0 +1,66 @@
+:local {   
+  .selectclass {
+    appearance: none;
+    background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" class="is-bidi"><path d="M48 12L24 36 0 12h48z"/></svg>');
+    background-color: #fff;
+    background-position: right center;
+    background-repeat: no-repeat;
+    background-size: 25px 10px;
+    border: 1px solid #dedfe0;
+    cursor: pointer;
+    font-size: 1.143rem;
+    height: 28px;
+    outline: none;
+    position: relative;
+    text-indent: 0.12857rem;
+    width: 100%;
+
+    &::-ms-expand {
+      display: none; 
+    }
+  }
+
+  .ulclass {
+    background-color: #fff;
+    border: 1px solid #dedfe0;
+    display: block;
+    list-style-type: none;
+    margin: 0;
+    padding-left: 0;
+    user-select: none;
+  }
+
+  .liclass {
+    border: 0;
+    color: #1c1f21;
+    cursor: pointer;
+    font-size: 1.143rem;
+    list-style-type: none;
+    width: 100%;
+
+    &:hover {
+      background-color: #ebf6fd;
+    } 
+
+    &:active {
+      background-color: #0079be;
+      color: #fff;
+    } 
+  }
+
+  .selected {
+    background-color: #0079be;
+    border: 0;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1.143rem; 
+  }
+
+  .spanclass {
+    cursor: pointer;
+    display: inline-block;
+    flex: 1 1 auto;
+    text-indent: 0.42857rem;
+    width: 100%;
+  }
+}

--- a/packages/terra-hookshot/src/terra-dev-site/doc/example/HookshotExample.jsx
+++ b/packages/terra-hookshot/src/terra-dev-site/doc/example/HookshotExample.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Button from 'terra-button';
 import InputField from 'terra-form-input/lib/InputField';
-import SelectField from 'terra-form-select/lib/SelectField';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import Hookshot from 'terra-hookshot/lib/Hookshot';
+import HTMLSelect from './HTMLSelectExample';
 
 const ATTACHMENT_POSITIONS = [
   'top start',
@@ -16,13 +16,6 @@ const ATTACHMENT_POSITIONS = [
   'bottom center',
   'bottom end',
 ];
-
-const generateOptions = values => (
-  values.map((currentValue, index) => {
-    const keyValue = index;
-    return <SelectField.Option key={keyValue} value={currentValue} display={currentValue} />;
-  })
-);
 
 const attachmentValues = (attachment) => {
   if (attachment === 'middle start') {
@@ -52,9 +45,6 @@ class HookshotStandard extends React.Component {
     super(props);
     this.handleButtonClick = this.handleButtonClick.bind(this);
     this.handleRequestClose = this.handleRequestClose.bind(this);
-    this.handleAttachementBehaviorChange = this.handleAttachementBehaviorChange.bind(this);
-    this.handleContentAttachmentChange = this.handleContentAttachmentChange.bind(this);
-    this.handleTargetAttachmentChange = this.handleTargetAttachmentChange.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
     this.state = {
       isOpen: false,
@@ -71,18 +61,6 @@ class HookshotStandard extends React.Component {
 
   handleRequestClose() {
     this.setState({ isOpen: false });
-  }
-
-  handleAttachementBehaviorChange(value) {
-    this.setState({ hookshotAttachmentBehavior: value });
-  }
-
-  handleContentAttachmentChange(value) {
-    this.setState({ hookshotContentAttachment: value });
-  }
-
-  handleTargetAttachmentChange(value) {
-    this.setState({ hookshotTargetAttachment: value });
   }
 
   handleInputChange(event) {
@@ -103,15 +81,8 @@ class HookshotStandard extends React.Component {
 
     return (
       <div>
-        <SelectField
-          label="Attachment Behavior"
-          selectId={getId('hookshotAttachmentBehavior')}
-          selectAttrs={{ name: 'hookshotAttachmentBehavior' }}
-          value={this.state.hookshotAttachmentBehavior}
-          onChange={this.handleAttachementBehaviorChange}
-        >
-          {generateOptions(Hookshot.attachmentBehaviors)}
-        </SelectField>
+        <HTMLSelect labelText="Attachment Behavior" selectName="hookshotAttachmentBehavior" value={Hookshot.attachmentBehaviors[0]} selectOptions={Hookshot.attachmentBehaviors} HookShotName="HookShotBehaviour" idAppendName="Example" />
+        <br />
         <InputField
           label="Attachment Margin in Px"
           inputId={getId('hookshotAttachmentMargin')}
@@ -120,24 +91,10 @@ class HookshotStandard extends React.Component {
           style={{ width: '200px' }}
           onChange={this.handleInputChange}
         />
-        <SelectField
-          label="Content Attachment"
-          selectId={getId('hookshotContentAttachment')}
-          selectAttrs={{ name: 'hookshotContentAttachment' }}
-          value={this.state.hookshotContentAttachment}
-          onChange={this.handleContentAttachmentChange}
-        >
-          {generateOptions(ATTACHMENT_POSITIONS)}
-        </SelectField>
-        <SelectField
-          label="Target Attachment"
-          selectId={getId('hookshotTargetAttachment')}
-          selectAttrs={{ name: 'hookshotTargetAttachment' }}
-          value={this.state.hookshotTargetAttachment}
-          onChange={this.handleTargetAttachmentChange}
-        >
-          {generateOptions(ATTACHMENT_POSITIONS)}
-        </SelectField>
+        <HTMLSelect labelText="Content Attachment" selectName="hookshotContentAttachment" value={ATTACHMENT_POSITIONS[1]} selectOptions={ATTACHMENT_POSITIONS} HookShotName="HookShotContent" idAppendName="Example" />
+        <br />
+        <HTMLSelect labelText="Target Attachment" selectName="hookshotTargetAttachment" value={ATTACHMENT_POSITIONS[7]} selectOptions={ATTACHMENT_POSITIONS} HookShotName="HookShotTarget" idAppendName="Example" />
+        <br />
         <Hookshot
           attachmentBehavior={this.state.hookshotAttachmentBehavior}
           attachmentMargin={this.state.hookshotAttachmentMargin}


### PR DESCRIPTION
### Summary
Resolves issue #539. Removed direct dependency on terra-form-select for terra-hookshot by updating the terra-dev-site documentation examples using native html select along with terra-hookhot.

### Additional Details

Created new class under terra-devsite doc refferred from all the exisiting example doc. which internally uses native html select and terra-hookshot component to build the dropdown by accepting the  following props  

labelName : Text applied to the Select label.
selectName:  Name applied to the html select.
value : Default value to be binded to the select.
selectOptions :  Options to be binded to html select.
hookshotName: Name applied to hookshot.
idAppedName: Text to be appended when setting the id attribute for either select or hookshot components.

Created new style compoenent under terra-devsite docs to match the dropdown appearance of terra-form-select and have similar appearance for html select across all the browsers. this styles is refferred from the above class .