### PR TITLE
Explicitly pull in Error icon from terra-icon instead of pulling from terra-form-field

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Explicitly pull in Error icon from terra-icon instead of pulling from terra-form-field
 
 4.8.1 - (July 23, 2019)
 ------------------

--- a/packages/terra-date-picker/src/DatePickerField.jsx
+++ b/packages/terra-date-picker/src/DatePickerField.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Field from 'terra-form-field';
+import IconError from 'terra-icon/lib/icon/IconError';
 import DatePicker from './DatePicker';
 
 const propTypes = {
@@ -131,7 +132,7 @@ const propTypes = {
 const defaultProps = {
   disabled: false,
   error: null,
-  errorIcon: Field.defaultProps.errorIcon,
+  errorIcon: <IconError />,
   excludeDates: undefined,
   filterDate: undefined,
   help: null,


### PR DESCRIPTION
### Summary
Update how we access the Error icon in terra-datepicker field.