### PR TITLE
Update DangerJS to latest major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "browserslist-config-terra": "^1.0.0",
     "check-installed-dependencies": "^1.0.0",
     "core-js": "^3.1.3",
-    "danger": "^7.0.0",
+    "danger": "^8.0.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
### Summary
DangerJS v8.0.0 was just released, updating to latest major version

