### PR TITLE
[terra-application-navigation] Fixed themable variable naming.

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Corrected themeable variable name that slipped through lint filter.
 
 1.0.0 - (July 23, 2019)
 ------------------

--- a/packages/terra-application-navigation/src/tabs/Tab.module.scss
+++ b/packages/terra-application-navigation/src/tabs/Tab.module.scss
@@ -99,7 +99,7 @@
     &[aria-current='false']:active {
       .tab-inner {
         background-color: var(--terra-application-navigation-tab-active-background-color, rgba(3, 43, 70, 0.4));
-        color: var(--terra-application-navigation-tab-active-background-color, rgba(255, 255, 255, 0.5));
+        color: var(--terra-application-navigation-tab-active-color, rgba(255, 255, 255, 0.5));
       }
     }
 


### PR DESCRIPTION
### Summary
Corrected mislabeled themable variable that got past the lint rule.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
