### PR TITLE
ESLint 6 Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "eslintConfig": {
     "extends": "terra",
     "rules": {
-      "react/forbid-prop-types": "false",
+      "react/forbid-prop-types": "off",
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -39,7 +39,8 @@
     },
     "settings": {
       "polyfills": [
-        "promises"
+        "Promise",
+        "Map"
       ]
     }
   },
@@ -101,8 +102,8 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",
-    "eslint": "^5.0.0",
-    "eslint-config-terra": "^2.0.0",
+    "eslint": "^6.1.0",
+    "eslint-config-terra": "cerner/eslint-config-terra#update-dependencies",
     "gh-pages": "^2.0.1",
     "glob": "^7.1.1",
     "identity-obj-proxy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",
     "eslint": "^6.1.0",
-    "eslint-config-terra": "cerner/eslint-config-terra#update-dependencies",
+    "eslint-config-terra": "^3.0.0",
     "gh-pages": "^2.0.1",
     "glob": "^7.1.1",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/terra-aggregator/CHANGELOG.md
+++ b/packages/terra-aggregator/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated bracket formatting in test files to match eslint 6 rules.
 
 4.23.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-aggregator/src/terra-dev-site/doc/common/SimpleAggregatorItem.jsx
+++ b/packages/terra-aggregator/src/terra-dev-site/doc/common/SimpleAggregatorItem.jsx
@@ -37,8 +37,7 @@ const SimpleAggregatorItem = ({ name, aggregatorDelegate, ...customProps }) => (
         >
         Get Focus
         </button>
-      )
-    }
+      )}
     {aggregatorDelegate.hasFocus ? <h4>Section has focus!</h4> : null}
   </ContentContainer>
 );

--- a/packages/terra-application-layout/CHANGELOG.md
+++ b/packages/terra-application-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 5.10.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-application-layout/src/ApplicationLayout.jsx
+++ b/packages/terra-application-layout/src/ApplicationLayout.jsx
@@ -121,9 +121,9 @@ class ApplicationLayout extends React.Component {
 
     const config = {};
     Object.keys(originalMenuConfig).forEach((menuKey) => {
-      const menuConfig = Object.assign({}, originalMenuConfig[menuKey]);
+      const menuConfig = { ...originalMenuConfig[menuKey] };
 
-      const menuComponentConfig = Object.assign({}, menuConfig.component);
+      const menuComponentConfig = { ...menuConfig.component };
 
       /**
        * Every supplied menu component is wrapped with an ApplicationMenuWrapper.
@@ -133,8 +133,8 @@ class ApplicationLayout extends React.Component {
           return;
         }
 
-        const componentConfig = Object.assign({}, menuComponentConfig[size]);
-        const componentProps = Object.assign({}, componentConfig.props);
+        const componentConfig = { ...menuComponentConfig[size] };
+        const componentProps = { ...componentConfig.props };
 
         /**
          * ApplicationMenuWrapper-specific props are injected into the props object with a prop
@@ -166,9 +166,7 @@ class ApplicationLayout extends React.Component {
   static buildRoutingConfig(props) {
     const { routingConfig } = props;
 
-    const updatedConfig = Object.assign({}, routingConfig, {
-      menu: ApplicationLayout.buildApplicationMenus(props, Object.assign({}, routingConfig.menu, ApplicationLayout.buildNavigationMenuConfig(props))),
-    });
+    const updatedConfig = { ...routingConfig, menu: ApplicationLayout.buildApplicationMenus(props, { ...routingConfig.menu, ...ApplicationLayout.buildNavigationMenuConfig(props) }) };
 
     return updatedConfig;
   }

--- a/packages/terra-application-links/CHANGELOG.md
+++ b/packages/terra-application-links/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Removed unnecessary eslint disable comments
 
 6.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-application-links/src/tabs/_TabMenuDisplay.jsx
+++ b/packages/terra-application-links/src/tabs/_TabMenuDisplay.jsx
@@ -116,7 +116,6 @@ class TabMenuDisplay extends React.Component {
     ]);
 
     return (
-      /* eslint-disable jsx-a11y/no-static-element-interactions */
       <div
         {...customProps}
         {...attributes}
@@ -137,7 +136,6 @@ class TabMenuDisplay extends React.Component {
         </div>
         {popup}
       </div>
-      /* eslint-enable jsx-ally/no-static-element-interactions */
     );
   }
 }

--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 1.5.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 6.9.0 - (August 14, 2019)
 ------------------
@@ -35,7 +37,7 @@ Unreleased
 * Fixed Collapsible issue for single item group
 
 6.5.0 - (July 10, 2019)
------------------- 
+------------------
 ### Changed
 * Minor dependency version bump
 * Replaced Terra-Form with Terra-Form-Checkbox in CollapsibleMenuViewToggle

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
@@ -109,7 +109,7 @@ class CollapsibleMenuViewItem extends React.Component {
     } = this.props;
 
     const { isCollapsibleGroupItem, isCollapsibleMenuItem } = this.context;
-    const attributes = Object.assign({}, customProps);
+    const attributes = { ...customProps };
     let item;
 
     if (isCollapsibleMenuItem) {

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 4.10.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -101,7 +101,7 @@ class DatePickerInput extends React.Component {
   }
 
   handleOnButtonClick(event) {
-    const attributes = Object.assign({}, this.props.inputAttributes);
+    const attributes = { ...this.props.inputAttributes };
 
     if (!attributes.readOnly && this.onCalendarButtonClick && this.props.onClick) {
       this.onCalendarButtonClick(event, this.props.onClick);
@@ -147,7 +147,7 @@ class DatePickerInput extends React.Component {
     delete customProps.onCalendarButtonClick;
     delete customProps.shouldShowPicker;
 
-    const additionalInputProps = Object.assign({}, customProps, inputAttributes);
+    const additionalInputProps = { ...customProps, ...inputAttributes };
 
     const dateValue = DateUtil.convertToISO8601(value, DateUtil.getFormatByLocale(intl.locale));
     const buttonText = intl.formatMessage({ id: 'Terra.datePicker.openCalendar' });

--- a/packages/terra-date-picker/src/DatePickerField.jsx
+++ b/packages/terra-date-picker/src/DatePickerField.jsx
@@ -206,7 +206,7 @@ const DatePickerField = (props) => {
 
   let mergedInputAttrs = inputAttributes;
   if (ariaDescriptionIds) {
-    mergedInputAttrs = Object.assign({ 'aria-describedby': ariaDescriptionIds }, inputAttributes);
+    mergedInputAttrs = { 'aria-describedby': ariaDescriptionIds, ...inputAttributes };
   }
 
   return (

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 4.10.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
+++ b/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
@@ -111,7 +111,7 @@ Terra.describeViewports('DateTimePicker', ['tiny', 'large'], () => {
       browser.moveToObject('#root', 0, 0);
     });
 
-    const ignoredDisabledAlly = Object.assign({ 'color-contrast': { enabled: false } }, ignoredA11y);
+    const ignoredDisabledAlly = { 'color-contrast': { enabled: false }, ...ignoredA11y };
     Terra.it.isAccessible({ rules: ignoredDisabledAlly });
     Terra.it.matchesScreenshot();
   });

--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 4.18.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-disclosure-manager/src/DisclosureManager.jsx
+++ b/packages/terra-disclosure-manager/src/DisclosureManager.jsx
@@ -16,7 +16,7 @@ const availableDisclosureSizes = {
   FULLSCREEN: 'fullscreen',
 };
 
-const arrayReducer = (mappingObject, value) => Object.assign({ [`${value}`]: value }, mappingObject);
+const arrayReducer = (mappingObject, value) => ({ [`${value}`]: value, ...mappingObject });
 const availableDisclosureHeights = [240, 420, 600, 690, 780, 870, 960, 1140].reduce(arrayReducer, {});
 const availableDisclosureWidths = [320, 480, 560, 640, 800, 960, 1120, 1280, 1440, 1600, 1760, 1920].reduce(arrayReducer, {});
 
@@ -65,9 +65,9 @@ class DisclosureManager extends React.Component {
    * Clones the current disclosure component state objects and returns the structure for further mutation.
    */
   static cloneDisclosureState(state) {
-    const newState = Object.assign({}, state);
+    const newState = { ...state };
     newState.disclosureComponentKeys = Object.assign([], newState.disclosureComponentKeys);
-    newState.disclosureComponentData = Object.assign({}, newState.disclosureComponentData);
+    newState.disclosureComponentData = { ...newState.disclosureComponentData };
     newState.disclosureComponentDelegates = Object.assign([], newState.disclosureComponentDelegates);
 
     return newState;
@@ -121,9 +121,7 @@ class DisclosureManager extends React.Component {
           disclosureComponentData: {
             ...state.disclosureComponentData,
             ...{
-              [key]: Object.assign({}, state.disclosureComponentData[key], {
-                headerAdapterData: { title, collapsibleMenuView },
-              }),
+              [key]: { ...state.disclosureComponentData[key], headerAdapterData: { title, collapsibleMenuView } },
             },
           },
         }));

--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Updated bracket formatting in test files to match eslint 6 rules.
 
 1.6.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/DefaultFormValidation.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/DefaultFormValidation.jsx
@@ -88,8 +88,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </form>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitCheckboxField.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitCheckboxField.jsx
@@ -105,8 +105,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitDatePicker.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitDatePicker.jsx
@@ -75,8 +75,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitRadioField.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitRadioField.jsx
@@ -105,8 +105,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/MaxLengthInput.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/MaxLengthInput.jsx
@@ -83,8 +83,7 @@ export default class Example extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/NumericValidation.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/NumericValidation.jsx
@@ -89,8 +89,7 @@ export default class Example extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationAsynchronous.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationAsynchronous.jsx
@@ -79,8 +79,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationDisableSubmit.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationDisableSubmit.jsx
@@ -110,8 +110,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationOnInput.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationOnInput.jsx
@@ -110,8 +110,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationOnSubmit.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationOnSubmit.jsx
@@ -216,8 +216,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationParsing.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/ValidationParsing.jsx
@@ -106,8 +106,7 @@ export default class MainEntry extends React.Component {
             <p>Form Submitted Successfully With</p>
             <pre>{JSON.stringify(this.state.submittedValues, 0, 2)}</pre>
           </div>
-          )
-        }
+          )}
       </Spacer>
     );
   }

--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Cleaned up lint in test files
 
 5.14.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-hookshot/tests/jest/HookshotDefaultExample.jsx
+++ b/packages/terra-hookshot/tests/jest/HookshotDefaultExample.jsx
@@ -35,7 +35,13 @@ class HookshotDefaultExample extends React.Component {
         >
           {hookshotContent}
         </Hookshot>
-        <button type="button" id="hookshot-standard-button" onClick={this.handleButtonClick} />
+        <button
+          type="button"
+          id="hookshot-standard-button"
+          onClick={this.handleButtonClick}
+        >
+          {''}
+        </button>
       </div>
     );
   }

--- a/packages/terra-layout/CHANGELOG.md
+++ b/packages/terra-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 4.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-layout/src/Layout.jsx
+++ b/packages/terra-layout/src/Layout.jsx
@@ -39,13 +39,14 @@ class Layout extends React.Component {
 
     const menuIsPresent = !!props.menu;
 
-    return Object.assign({}, currentState || {}, {
+    return {
+      ...currentState || {},
       isFixedMenu,
       isToggleMenu,
       menuIsPresent,
       menuIsOpen: menuIsPresent && (currentState.menuIsOpen || isFixedMenu),
       menuIsPinned: menuIsPresent && currentState.menuIsPinned,
-    });
+    };
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -168,8 +169,7 @@ class Layout extends React.Component {
               toggleMenu: shouldAllowMenuToggle ? this.toggleMenu : undefined,
               menuIsOpen,
             },
-          }) : null
-        }
+          }) : null}
       </ContentContainer>
     );
   }

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 6.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-menu/src/MenuItem.jsx
+++ b/packages/terra-menu/src/MenuItem.jsx
@@ -160,7 +160,7 @@ class MenuItem extends React.Component {
 
     const { isGroupItem, isSelectableMenu } = this.context;
 
-    const attributes = Object.assign({}, customProps);
+    const attributes = { ...customProps };
     attributes.tabIndex = isDisabled ? '-1' : '0';
     attributes['aria-disabled'] = isDisabled;
 

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Disabled max-classes-per-file eslint rule in doc example
 
 6.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-modal-manager/src/terra-dev-site/doc/example/ModalManagerExample.jsx
+++ b/packages/terra-modal-manager/src/terra-dev-site/doc/example/ModalManagerExample.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
@@ -295,3 +296,4 @@ ModalManagerExample.propTypes = {
 };
 
 export default ModalManagerExample;
+/* eslint-enable max-classes-per-file */

--- a/packages/terra-navigation-layout/CHANGELOG.md
+++ b/packages/terra-navigation-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 5.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-navigation-layout/src/routingUtils.js
+++ b/packages/terra-navigation-layout/src/routingUtils.js
@@ -84,9 +84,7 @@ const reduceRouteConfig = (routeConfig, size) => {
       ))
         .map(parentRoute => parentRoute.path);
 
-      return Object.assign({}, route, {
-        parentPaths: matchedParentPaths.reverse(),
-      });
+      return { ...route, parentPaths: matchedParentPaths.reverse() };
     });
 };
 

--- a/packages/terra-navigation-layout/src/terra-dev-site/doc/example/Page3Content.jsx
+++ b/packages/terra-navigation-layout/src/terra-dev-site/doc/example/Page3Content.jsx
@@ -18,8 +18,7 @@ const Page3Content = ({ layoutConfig }) => (
           >
             Toggle Menu
           </button>
-        )
-      }
+        )}
     </div>
   </div>
 );

--- a/packages/terra-navigation-side-menu/CHANGELOG.md
+++ b/packages/terra-navigation-side-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Cleaned up ESLint comments
 
 2.16.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-navigation-side-menu/src/_MenuItem.jsx
+++ b/packages/terra-navigation-side-menu/src/_MenuItem.jsx
@@ -117,7 +117,6 @@ class MenuItem extends React.Component {
       customProps.className,
     ]);
 
-    /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex */
     return (
       <li
         className={cx('list-item')}
@@ -139,7 +138,6 @@ class MenuItem extends React.Component {
         </div>
       </li>
     );
-    /* eslint-enable jsx-ally/no-static-element-interactions */
   }
 }
 

--- a/packages/terra-navigation-side-menu/src/terra-dev-site/doc/example/NavigationSideMenuExample.jsx
+++ b/packages/terra-navigation-side-menu/src/terra-dev-site/doc/example/NavigationSideMenuExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
+/* eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 import NavigationSideMenu from 'terra-navigation-side-menu/lib/NavigationSideMenu';
 
 import styles from './NavigationSideMenuExample.module.scss';

--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated bracket formatting in test files to match eslint 6 rules.
 
 3.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-notification-dialog/src/NotificationDialog.jsx
+++ b/packages/terra-notification-dialog/src/NotificationDialog.jsx
@@ -182,15 +182,12 @@ class NotificationDialog extends React.Component {
               <div id="notification-dialog-header" className={cx('header-body')}>{header || defaultHeader}</div>
               <div className={cx('notification-dialog-body')}>
                 {variant
-                  && <div className={cx('icon-container')}>{getIcon(variant, customIcon)}</div>
-                }
+                  && <div className={cx('icon-container')}>{getIcon(variant, customIcon)}</div>}
                 <div className={cx('text-wrapper')}>
                   {title
-                    && <div id="notification-dialog-title" className={cx('title')}>{title}</div>
-                  }
+                    && <div id="notification-dialog-title" className={cx('title')}>{title}</div>}
                   {message
-                    && <div className={cx('message')}>{message}</div>
-                  }
+                    && <div className={cx('message')}>{message}</div>}
                 </div>
               </div>
               <div className={cx('footer-body')}>{actionSection(primaryAction, secondaryAction)}</div>

--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Cleaned up lint in test files
 
 6.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-popup/src/terra-dev-site/test/popup/ArrowHorizontalAttachmentsPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/ArrowHorizontalAttachmentsPopup.test.jsx
@@ -75,7 +75,9 @@ class AlignmentPopup extends React.Component {
             className={cx('popup-button')}
             onClick={this.handleButtonClick}
             ref={this.setButtonNode}
-          />
+          >
+            {''}
+          </button>
         </div>
         <p>Choose Target Attachment:</p>
         <button type="button" id="attach-Top" value="top right" onClick={this.handleAttachment}>Attach Top Right</button>

--- a/packages/terra-popup/src/terra-dev-site/test/popup/ArrowSmallTargetLeftPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/ArrowSmallTargetLeftPopup.test.jsx
@@ -73,7 +73,9 @@ class OffsetPopup extends React.Component {
           className={cx('popup-button')}
           onClick={this.handleButtonClick}
           ref={this.setButtonNode}
-        />
+        >
+          {''}
+        </button>
       </div>
     );
   }

--- a/packages/terra-popup/src/terra-dev-site/test/popup/ArrowSmallTargetRightPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/ArrowSmallTargetRightPopup.test.jsx
@@ -73,7 +73,9 @@ class OffsetPopup extends React.Component {
           className={cx('popup-button')}
           onClick={this.handleButtonClick}
           ref={this.setButtonNode}
-        />
+        >
+          {''}
+        </button>
       </div>
     );
   }

--- a/packages/terra-popup/src/terra-dev-site/test/popup/ArrowVerticalAttachmentsPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/ArrowVerticalAttachmentsPopup.test.jsx
@@ -74,7 +74,9 @@ class AlignmentPopup extends React.Component {
             className={cx('popup-button')}
             onClick={this.handleButtonClick}
             ref={this.setButtonNode}
-          />
+          >
+            {''}
+          </button>
         </div>
         <p>Choose Content Attachment:</p>
         <button type="button" id="attach-Left" value="bottom left" onClick={this.handleAttachment}>Attach Bottom Left</button>

--- a/packages/terra-popup/src/terra-dev-site/test/popup/ArrowVerticalLeftAdjustmentPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/ArrowVerticalLeftAdjustmentPopup.test.jsx
@@ -73,7 +73,9 @@ class AlignmentPopup extends React.Component {
           className={cx('popup-button')}
           onClick={this.handleButtonClick}
           ref={this.setButtonNode}
-        />
+        >
+          {''}
+        </button>
       </div>
     );
   }

--- a/packages/terra-popup/src/terra-dev-site/test/popup/ArrowVerticalRightAdjustmentPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/ArrowVerticalRightAdjustmentPopup.test.jsx
@@ -73,7 +73,9 @@ class AlignmentPopup extends React.Component {
           className={cx('popup-button')}
           onClick={this.handleButtonClick}
           ref={this.setButtonNode}
-        />
+        >
+          {''}
+        </button>
       </div>
     );
   }

--- a/packages/terra-popup/src/terra-dev-site/test/popup/DifferentAttachmentsPopup.test.jsx
+++ b/packages/terra-popup/src/terra-dev-site/test/popup/DifferentAttachmentsPopup.test.jsx
@@ -81,7 +81,9 @@ class AlignmentPopup extends React.Component {
             className={cx('popup-button')}
             onClick={this.handleButtonClick}
             ref={this.setButtonNode}
-          />
+          >
+            {''}
+          </button>
         </div>
         <p>Choose Content Attachment. It will flip the target attachment.</p>
         <button type="button" id="attach-Left" value="bottom left" onClick={this.handleAttachment}>Attach Bottom Left</button>

--- a/packages/terra-slide-panel-manager/CHANGELOG.md
+++ b/packages/terra-slide-panel-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Disabled max-classes-per-file eslint rule in doc example
 
 5.8.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-slide-panel-manager/src/terra-dev-site/doc/example/SlidePanelManagerExample.jsx
+++ b/packages/terra-slide-panel-manager/src/terra-dev-site/doc/example/SlidePanelManagerExample.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
@@ -299,3 +300,4 @@ SlidePanelManagerExample.propTypes = {
 };
 
 export default SlidePanelManagerExample;
+/* eslint-disable max-classes-per-file */

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Cleaned up ESLint comments
 
 3.12.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-slide-panel/src/terra-dev-site/doc/example/DefaultSlidePanel.jsx
+++ b/packages/terra-slide-panel/src/terra-dev-site/doc/example/DefaultSlidePanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
+/* eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 import SlidePanel from 'terra-slide-panel/lib/SlidePanel';
 import classNames from 'classnames/bind';
 import styles from './DefaultSlidePanel.module.scss';

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 6.9.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-tabs/src/TabPane.jsx
+++ b/packages/terra-tabs/src/TabPane.jsx
@@ -51,7 +51,7 @@ const TabPane = ({
   isIconOnly,
   ...customProps
 }) => {
-  const attributes = Object.assign({}, customProps);
+  const attributes = { ...customProps };
   const paneClassNames = cx([
     'tab',
     { 'is-disabled': isDisabled },

--- a/packages/terra-tabs/src/_CollapsibleTabs.jsx
+++ b/packages/terra-tabs/src/_CollapsibleTabs.jsx
@@ -267,7 +267,6 @@ class CollapsibleTabs extends React.Component {
 
     return (
       <div>
-        {/* eslint-disable jsx-a11y/no-static-element-interactions */}
         <div
           className={cx(['collapsible-tabs-container', { 'is-calculating': this.isCalculating }])}
           ref={this.setContainer}
@@ -275,7 +274,6 @@ class CollapsibleTabs extends React.Component {
           onKeyDown={this.handleOnKeyDown}
           role="tablist"
         >
-          {/* eslint-enable jsx-ally/no-static-element-interactions */}
           {visibleChildren}
           {menu}
         </div>

--- a/packages/terra-tabs/src/_TabMenu.jsx
+++ b/packages/terra-tabs/src/_TabMenu.jsx
@@ -107,7 +107,6 @@ class TabMenu extends React.Component {
     });
 
     return (
-      /* eslint-disable jsx-a11y/no-static-element-interactions */
       <div
         role="button"
         tabIndex="0"
@@ -131,7 +130,6 @@ class TabMenu extends React.Component {
           {menuItems}
         </Menu>
       </div>
-      /* eslint-enable jsx-ally/no-static-element-interactions */
     );
   }
 }

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Replaced Object.assign syntax with Object spread syntax
 
 4.7.0 - (August 14, 2019)
 ------------------

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -719,9 +719,9 @@ class TimeInput extends React.Component {
       ...customProps
     } = this.props;
 
-    const instanceHoursAttrs = Object.assign({}, hourAttributes);
-    const instanceMinuteAttrs = Object.assign({}, minuteAttributes);
-    const instanceSecondAttrs = Object.assign({}, secondAttributes);
+    const instanceHoursAttrs = { ...hourAttributes };
+    const instanceMinuteAttrs = { ...minuteAttributes };
+    const instanceSecondAttrs = { ...secondAttributes };
 
     // Using the state of hour, minute, and second (if shown) create a time in UTC represented in ISO 8601 format.
     let timeValue = '';

--- a/packages/terra-time-input/src/TimeUtil.js
+++ b/packages/terra-time-input/src/TimeUtil.js
@@ -267,7 +267,7 @@ TimeUtil.isConsideredMobileDevice = () => window.matchMedia('(max-width: 1024px)
     'ontouchstart' in window
     // eslint-disable-next-line no-undef
     || (window.DocumentTouch && document instanceof DocumentTouch)
-    || navigator.maxTouchPoints > 0
+    || navigator.maxTouchPoints > 0 // eslint-disable-line compat/compat
     || navigator.msMaxTouchPoints > 0
   );
 

--- a/packages/terra-time-input/src/terra-dev-site/test/time-input/time-input/Second.test.jsx
+++ b/packages/terra-time-input/src/terra-dev-site/test/time-input/time-input/Second.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import classNames from 'classnames/bind';
 import TimeInput from '../../../../TimeInput';
+import styles from './time-input.test.module.scss';
+
+const cx = classNames.bind(styles);
 
 const TimeInputDefault = () => (
-  <div style={{ caretColor: 'transparent' }}>
+  <div className={cx(['content-wrapper'])}>
     <TimeInput
       id="timeInput"
       name="time-input"

--- a/packages/terra-time-input/src/terra-dev-site/test/time-input/time-input/SecondTime.test.jsx
+++ b/packages/terra-time-input/src/terra-dev-site/test/time-input/time-input/SecondTime.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import classNames from 'classnames/bind';
 import TimeInput from '../../../../TimeInput';
+import styles from './time-input.test.module.scss';
+
+const cx = classNames.bind(styles);
 
 const TimeInputDefault = () => (
-  <div style={{ caretColor: 'transparent' }}>
+  <div className={cx(['content-wrapper'])}>
     <TimeInput
       id="timeInput"
       name="time-input"

--- a/packages/terra-time-input/src/terra-dev-site/test/time-input/twelve-hour/Second.test.jsx
+++ b/packages/terra-time-input/src/terra-dev-site/test/time-input/twelve-hour/Second.test.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import classNames from 'classnames/bind';
 import TimeInput from '../../../../TimeInput';
 import TimeUtil from '../../../../TimeUtil';
+import styles from '../time-input/time-input.test.module.scss';
+
+const cx = classNames.bind(styles);
 
 class TimeInputDefault extends React.Component {
   constructor(props) {
@@ -22,7 +26,7 @@ Time Input:
             {this.state.input}
           </h3>
         </div>
-        <div style={{ caretColor: 'transparent' }}>
+        <div className={cx(['content-wrapper'])}>
           <TimeInput
             id="timeInput"
             name="time-input"

--- a/packages/terra-time-input/tests/jest/TimeInput.test.jsx
+++ b/packages/terra-time-input/tests/jest/TimeInput.test.jsx
@@ -1,4 +1,4 @@
-/* globals spyOn jest */
+/* globals spyOn */
 
 import React from 'react';
 /* eslint-disable-next-line import/no-extraneous-dependencies */


### PR DESCRIPTION
### Summary
Testing out [`eslint-config-terra` update](https://github.com/cerner/eslint-config-terra/pull/34)

Changes include:
* Object.assign usage switched to Object spread syntax: https://eslint.org/docs/rules/prefer-object-spread#prefer-use-of-an-object-spread-over-objectassign-prefer-object-spread
* Formatting for curly braces and new lines
```diff
-  )
-}
+)}
```
* Disable compat linter for `maxTouchPoints`. We don't polyfill this but we check for browser specific equivalents in browsers that don't support `maxTouchPoints`, e.g. `msMaxTouchPoints`. We  are also slated to remove the `maxTouchPoints` code when we refactor Checkbox and Radio button.