### PR TITLE
Remove conditional logic around importing wicg-inert

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Renamed test and example SCSS files to end with `.module.scss` extension
+* Removed conditional logic required to import wicg-inert polyfill
 
 3.3.0 - (June 19, 2019)
 ------------------

--- a/packages/terra-abstract-modal/package.json
+++ b/packages/terra-abstract-modal/package.json
@@ -31,7 +31,7 @@
     "mutationobserver-shim": "0.3.3",
     "prop-types": "^15.5.8",
     "react-portal": "^4.1.2",
-    "wicg-inert": "^2.1.0"
+    "wicg-inert": "^2.1.1"
   },
   "devDependencies": {
     "terra-doc-template": "^2.2.0",

--- a/packages/terra-abstract-modal/src/AbstractModal.jsx
+++ b/packages/terra-abstract-modal/src/AbstractModal.jsx
@@ -4,17 +4,8 @@ import { Portal } from 'react-portal';
 import KeyCode from 'keycode-js';
 import 'mutationobserver-shim';
 import './_matches-polyfill';
+import 'wicg-inert';
 import ModalContent from './_ModalContent';
-
-// Importing WICG Inert polyfill causes Jest to crash
-// Issue logged to Jest repo: https://github.com/facebook/jest/issues/8373
-// This logic avoids importing the polyfill when running Jest tests
-// It also checks to make sure not to load the inert polyfill if it has already been defined
-// eslint-disable-next-line no-prototype-builtins
-if (process.env.NODE_ENV !== 'test' && !Element.prototype.hasOwnProperty('inert')) {
-  // eslint-disable-next-line global-require
-  require('wicg-inert');
-}
 
 const zIndexes = ['6000', '7000', '8000', '9000'];
 


### PR DESCRIPTION
### Summary
[The wicg-inert polyfill updated to use the same logic we were using to ensure that inert is not defined on the Element prototype before it tries to define that](https://github.com/WICG/inert/pull/123). With this change, we no longer need to conditionally load it and go back to a regular import statement. This also resolved the issue we had with this import when running it through Jest.