### PR TITLE
Fix danger message formatting

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -27,5 +27,5 @@ const missingChangelogs = [...changedPackages].filter(packageName => !changedCha
 
 // Fail if there are package changes without a CHANGELOG update
 if (missingChangelogs.length > 0) {
-  fail(`Please include a CHANGELOG entry for each changed package this PR. Looks like a CHANGELOG is missing for: \n - ${missingChangelogs.join('\n - ')}`);
+  fail(`Please include a CHANGELOG entry for each changed package this PR. Looks like a CHANGELOG is missing for: \n\n - ${missingChangelogs.join('\n - ')}`);
 }

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -756,7 +756,6 @@ class TimeInput extends React.Component {
           pattern="\d*"
           disabled={disabled}
         />
-        <p>:P</p>
         {this.props.variant === TimeUtil.FORMAT_12_HOUR && (
           [
             <Input

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -135,7 +135,7 @@ class TimeInput extends React.Component {
         this.anteMeridiem = context.intl.formatMessage({ id: 'Terra.timeInput.am' });
         this.postMeridiem = context.intl.formatMessage({ id: 'Terra.timeInput.pm' });
       }
-
+:P
       if (hour) {
         const parsedHour = TimeUtil.parseTwelveHourTime(hour, this.anteMeridiem, this.postMeridiem);
         hour = parsedHour.hourString;

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -135,6 +135,7 @@ class TimeInput extends React.Component {
         this.anteMeridiem = context.intl.formatMessage({ id: 'Terra.timeInput.am' });
         this.postMeridiem = context.intl.formatMessage({ id: 'Terra.timeInput.pm' });
       }
+
       if (hour) {
         const parsedHour = TimeUtil.parseTwelveHourTime(hour, this.anteMeridiem, this.postMeridiem);
         hour = parsedHour.hourString;

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -755,7 +755,6 @@ class TimeInput extends React.Component {
           pattern="\d*"
           disabled={disabled}
         />
-        <p>:P</p>
         {this.props.variant === TimeUtil.FORMAT_12_HOUR && (
           [
             <Input

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -756,6 +756,7 @@ class TimeInput extends React.Component {
           pattern="\d*"
           disabled={disabled}
         />
+        <p>:P</p>
         {this.props.variant === TimeUtil.FORMAT_12_HOUR && (
           [
             <Input

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -135,7 +135,6 @@ class TimeInput extends React.Component {
         this.anteMeridiem = context.intl.formatMessage({ id: 'Terra.timeInput.am' });
         this.postMeridiem = context.intl.formatMessage({ id: 'Terra.timeInput.pm' });
       }
-:P
       if (hour) {
         const parsedHour = TimeUtil.parseTwelveHourTime(hour, this.anteMeridiem, this.postMeridiem);
         hour = parsedHour.hourString;
@@ -756,6 +755,7 @@ class TimeInput extends React.Component {
           pattern="\d*"
           disabled={disabled}
         />
+        <p>:P</p>
         {this.props.variant === TimeUtil.FORMAT_12_HOUR && (
           [
             <Input


### PR DESCRIPTION
### Summary
The previous commit overhauling the danger file also updated danger's version. In some version danger stopped including two new lines before `warn` and `fail` messages. Removing those new lines causes the markdown to not be parsed correctly. Adding an empty line before the list starts causes the list to be displayed properly.

The change in effect: <img width="792" alt="Screen Shot 2019-06-04 at 1 33 54 PM" src="https://user-images.githubusercontent.com/11130785/58904586-71f7e580-86cd-11e9-9d98-31e8fcbf58c9.png">