### PR TITLE
Update DisclosureManagerHeaderAdapter.jsx docs

### DIFF
--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 ----------
 
+### Changed
+* Updated inline documentation for DisclosureManagerHeaderAdapter
+
 4.19.0 - (August 21, 2019)
 ------------------
 ### Changed

--- a/packages/terra-disclosure-manager/src/DisclosureManagerHeaderAdapter.jsx
+++ b/packages/terra-disclosure-manager/src/DisclosureManagerHeaderAdapter.jsx
@@ -8,9 +8,9 @@ const propTypes = {
    */
   title: PropTypes.string,
   /**
-   * An array of CollapsibleMenuView Items, Dividers, or Toggles to render within the DisclosureManager's header.
+   * A CollapsibleMenuView component to render within the DisclosureManager's header.
    */
-  collapsibleMenuItems: PropTypes.element,
+  collapsibleMenuView: PropTypes.element,
 };
 
 /**


### PR DESCRIPTION
Updating doc that didn't get changed during development. The consumer-facing documentation referenced the correct prop name, so this doesn't functionally impact anything.