### PR TITLE
Test dev-site webpack plugin passivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "stylelint": "^10.0.1",
     "stylelint-config-terra": "^3.0.0",
     "terra-aggregate-translations": "^1.0.0",
-    "terra-dev-site": "^6.0.0",
+    "terra-dev-site": "cerner/terra-dev-site#extend-dev-site",
     "terra-disclosure-manager": "^4.9.0",
     "terra-enzyme-intl": "^3.0.0",
     "terra-toolkit": "^5.4.0",


### PR DESCRIPTION
### Summary
Testing the passivity of the terra-dev-site change to use a webpack plugin instead of webpack config.

### Additional Details

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
