### PR TITLE
Update tabindex logic on main element

### DIFF
--- a/packages/terra-application-header-layout/CHANGELOG.md
+++ b/packages/terra-application-header-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+# Removed
+* Removed tabindex on main element to prevent keyboard page scroll bug
 
 3.6.0 - (April 24, 2019)
 ------------------

--- a/packages/terra-application-header-layout/src/ApplicationHeaderLayout.jsx
+++ b/packages/terra-application-header-layout/src/ApplicationHeaderLayout.jsx
@@ -84,7 +84,9 @@ const ApplicationHeaderLayout = ({
     const mainContainer = document.querySelector(['[data-terra-layout-main]']);
 
     if (mainContainer) {
+      mainContainer.setAttribute('tabindex', '-1');
       mainContainer.focus();
+      mainContainer.removeAttribute('tabindex');
     }
   };
 

--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 * Update react-router-dom peerDependency to latest stable major release
 * Updated tabbable dependency to ^4.0.0
 
+# Changed
+* Update skip to content link handling to only temporary set tabindex to prevent keyboard page scroll bug
+
 3.4.0 - (April 24, 2019)
 ------------------
 ### Changed

--- a/packages/terra-layout/src/_LayoutSlidePanel.jsx
+++ b/packages/terra-layout/src/_LayoutSlidePanel.jsx
@@ -161,7 +161,7 @@ class LayoutSlidePanel extends React.Component {
         </div>
         <OverlayContainer className={cx('content')}>
           <Overlay isRelativeToContainer onRequestClose={onToggle} isOpen={isOverlayOpen} backgroundStyle={overlayBackground} zIndex="6000" />
-          <main data-terra-layout-main tabIndex="-1" className={cx('main-container')}>
+          <main data-terra-layout-main className={cx('main-container')}>
             {children}
           </main>
         </OverlayContainer>

--- a/packages/terra-layout/tests/jest/__snapshots__/LayoutSlidePanel.test.jsx.snap
+++ b/packages/terra-layout/tests/jest/__snapshots__/LayoutSlidePanel.test.jsx.snap
@@ -28,7 +28,6 @@ exports[`LayoutSlidePanel should render when small 1`] = `
     <main
       className="main-container"
       data-terra-layout-main={true}
-      tabIndex="-1"
     >
       <div>
         Child
@@ -66,7 +65,6 @@ exports[`LayoutSlidePanel should render when tiny 1`] = `
     <main
       className="main-container"
       data-terra-layout-main={true}
-      tabIndex="-1"
     >
       <div>
         Child
@@ -104,7 +102,6 @@ exports[`LayoutSlidePanel should render with provided props 1`] = `
     <main
       className="main-container"
       data-terra-layout-main={true}
-      tabIndex="-1"
     >
       <div>
         Child
@@ -137,7 +134,6 @@ exports[`LayoutSlidePanel should render without optional props 1`] = `
     <main
       className="main-container"
       data-terra-layout-main={true}
-      tabIndex="-1"
     />
   </OverlayContainer>
 </div>


### PR DESCRIPTION
### Summary
Resolves https://github.com/cerner/terra-core/issues/2322 partly.
The other part of the fix is in: https://github.com/cerner/terra-core/pull/2396

Edit: Tested the skip link navigation to the main content interaction with both JAWS/IE 11 and VoiceOver/Safari and it continues to work the same as prior to this change, correctly navigating the user to the main content when the user "clicks" on the skip to main content button.