### PR TITLE
Fix Node Engine Version For Heroku Deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "terra-framework",
   "engines": {
-    "node": "8.x"
+    "node": ">=8.9.2 <12"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "terra-framework",
   "engines": {
-    "node": ">=8.9.2"
+    "node": "8.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
NodeJS release `v12.0.0` this morning. Heroku builds are failing for deployments because its pulling the latest version and some of the post install scripts of our dependencies like node-sass are failing.

According to Heroku's documentation, it will pull the engine version from the package.json, but to keep an open engine version, you must specify `8.x` instead of `>=8.9.2`.

https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version

For deployments to builds, this is the fix, however, this is putting a limitation on our repo since `>=` syntax is supported by npm: https://docs.npmjs.com/files/package.json#engines

### Edit
Heroku actually is honoring the range we defined so limiting the engine version less than 12