### PR TITLE
Add node contains polyfill for IE10 / IE11 for abstract modal

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added Node.contains polyfill to better support IE 10 / IE 11
 
 3.6.0 - (July 16, 2019)
 ------------------

--- a/packages/terra-abstract-modal/src/AbstractModal.jsx
+++ b/packages/terra-abstract-modal/src/AbstractModal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Portal } from 'react-portal';
 import KeyCode from 'keycode-js';
 import 'mutationobserver-shim';
+import './_contains-polyfill';
 import './_matches-polyfill';
 import 'wicg-inert';
 import ModalContent from './_ModalContent';

--- a/packages/terra-abstract-modal/src/_contains-polyfill.js
+++ b/packages/terra-abstract-modal/src/_contains-polyfill.js
@@ -1,0 +1,19 @@
+// Source: https://github.com/Financial-Times/polyfill-service/pull/183/files
+// Needed for IE11 and IE10
+if (!Node.prototype.contains) {
+  Node.prototype.contains = function contains(node) {
+    /* eslint-disable-next-line prefer-rest-params */
+    if (!(0 in arguments)) {
+      throw new TypeError('1 argument is required');
+    }
+    /* eslint-disable no-cond-assign */
+    do {
+      if (this === node) {
+        return true;
+      }
+      /* eslint-disable-next-line no-param-reassign */
+    } while (node = node && node.parentNode);
+    return false;
+    /* eslint-enable no-cond-assign */
+  };
+}


### PR DESCRIPTION
### Summary
Similar change to https://github.com/cerner/terra-core/commit/6fd60818bb20dfa00010c37752b59f46a6e0d2c5
Needed to support inert polyfill in IE10 / IE11