### PR TITLE
[keycode-js]Updates keycode-js to v2.0.1

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 3.10.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-abstract-modal/package.json
+++ b/packages/terra-abstract-modal/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "mutationobserver-shim": "0.3.3",
     "prop-types": "^15.5.8",
     "react-portal": "^4.1.2",

--- a/packages/terra-abstract-modal/src/AbstractModal.jsx
+++ b/packages/terra-abstract-modal/src/AbstractModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Portal } from 'react-portal';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import 'mutationobserver-shim';
 import './_contains-polyfill';
 import './_matches-polyfill';

--- a/packages/terra-application-links/CHANGELOG.md
+++ b/packages/terra-application-links/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 6.10.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-application-links/package.json
+++ b/packages/terra-application-links/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "resize-observer-polyfill": "^1.4.1",
     "terra-icon": "^3.1.0",

--- a/packages/terra-application-links/src/tabs/_CollapsedTab.jsx
+++ b/packages/terra-application-links/src/tabs/_CollapsedTab.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { matchPath } from 'react-router-dom';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import styles from './ApplicationTabs.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-application-links/src/tabs/_Tab.jsx
+++ b/packages/terra-application-links/src/tabs/_Tab.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { matchPath } from 'react-router-dom';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import styles from './ApplicationTabs.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-application-links/src/tabs/_TabMenu.jsx
+++ b/packages/terra-application-links/src/tabs/_TabMenu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Popup from 'terra-popup';
 import { matchPath } from 'react-router-dom';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import { FormattedMessage } from 'react-intl';
 import TabMenuList from './_TabMenuList';
 import TabMenuDisplay from './_TabMenuDisplay';

--- a/packages/terra-application-links/src/tabs/_TabMenuDisplay.jsx
+++ b/packages/terra-application-links/src/tabs/_TabMenuDisplay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import IconCaretDown from 'terra-icon/lib/icon/IconCaretDown';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import styles from './ApplicationTabs.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 1.3.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-application-navigation/package.json
+++ b/packages/terra-application-navigation/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "focus-trap-react": "^6.0.0",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.8",
     "react-onclickoutside": "^6.7.1",

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 4.11.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "focus-trap-react": "^6.0.0",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "moment": "^2.21.0",
     "prop-types": "^15.5.8",
     "react-onclickoutside": "^6.7.1",

--- a/packages/terra-date-picker/src/react-datepicker/index.jsx
+++ b/packages/terra-date-picker/src/react-datepicker/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 import { Portal } from 'react-portal';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import Popup from 'terra-popup';
 import classNames from 'classnames/bind';
 import { injectIntl, intlShape } from 'react-intl';

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 4.11.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-date-time-picker/package.json
+++ b/packages/terra-date-time-picker/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "moment": "^2.21.0",
     "moment-timezone": "^0.5.13",
     "prop-types": "^15.5.8",

--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import DatePicker from 'terra-date-picker';
 import TimeInput from 'terra-time-input';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import DateUtil from 'terra-date-picker/lib/DateUtil';
 import styles from './DateTimePicker.module.scss';
 import DateTimeUtils from './DateTimeUtils';

--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 5.15.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-hookshot/package.json
+++ b/packages/terra-hookshot/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "classlist-polyfill": "^1.2.0",
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "react-onclickoutside": "^6.7.1",
     "react-portal": "^4.1.2",

--- a/packages/terra-hookshot/src/HookshotContent.jsx
+++ b/packages/terra-hookshot/src/HookshotContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import onClickOutside from 'react-onclickoutside';
 import ResizeObserver from 'resize-observer-polyfill';
 import styles from './HookshotContent.module.scss';

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 6.10.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-menu/package.json
+++ b/packages/terra-menu/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "terra-arrange": "^3.0.0",
     "terra-content-container": "^3.0.0",

--- a/packages/terra-menu/src/MenuItem.jsx
+++ b/packages/terra-menu/src/MenuItem.jsx
@@ -4,7 +4,7 @@ import Arrange from 'terra-arrange';
 import CheckIcon from 'terra-icon/lib/icon/IconCheckmark';
 import ChevronIcon from 'terra-icon/lib/icon/IconChevronRight';
 import classNames from 'classnames/bind';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import styles from './MenuItem.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-menu/src/_MenuContent.jsx
+++ b/packages/terra-menu/src/_MenuContent.jsx
@@ -8,7 +8,7 @@ import ContentContainer from 'terra-content-container';
 import IconClose from 'terra-icon/lib/icon/IconClose';
 import Arrange from 'terra-arrange';
 import classNames from 'classnames/bind';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import MenuUtils from './_MenuUtils';
 import styles from './Menu.module.scss';
 

--- a/packages/terra-navigation-side-menu/CHANGELOG.md
+++ b/packages/terra-navigation-side-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 2.17.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-navigation-side-menu/package.json
+++ b/packages/terra-navigation-side-menu/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "terra-action-header": "^2.0.0",
     "terra-content-container": "^3.0.0",

--- a/packages/terra-navigation-side-menu/src/NavigationSideMenu.jsx
+++ b/packages/terra-navigation-side-menu/src/NavigationSideMenu.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames/bind';
 import ActionHeader from 'terra-action-header';
 import ContentContainer from 'terra-content-container';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import MenuItem from './_MenuItem';
 
 import styles from './NavigationSideMenu.module.scss';

--- a/packages/terra-navigation-side-menu/src/_MenuItem.jsx
+++ b/packages/terra-navigation-side-menu/src/_MenuItem.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames/bind';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import ChevronRight from 'terra-icon/lib/icon/IconChevronRight';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
 

--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 3.10.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-notification-dialog/package.json
+++ b/packages/terra-notification-dialog/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "focus-trap-react": "^6.0.0",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "terra-abstract-modal": "^3.9.0",
     "terra-button": "^3.3.0",

--- a/packages/terra-notification-dialog/src/NotificationDialog.jsx
+++ b/packages/terra-notification-dialog/src/NotificationDialog.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AbstractModal from 'terra-abstract-modal';
 import FocusTrap from 'focus-trap-react';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import Button from 'terra-button';
 import classNames from 'classnames/bind';
 import { FormattedMessage } from 'react-intl';

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 6.10.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-tabs/package.json
+++ b/packages/terra-tabs/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "resize-observer-polyfill": "^1.4.1",
     "terra-content-container": "^3.0.0",

--- a/packages/terra-tabs/src/_CollapsibleTabs.jsx
+++ b/packages/terra-tabs/src/_CollapsibleTabs.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ResizeObserver from 'resize-observer-polyfill';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import Menu from './_TabMenu';
 import styles from './Tabs.module.scss';
 

--- a/packages/terra-tabs/src/_TabMenu.jsx
+++ b/packages/terra-tabs/src/_TabMenu.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Menu from 'terra-menu';
 import IconCaretDown from 'terra-icon/lib/icon/IconCaretDown';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import { FormattedMessage } from 'react-intl';
 import styles from './Tabs.module.scss';
 

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+Updated `keycode-js` from `v1.0.4` to `v2.0.1`
 
 4.8.0 - (August 21, 2019)
 ------------------

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "terra-button-group": "^3.0.0",
     "terra-form-input": "^2.3.0"

--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -5,7 +5,7 @@ import Input from 'terra-form-input';
 import ButtonGroup from 'terra-button-group';
 import { injectIntl, intlShape } from 'react-intl';
 
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import TimeUtil from './TimeUtil';
 import styles from './TimeInput.module.scss';
 

--- a/packages/terra-time-input/tests/jest/TimeInput.test.jsx
+++ b/packages/terra-time-input/tests/jest/TimeInput.test.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl, mountWithIntl, renderWithIntl } from 'terra-enzyme-intl';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import TimeInput from '../../lib/TimeInput';
 import TimeUtil from '../../lib/TimeUtil';
 


### PR DESCRIPTION
### Summary
Updates `keycode-js` from `v1.0.4` to `v2.0.1`

### Additional Details
Throws warning for multiple versions of `keycode-js`. Will be fixed once terra-core is updated to keycode-js `v2.0.1`

Solves : #857 