### PR TITLE
[terra-disclosure-manager] Explicitly documenting the required arguments for the disclose behavior

### DIFF
--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Explicitly documented the required arguments for the disclose behavior
 
 4.8.0 - (April 16, 2019)
 ------------------

--- a/packages/terra-disclosure-manager/docs/README.md
+++ b/packages/terra-disclosure-manager/docs/README.md
@@ -154,18 +154,18 @@ disclosureManager.disclose({
 
 `disclose` Argument API:
 
-|Key|Value|
-|---|---|
-|`preferredType`|The String describing the preferred disclosure type. This will be used to match the disclosure request to an appropriate DisclosureManager. Depending on the structuring of managers in a given component, the `preferredType` value may not be honored. If the provided `preferredType` is not supported by any present disclosure managers, the root disclosure manager will perform the disclosure using its own disclosure type, regardless of the `preferredType` value.
-|`size`|The String size desired for the disclosure. One of `tiny`, `small`, `medium`, `large`, `huge`, or `fullscreen`. The functional implementation of this size is determined by the rendering component.|
-|`content`|An Object containing a key and a component describing the component to be disclosed. See the `content` API below.|
+|Key|Is Required|Value|
+|---|---|---|
+|`preferredType`|optional|The String describing the preferred disclosure type. This will be used to match the disclosure request to an appropriate DisclosureManager. Depending on the structuring of managers in a given component, the `preferredType` value may not be honored. If the provided `preferredType` is not supported by any present disclosure managers, the root disclosure manager will perform the disclosure using its own disclosure type, regardless of the `preferredType` value.|
+|`size`|optional|The String size desired for the disclosure. One of `tiny`, `small`, `medium`, `large`, `huge`, or `fullscreen`. The functional implementation of this size is determined by the rendering component. If not provided, a default size will be used.|
+|`content`|**required**|An Object containing a key and a component describing the component to be disclosed. See the `content` API below.|
 
 `content` Object API:
 
-|Key|Value|
-|---|---|
-|key|A String key uniquely identifying the component to the DisclosureManager. This key will be added to the component (as a `key` prop) when rendered.|
-|component|A React element that will be disclosed.|
+|Key|Is Required|Value|
+|---|---|---|
+|`key`|**required**|A String key identifying the component to the DisclosureManager. This key must be unique amongst the set of all actively disclosed component keys.|
+|`component`|**required**|A React element that will be disclosed.|
 
 #### Disclosure Content
 

--- a/packages/terra-disclosure-manager/docs/README.md
+++ b/packages/terra-disclosure-manager/docs/README.md
@@ -157,7 +157,8 @@ disclosureManager.disclose({
 |Key|Is Required|Value|
 |---|---|---|
 |`preferredType`|optional|The String describing the preferred disclosure type. This will be used to match the disclosure request to an appropriate DisclosureManager. Depending on the structuring of managers in a given component, the `preferredType` value may not be honored. If the provided `preferredType` is not supported by any present disclosure managers, the root disclosure manager will perform the disclosure using its own disclosure type, regardless of the `preferredType` value.|
-|`size`|optional|The String size desired for the disclosure. One of `tiny`, `small`, `medium`, `large`, `huge`, or `fullscreen`. The functional implementation of this size is determined by the rendering component. If not provided, a default size will be used.|
+|`size`|optional|The String size desired for the disclosure. One of `tiny`, `small`, `medium`, `large`, `huge`, or `fullscreen`. The functional implementation of this size is determined by the rendering component. `size` should not be provided if `dimensions` are specified.|
+|`dimensions`|optional|An Object containing explicit `height` and `width` values for the disclosure. These values may not be honored due to the disclosure type or the available viewport size. `dimensions` should not be provided if a `size` is specified.<br />Supported `height` values include: `'240'`, `'420'`, `'600'`, `'690'`, `'780'`, `'870'`, `'960'`, `'1140'`.<br />Supported `width` values include: `'320'`, `'480'`, `'640'`, `'800'`, `'960'`, `'1120'`, `'1280'`, `'1440'`, `'1600'`, `'1760'`, `'1920'`.|
 |`content`|**required**|An Object containing a key and a component describing the component to be disclosed. See the `content` API below.|
 
 `content` Object API:

--- a/packages/terra-disclosure-manager/src/DisclosureManager.jsx
+++ b/packages/terra-disclosure-manager/src/DisclosureManager.jsx
@@ -409,7 +409,7 @@ class DisclosureManager extends React.Component {
     return () => {
       const { disclosureComponentKeys } = this.state;
 
-      if (!key || disclosureComponentKeys[disclosureComponentKeys.length - 1] !== key) {
+      if (disclosureComponentKeys[disclosureComponentKeys.length - 1] !== key) {
         /**
          * If the top component key in the disclosure stack does not match
          * the key used to generate this function, or the key is undefined, then the pop action is rejected.


### PR DESCRIPTION
### Summary
As of #583, the DisclosureManager will prevent dismissals of components disclosed without a key. A unique key is expected to be provided with the disclose request, per the documentation, and this was not expected to be a breaking change.

However, some consumers of the disclosure manager were **not** providing a key with their disclose requests. As of #583, this results in modals that can be opened but not closed. While I consider this a bug in their implementation, it is a regression in their functionality and leaves their applications in an unfortunate state.

This PR updates the documentation to be more explicit and removes the undefined check within the dismiss functions that is causing the above issue. I've logged #623 to better handle this in the future. 
