### PR TITLE
Terra-dev-site version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-test-renderer": "^16.4.2",
     "stylelint": "^9.2.0",
     "stylelint-config-terra": "^2.0.0",
-    "terra-dev-site": "^3.0.0",
+    "terra-dev-site": "^4.0.0",
     "terra-enzyme-intl": "^3.0.0",
     "terra-toolkit": "^4.16.0",
     "xfc": "^1.2.1"


### PR DESCRIPTION
### Summary
Updated terra-dev-site version in root package.json to:

`"terra-dev-site": "^4.0.0",`

Resolves [#616](https://github.com/cerner/terra-framework/issues/616)

