### PR TITLE
Remove responsive-element from terra-layout and terra-navigation-layout

### DIFF
--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Added hard-coded breakpoint values to LayoutUtils.js
+
+### Removed
+* Removed dependency on terra-responsive-element
 
 4.1.0 - (March 15, 2019)
 ------------------

--- a/packages/terra-layout/package.json
+++ b/packages/terra-layout/package.json
@@ -32,8 +32,7 @@
     "prop-types": "^15.5.8",
     "tabbable": "^4.0.0",
     "terra-content-container": "^3.0.0",
-    "terra-overlay": "^3.0.0",
-    "terra-responsive-element": "^4.0.0"
+    "terra-overlay": "^3.0.0"
   },
   "devDependencies": {
     "react-router-dom": "^5.0.0",

--- a/packages/terra-layout/src/LayoutUtils.js
+++ b/packages/terra-layout/src/LayoutUtils.js
@@ -1,4 +1,10 @@
-import breakpoints from 'terra-responsive-element/lib/breakpoints.module.scss';
+const breakpoints = {
+  tiny: 544,
+  small: 768,
+  medium: 992,
+  large: 1216,
+  huge: 1440,
+};
 
 const {
   small, medium, large, huge,

--- a/packages/terra-navigation-layout/CHANGELOG.md
+++ b/packages/terra-navigation-layout/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Added hard-coded breakpoint values to NavigationLayout.jsx
+
+### Removed
+* Removed dependency on terra-responsive-element
 
 5.1.0 - (March 15, 2019)
 ------------------

--- a/packages/terra-navigation-layout/package.json
+++ b/packages/terra-navigation-layout/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-layout": "^4.1.0",
-    "terra-responsive-element": "^4.0.0"
+    "terra-layout": "^4.1.0"
   },
   "devDependencies": {
     "react-router-dom": "^5.0.0",

--- a/packages/terra-navigation-layout/src/NavigationLayout.jsx
+++ b/packages/terra-navigation-layout/src/NavigationLayout.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
 import Layout from 'terra-layout';
-import breakpoints from 'terra-responsive-element/lib/breakpoints.module.scss';
 
 import NavigationLayoutContent from './NavigationLayoutContent';
 import { navigationLayoutConfigPropType, supportedComponentBreakpoints } from './configurationPropTypes';
@@ -11,6 +10,14 @@ import { reduceRouteConfig, validateMatchExists } from './routingUtils';
 
 const getBreakpointSize = (queryWidth) => {
   const width = queryWidth || window.innerWidth;
+  const breakpoints = {
+    tiny: 544,
+    small: 768,
+    medium: 992,
+    large: 1216,
+    huge: 1440,
+  };
+
   const {
     small, medium, large, huge,
   } = breakpoints;

--- a/packages/terra-navigation-layout/tests/jest/__snapshots__/NavigationLayout.test.jsx.snap
+++ b/packages/terra-navigation-layout/tests/jest/__snapshots__/NavigationLayout.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`NavigationLayout should render a NavigationLayout with defaulted compon
           },
         ]
       }
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
   menu={
@@ -35,7 +35,7 @@ exports[`NavigationLayout should render a NavigationLayout with defaulted compon
           },
         ]
       }
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
       stackNavigationIsEnabled={true}
     />
   }
@@ -54,7 +54,7 @@ exports[`NavigationLayout should render a NavigationLayout with defaulted compon
         },
       ]
     }
-    navigationLayoutSize="tiny"
+    navigationLayoutSize="medium"
     redirectPath="/"
   />
 </Layout>
@@ -65,19 +65,19 @@ exports[`NavigationLayout should render a NavigationLayout with provided compone
   header={
     <Header
       navigationLayoutRoutes={Array []}
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
   menu={
     <Menu
       navigationLayoutRoutes={Array []}
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
 >
   <Content
     navigationLayoutRoutes={Array []}
-    navigationLayoutSize="tiny"
+    navigationLayoutSize="medium"
   />
 </Layout>
 `;
@@ -99,7 +99,7 @@ exports[`NavigationLayout should render a NavigationLayout with provided compone
           },
         ]
       }
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
   menu={
@@ -117,7 +117,7 @@ exports[`NavigationLayout should render a NavigationLayout with provided compone
           },
         ]
       }
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
 >
@@ -135,7 +135,7 @@ exports[`NavigationLayout should render a NavigationLayout with provided compone
         },
       ]
     }
-    navigationLayoutSize="tiny"
+    navigationLayoutSize="medium"
   />
 </Layout>
 `;
@@ -145,7 +145,7 @@ exports[`NavigationLayout should render a NavigationLayout with provided menu te
   header={
     <NavigationLayoutContent
       navigationLayoutRoutes={Array []}
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
   menu={null}
@@ -153,7 +153,7 @@ exports[`NavigationLayout should render a NavigationLayout with provided menu te
 >
   <NavigationLayoutContent
     navigationLayoutRoutes={Array []}
-    navigationLayoutSize="tiny"
+    navigationLayoutSize="medium"
   />
 </Layout>
 `;
@@ -175,7 +175,7 @@ exports[`NavigationLayout should render a NavigationLayout without menu if locat
           },
         ]
       }
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
   menu={null}
@@ -194,7 +194,7 @@ exports[`NavigationLayout should render a NavigationLayout without menu if locat
         },
       ]
     }
-    navigationLayoutSize="tiny"
+    navigationLayoutSize="medium"
     redirectPath="/"
   />
 </Layout>
@@ -205,14 +205,14 @@ exports[`NavigationLayout should render a default NavigationLayout 1`] = `
   header={
     <NavigationLayoutContent
       navigationLayoutRoutes={Array []}
-      navigationLayoutSize="tiny"
+      navigationLayoutSize="medium"
     />
   }
   menu={null}
 >
   <NavigationLayoutContent
     navigationLayoutRoutes={Array []}
-    navigationLayoutSize="tiny"
+    navigationLayoutSize="medium"
   />
 </Layout>
 `;


### PR DESCRIPTION
### Summary
Removes dependency on terra-responsive element. This update will make it easier for us to roll out the required non-passive change to terra-responsive-element.