### PR TITLE
[terra-date-time-picker] Fixed js error in the filterDate example.

### DIFF
--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed js error in the filterDate example.
 
 4.1.0 - (March 15, 2019)
 ------------------

--- a/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerFilterDates.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerFilterDates.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import Field from 'terra-form-field';
 // eslint-disable-next-line import/no-unresolved, import/extensions
@@ -50,8 +51,14 @@ DateTimePickerExample.propTypes = propTypes;
 DateTimePickerExample.defualtProps = defaultProps;
 
 const isWeekday = (date) => {
-  const day = date.day();
-  return day !== 0 && day !== 6;
+  const momentDate = moment(date);
+
+  if (momentDate && momentDate.isValid()) {
+    const day = momentDate.day();
+    return day !== 0 && day !== 6;
+  }
+
+  return true;
 };
 
 const DateTimePickerExampleFilterDates = () => (


### PR DESCRIPTION
### Summary
Fix js error in the filterDate example.

### Additional Details

- Fixes #667 
- PR #590 changed the data type of the paramter in the filterDate callback from a moment object to a string. The filterDate example in terra-date-time-picker needs to be updated to handle this change.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
