### PR TITLE
Address new axe-core rules

### DIFF
--- a/packages/terra-aggregator/src/terra-dev-site/doc/common/placeholder-list/PlaceholderList.jsx
+++ b/packages/terra-aggregator/src/terra-dev-site/doc/common/placeholder-list/PlaceholderList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './PlaceholderList.module.scss';
 /* eslint-disable */
 const List = ({ children, isPadded }) => (
-  <ul role="listbox" className={isPadded ? 'placeholder-list is-padded' : 'placeholder-list '}>
+  <ul aria-label="Placeholder list" role="listbox" className={isPadded ? 'placeholder-list is-padded' : 'placeholder-list '}>
     {children}
   </ul>
 );

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -80,7 +80,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
     } if (isCollapsibleMenuItem) {
       return (
         <li role="none">
-          <List {...customProps} role="listbox">
+          <List {...customProps} role="listbox" aria-label="Item Group">
             {children}
           </List>
         </li>

--- a/packages/terra-date-picker/src/react-datepicker/month.jsx
+++ b/packages/terra-date-picker/src/react-datepicker/month.jsx
@@ -124,7 +124,7 @@ export default class Month extends React.Component {
 
   render () {
     return (
-      <div tabIndex="0" className={this.getClassNames()} onMouseLeave={this.handleMouseLeave} role="listbox">
+      <div tabIndex="0" aria-label="Month" className={this.getClassNames()} onMouseLeave={this.handleMouseLeave} role="listbox">
         {this.renderWeeks()}
       </div>
     )

--- a/packages/terra-dialog-modal/src/DialogModal.jsx
+++ b/packages/terra-dialog-modal/src/DialogModal.jsx
@@ -83,7 +83,9 @@ const DialogModal = (props) => {
       <div {...customProps} className={cx('dialog-modal-inner-wrapper', customProps.className)}>
         <div className={cx('dialog-modal-container')}>
           <div>{header}</div>
-          <div className={cx('dialog-modal-body')}>{children}</div>
+          {// Usage of tabIndex="0" to allow users to focus on potentially scrollable content
+           /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+          <div className={cx('dialog-modal-body')} tabIndex="0">{children}</div>
           <div>{footer}</div>
         </div>
       </div>

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -289,13 +289,19 @@ Terra.describeViewports('ModalManager - Behaviors', ['large'], () => {
 
   describe('Component Integration', () => {
     before(() => browser.url('/#/raw/tests/terra-modal-manager/modal-manager/modal-manager-integration'));
+    // Disable rule until the following issue is resolved in terra-core:
+    // https://github.com/cerner/terra-core/issues/2505
+    const ignoredA11y = {
+      'aria-input-field-name': { enabled: false },
+    };
+
     describe('Select Field in Modal Manager', () => {
       it('Select Field in Modal Manager', () => {
         browser.click('#root-component .disclose-small');
 
         browser.waitForVisible('[class*="slide-group"] #DemoContainer-1 .maximize', 1000);
         browser.click('[role="dialog"] [data-terra-select]');
-        Terra.validates.element({ selector });
+        Terra.validates.element({ selector, axeRules: { rules: ignoredA11y }});
         browser.keys(['Escape', 'Escape']);
       });
     });

--- a/packages/terra-popup/src/_PopupOverlay.jsx
+++ b/packages/terra-popup/src/_PopupOverlay.jsx
@@ -55,15 +55,20 @@ class PopupOverlay extends React.Component {
 
     return (
       <React.Fragment>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+        {
+          // Usage of tabIndex="0" to allow users to focus on potentially scrollable content
+          /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex */
+        }
         <div
           onClick={this.handleOnClick}
           {...customProps}
           className={cx(['popup-overlay', customProps.className])}
+          tabIndex="0"
         >
           <div className={cx('inner')} />
           {children}
         </div>
+        {/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
       </React.Fragment>
     );
   }

--- a/packages/terra-slide-panel/src/SlidePanel.jsx
+++ b/packages/terra-slide-panel/src/SlidePanel.jsx
@@ -96,18 +96,20 @@ class SlidePanel extends React.Component {
       { fill },
       customProps.className,
     ]);
-
+    // Usage of tabIndex="0" to allow users to focus on potentially scrollable content
+    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     const panelDiv = (
-      <div className={cx(['panel'])} tabIndex="-1" aria-hidden={!isOpen ? 'true' : 'false'} ref={this.setPanelNode}>
+      <div className={cx(['panel'])} tabIndex="0" aria-hidden={!isOpen ? 'true' : 'false'} ref={this.setPanelNode}>
         {panelContent}
       </div>
     );
 
     const mainDiv = (
-      <div className={cx('main')} tabIndex="-1" ref={this.mainNode}>
+      <div className={cx('main')} tabIndex="0" ref={this.mainNode}>
         {mainContent}
       </div>
     );
+    /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
 
     const content = (panelPosition === SlidePanelPositions.START) ? (
       <React.Fragment>


### PR DESCRIPTION
### Summary
There are some new axe-core rules that are impacting terra components.
The main rules that are impact the components are around the following:

* ARIA input fields have an accessible name
* Ensure scrollable region is focusable

This PR is a WIP to address these new rules/updates to rules.
To do:
- [ ] Get translations
- [ ] Add styles for `tabIndex="0"`
  - We likely want keyboard only styles to apply focus indication when focused on a scrollable region.
  - More info: https://developer.paciellogroup.com/blog/2016/02/short-note-on-improving-usability-of-scrollable-regions/
- [ ] Get tests back to stable / passing state