### PR TITLE
Update form validation main key

### DIFF
--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Update main key in package.json to point to `lib/FormValidationUtil.js`
 
 1.4.1 - (July 23, 2019)
 ------------------

--- a/packages/terra-form-validation/package.json
+++ b/packages/terra-form-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-form-validation",
-  "main": "docs/README.md",
+  "main": "lib/FormValidationUtil.js",
   "version": "1.4.1",
   "description": "Form Validation Examples for Terra",
   "repository": {


### PR DESCRIPTION
### Summary
The main key in the package.json file for the terra-form-validations package currently points to the README.md file. This updates the main key to point to the actual JS module the package contains in the lib directory.

Consumers noted running into errors when trying to use the Utils module via `import FormValidationUtil from 'terra-form-validation';`