### PR TITLE
Update badges to point to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
       deploy:
         provider: pages
         skip_cleanup: true
-        github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+        github_token: $GITHUB_TOKEN # Set in travis-ci.com dashboard
         local_dir: build
         on:
           branch: master

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -25,7 +25,7 @@
 | identity-obj-proxy | ^3.0.0 | -- | an identity object using ES6 proxies |
 | jest | ^23.1.0 | -- | Delightful JavaScript Testing. |
 | lerna | ^2.8.0 | -- | Tool for managing JavaScript projects with multiple packages |
-| link-parent-bin | ^1.0.0 | -- | [![Build Status](https://travis-ci.org/nicojs/node-link-parent-bin.svg?branch=master)](https://travis-ci.org/nicojs/node-link-parent-bin) |
+| link-parent-bin | ^1.0.0 | -- | [![Build Status](https://travis-ci.com/nicojs/node-link-parent-bin.svg?branch=master)](https://travis-ci.com/nicojs/node-link-parent-bin) |
 | markdown-magic | ^0.1.25 | -- | Automatically update markdown files with content from external sources |
 | raf | ^3.4.0 | -- | requestAnimationFrame polyfill for node and the browser |
 | react | ^16.8.5 | -- | React is a JavaScript library for building user interfaces. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Cerner OSS](https://badgen.net/badge/Cerner/OSS/blue)](http://engineering.cerner.com/2014/01/cerner-and-open-source/)
 [![License](https://badgen.net/github/license/cerner/terra-framework)](https://github.com/cerner/terra-framework/blob/master/LICENSE)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 [![devDependencies status](https://badgen.net/david/dev/cerner/terra-framework)](https://david-dm.org/cerner/terra-framework?type=dev)
 [![lerna](https://badgen.net/badge/maintained%20with/lerna/cc00ff)](https://lernajs.io/)
 

--- a/packages/terra-abstract-modal/README.md
+++ b/packages/terra-abstract-modal/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-abstract-modal)](https://www.npmjs.org/package/terra-abstract-modal)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The abstract modal is a structural component that provides the ability to display portal'd content in a layer above the app. It consists of an overlay and an unstyled fixed position div in which content can be placed. The abstract modal is not intended to be consumed directly, but rather wrapped in a higher order component. Higher order components can provide the abstract modal with sizing, visual styles, and content (e.g; header, body, and actionable buttons). The abstract modals maximum size is constrained by the viewport size, so the content placed inside the modal needs to be responsive.
 

--- a/packages/terra-aggregator/README.md
+++ b/packages/terra-aggregator/README.md
@@ -3,7 +3,7 @@
 The Aggregator provides focus-based mechanisms for managing actions across disparate components.
 
 [![NPM version](https://badgen.net/npm/v/terra-aggregator)](https://www.npmjs.org/package/terra-aggregator)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 - [Getting Started](#getting-started)
 - [Documentation](https://github.com/cerner/terra-framework/tree/master/packages/terra-aggregator/docs)

--- a/packages/terra-application-header-layout/README.md
+++ b/packages/terra-application-header-layout/README.md
@@ -1,7 +1,7 @@
 # Terra Application Header Layout
 
 [![NPM version](https://badgen.net/npm/v/terra-application-header-layout)](https://www.npmjs.org/package/terra-application-header-layout)
-[![Build Status](https://badgen.net/travis/cerner/terra)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra)](https://travis-ci.com/cerner/terra-framework)
 
 This component renders an application header layout. To be used with a terra-layout or terra-navigation-layout.
 

--- a/packages/terra-application-layout/README.md
+++ b/packages/terra-application-layout/README.md
@@ -3,7 +3,7 @@
 The Terra Application Layout is a responsive, themeable layout for building applications.
 
 [![NPM version](https://badgen.net/npm/v/terra-application-layout)](https://www.npmjs.org/package/terra-application-layout)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 - [Getting Started](#getting-started)
 - [Documentation](https://github.com/cerner/terra-framework/tree/master/packages/terra-application/docs)

--- a/packages/terra-application-links/README.md
+++ b/packages/terra-application-links/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-applicaiton-links)](https://www.npmjs.org/package/terra-application-links)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 This packages contains a list and tab form of ApplicationLinks, to be used in horizontal and vertical display styles. Selection is managed by react-router.
 

--- a/packages/terra-application-menu-layout/README.md
+++ b/packages/terra-application-menu-layout/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-application-menu-layout)](https://www.npmjs.org/package/terra-application-menu-layout)
-[![Build Status](https://badgen.net/travis/cerner/terra)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra)](https://travis-ci.com/cerner/terra-framework)
 
 This component renders an application menu layout. To be used with a terra-layout or terra-navigation-layout.
 

--- a/packages/terra-application-name/README.md
+++ b/packages/terra-application-name/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-application-name)](https://www.npmjs.org/package/terra-application-name)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 Houses the title of the application, along with a logo. There are two versions - a header version and menu version. These should be used with the corresponding header and menu layouts.
 

--- a/packages/terra-application-utility/README.md
+++ b/packages/terra-application-utility/README.md
@@ -1,7 +1,7 @@
 # Terra Application Utility
 
 [![NPM version](https://badgen.net/npm/v/terra-application-utility)](https://www.npmjs.org/package/terra-application-utility)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The Utility is used to disclose a utility menu. There are two versions - a header version and menu version. These should be used with the corresponding `terra-application-header-layout` and `terra-application-menu-layout` components.
 

--- a/packages/terra-brand-footer/README.md
+++ b/packages/terra-brand-footer/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-brand-footer)](https://www.npmjs.org/package/terra-brand-footer)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 A standard footer for application layout which provides content areas to display options such as branding, copyright information, logo and navigation to related pages.
 

--- a/packages/terra-collapsible-menu-view/README.md
+++ b/packages/terra-collapsible-menu-view/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-collapsible-menu-view)](https://www.npmjs.org/package/terra-collapsible-menu-view)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The collapsible menu view is a mechanism that can be used in toolbar scenarios where actionable items will be displayed face-up and flex based on the space available. Any items that can not fit in the available space will be rolled into an ellipsis menu.
 

--- a/packages/terra-date-picker/README.md
+++ b/packages/terra-date-picker/README.md
@@ -1,7 +1,7 @@
 # Terra Date Picker
 
 [![NPM version](https://badgen.net/npm/v/terra-date-picker)](https://www.npmjs.org/package/terra-date-picker)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 Terra-date-picker is a controlled input component that provides users a way to enter or select a date from the date picker. terra-date-picker is essentially a wrapper for [react-datepicker][1] and leverages many of its props. One important difference between terra-date-picker and [react-datepicker][1] is that all of the date props in [react-datepicker][1] must be a [moment][2] object whereas the date props in terra-date-picker are ISO 8601 representation of the date.
 

--- a/packages/terra-date-time-picker/README.md
+++ b/packages/terra-date-time-picker/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-date-time-picker)](https://www.npmjs.org/package/terra-date-time-picker)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The DateTimePicker component has a date picker for selecting date and a time input for entering time. DateTimePicker supports the Spring and Fall daylight saving time changes.
 

--- a/packages/terra-dialog-modal/README.md
+++ b/packages/terra-dialog-modal/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-dialog-modal)](https://www.npmjs.org/package/terra-dialog-modal)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The Dialog Modal allows dynamic height modals. It's limited use case, as dynamic heights break with more complicated DOM structures. If content is too complicated, the terra-modal-manager should be used. The components is placed at an 8000 z-index. The dialog supports release and request focus props similar to terra-popup and terra-date-picker, so it can be presented from another modal with focus.
 

--- a/packages/terra-disclosure-manager/README.md
+++ b/packages/terra-disclosure-manager/README.md
@@ -1,7 +1,7 @@
 # Terra Disclosure Manager
 
 [![NPM version](https://badgen.net/npm/v/terra-disclosure-manager)](https://www.npmjs.org/package/terra-disclosure-manager)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The DisclosureManager is a stateful component used to manage disclosure presentation.
 

--- a/packages/terra-embedded-content-consumer/README.md
+++ b/packages/terra-embedded-content-consumer/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-embedded-content-consumer)](https://www.npmjs.org/package/terra-embedded-content-consumer)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The Embedded Content Consumer is the application component which is embedding web content within it.
 

--- a/packages/terra-form-validation/README.md
+++ b/packages/terra-form-validation/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-form-validation)](https://www.npmjs.org/package/terra-form-validation)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 Documentation on how to combine the form validation library [react-final-form](https://github.com/final-form/react-final-form) with UI Components that Terra provides.
 

--- a/packages/terra-hookshot/README.md
+++ b/packages/terra-hookshot/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-hookshot)](https://www.npmjs.org/package/terra-hookshot)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The Terra Hookshot component positions content according to a targeted attachment, ensuring they stay connected.
 

--- a/packages/terra-infinite-list/README.md
+++ b/packages/terra-infinite-list/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-infinite-list)](https://www.npmjs.org/package/terra-infinite-list)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The infinite list component provides virtual dom management and data request callbacks to manage large data sets within a list.
 

--- a/packages/terra-layout/README.md
+++ b/packages/terra-layout/README.md
@@ -3,7 +3,7 @@
 The Layout component provides a responsive starting point for the positioning of application components.
 
 [![NPM version](https://badgen.net/npm/v/terra-layout)](https://www.npmjs.org/package/terra-layout)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 - [Getting Started](#getting-started)
 - [Documentation](https://github.com/cerner/terra-framework/tree/master/packages/terra-layout/docs)

--- a/packages/terra-menu/README.md
+++ b/packages/terra-menu/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-menu)](https://www.npmjs.org/package/terra-menu)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The menu is a popup component that displays a list of items, item groups, and dividers. Menu Items can be actionable, have toggle-style selection, or have nested submenu items. Menu Item groups are a single-select grouping of menu items.
 The Menu will determine the height of the popup based on the number of items in the main menu.

--- a/packages/terra-modal-manager/README.md
+++ b/packages/terra-modal-manager/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-modal-manager)](https://www.npmjs.org/package/terra-modal-manager)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The ModalManager is a DisclosureManager implementation that presents disclosed content using an AbstractModal.
 

--- a/packages/terra-navigation-layout/README.md
+++ b/packages/terra-navigation-layout/README.md
@@ -3,7 +3,7 @@
 The Terra Navigation Layout package includes a variety of components and utilities to provide configuration-based, `react-router`-driven navigation to Terra applications.
 
 [![NPM version](https://badgen.net/npm/v/terra-navigation-layout)](https://www.npmjs.org/package/terra-navigation-layout)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 This component renders secondary navigation items with react router.
 

--- a/packages/terra-navigation-prompt/README.md
+++ b/packages/terra-navigation-prompt/README.md
@@ -1,7 +1,7 @@
 # Terra Navigation Prompt
 
 [![NPM version](https://badgen.net/npm/v/terra-navigation-prompt)](https://www.npmjs.org/package/terra-navigation-prompt)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 - [Getting Started](#getting-started)
 - [Documentation](https://github.com/cerner/terra-framework/tree/master/packages/terra-navigation-prompt/docs)

--- a/packages/terra-navigation-side-menu/README.md
+++ b/packages/terra-navigation-side-menu/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-navigation-side-menu)](https://www.npmjs.org/package/terra-navigation-side-menu)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 A structual component for nesting navigational items within the content section of the terra-menu-layout.
 

--- a/packages/terra-notification-dialog/README.md
+++ b/packages/terra-notification-dialog/README.md
@@ -1,7 +1,7 @@
 # Terra NotificationDialog
 
 [![NPM version](https://badgen.net/npm/v/terra-notification-dialog)](https://www.npmjs.org/package/terra-notification-dialog)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 `terra-notification-dialog` is a notification dialog component built over the `terra-abstract-modal`. It has the highest z-index of 9001. It is a common component to be used for confirmation/acceptance criteria style dialogs.
 

--- a/packages/terra-popup/README.md
+++ b/packages/terra-popup/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-popup)](https://www.npmjs.org/package/terra-popup)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The Terra Popup is higher order component that launches terra-hookshot positioned content with the ability to display a dynamic arrow.
 

--- a/packages/terra-slide-group/README.md
+++ b/packages/terra-slide-group/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-slide-group)](https://www.npmjs.org/package/terra-slide-group)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The SlideGroup is a component that utilizes the `react-transition-group` library to present a stack of components in an
 animated fashion.

--- a/packages/terra-slide-panel-manager/README.md
+++ b/packages/terra-slide-panel-manager/README.md
@@ -1,7 +1,7 @@
 # Terra SlidePanel Manager
 
 [![NPM version](https://badgen.net/npm/v/terra-slide-panel-manager)](https://www.npmjs.org/package/terra-slide-panel-manager)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The SlidePanelManager is a DisclosureManager implementation that presents disclosed content using a SlidePanel.
 

--- a/packages/terra-slide-panel/README.md
+++ b/packages/terra-slide-panel/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-slide-panel)](https://www.npmjs.org/package/terra-slide-panel)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The Terra SlidePanel component is a progressive disclosure mechanism that allows additional content to be shown and hidden in a variety of ways.
 

--- a/packages/terra-tabs/README.md
+++ b/packages/terra-tabs/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-tabs)](https://www.npmjs.org/package/terra-tabs)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 Tabs are containers used to organize content. They allow for quick switching between groups of contextually related content. Content is divided into different containers and each container is viewable one at a time. The user can switch between containers by selecting the corresponding tab control.
 

--- a/packages/terra-theme-provider/README.md
+++ b/packages/terra-theme-provider/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-theme-provider)](https://www.npmjs.org/package/terra-theme-provider)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The theme provider component provides a theme to Terra UI components rendered within it via CSS custom properties a.k.a CSS variables. This is accomplished by setting a CSS class which contains defined CSS custom properties for the specified theme on the DOM element that wraps the children rendered by the theme provider.
 

--- a/packages/terra-time-input/README.md
+++ b/packages/terra-time-input/README.md
@@ -1,7 +1,7 @@
 # Terra Time Input
 
 [![NPM version](https://badgen.net/npm/v/terra-time-input)](https://www.npmjs.org/package/terra-time-input)
-[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.org/cerner/terra-framework)
+[![Build Status](https://badgen.net/travis/cerner/terra-framework)](https://travis-ci.com/cerner/terra-framework)
 
 The terra-time-input component is a controlled input component for entering time. It is a controlled component because it manages the state of the value in the input. Because this is a controlled input component, it cannot accept the defaultValue prop as it always uses the value prop. React does not allow having both the defaultValue and value props.
 


### PR DESCRIPTION
### Summary
Updates travis build status badges to point to `travis-ci.com` instead of `travis-ci.org`

Closes #681 