### PR TITLE
[date-time-picker]Updated date-time-picker spec to support theming repos.

### DIFF
--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Added `browser.refresh()` to `date-time-picker-spec` to support wdio tests failing in theming repos.
 
 4.12.0 - (September 6, 2019)
 ------------------

--- a/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
+++ b/packages/terra-date-time-picker/tests/wdio/date-time-picker-spec.js
@@ -413,6 +413,7 @@ Terra.describeViewports('DateTimePicker', ['tiny', 'large'], () => {
   describe('onBlur (CDT to CST)', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-date-time-picker/date-time-picker/date-time-picker-dst-blur');
+      browser.refresh();
       browser.click('input[name="terra-time-minute-input"]');
       browser.keys('Tab');
       browser.waitForVisible('[class*="time-clarification"]');
@@ -439,6 +440,7 @@ Terra.describeViewports('DateTimePicker', ['tiny', 'large'], () => {
   describe('onBlur (CST to CDT)', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-date-time-picker/date-time-picker/date-time-picker-dst-blur');
+      browser.refresh();
       browser.click('input[name="terra-time-minute-input"]');
       browser.keys('Tab');
       browser.waitForVisible('[class*="time-clarification"]');


### PR DESCRIPTION
### Summary
Few wdio tests were failing in theming repos(verified in fusion and clinical theme) with `element ("[class*="time-clarification"]") still not visible after 3000ms` error. Added browser.refresh() to support the test.


