### PR TITLE
[terra-form-validation] Fixing onSubmit example

### DIFF
--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+Unreleased
+----------
+### Fixed
+* onSubmit example was not submitting.
+
 1.0.0 - (May 21, 2019)
 ------------------
 ### Added

--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Fixed
-* onSubmit example was not submitting.
+* onSubmit example is now submitting.
 
 1.0.0 - (May 21, 2019)
 ------------------

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationOnSubmit.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationOnSubmit.jsx
@@ -126,7 +126,7 @@ export default class MainEntry extends React.Component {
               <Select
                 id="airliner"
                 name={input.name}
-                onChange={(e, value) => { input.onChange(value); }}
+                onChange={(value) => { input.onChange(value); }}
                 defaultValue={input.value}
                 placeholder="Select an Airline"
               >


### PR DESCRIPTION
### Summary
Fixes https://github.com/cerner/terra-framework/issues/696.
The onSubmit example was using terra-select's 3.0.0 onChange function prop instead of 4.0.0.
onChange(event, value, name) -> onChange(value)

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
