### PR TITLE
Fixed missing hour not updated on re-entering same value

### DIFF
--- a/packages/terra-date-time-picker/src/DateTimePicker.jsx
+++ b/packages/terra-date-time-picker/src/DateTimePicker.jsx
@@ -3,9 +3,9 @@ import { injectIntl, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import DatePicker from 'terra-date-picker';
-import TimeInput from 'terra-time-input';
 import * as KeyCode from 'keycode-js';
 import DateUtil from 'terra-date-picker/lib/DateUtil';
+import TimeInput from 'terra-time-input';
 import styles from './DateTimePicker.module.scss';
 import DateTimeUtils from './DateTimeUtils';
 import TimeClarification from './_TimeClarification';
@@ -348,6 +348,7 @@ class DateTimePicker extends React.Component {
     // If both date and time are valid, check if the time is the missing hour and invoke onChange.
     // If the date is valid but time is invalid, the time in the dateTime state needs to be cleared and render.
     if (validDate && validTime) {
+      // this.handleChange(event, time);
       const updatedDateTime = DateTimeUtils.updateTime(previousDateTime, time, this.props.showSeconds);
 
       if (event.keyCode === KeyCode.KEY_DOWN

--- a/packages/terra-date-time-picker/src/DateTimeUtils.js
+++ b/packages/terra-date-time-picker/src/DateTimeUtils.js
@@ -126,9 +126,7 @@ class DateTimeUtils {
    * @return {boolean} - True if the time is valid.
    */
   static isValidTime(time, hasSeconds) {
-    const timeFormat = hasSeconds ? 'HH:mm:ss' : 'HH:mm';
-    const timeMoment = moment(time, timeFormat, true);
-    return timeMoment.isValid();
+    return TimeUtil.isValidTime(time, hasSeconds);
   }
 
   /**

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Fixed time-input componentDidUpdate for updating time-input on re-entering the same missing hour in time-input.
 
 4.9.0 - (September 6, 2019)
 ------------------

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -29,6 +29,8 @@
     "classnames": "^2.2.5",
     "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
+    "moment": "^2.21.0",
+    "moment-timezone": "^0.5.13",
     "terra-button-group": "^3.0.0",
     "terra-form-input": "^2.3.0"
   },

--- a/packages/terra-time-input/src/TimeUtil.js
+++ b/packages/terra-time-input/src/TimeUtil.js
@@ -1,3 +1,5 @@
+import moment from 'moment-timezone';
+
 class TimeUtil {
   /**
    * Determines if a provided nuermic input value is valid.
@@ -7,6 +9,19 @@ class TimeUtil {
    */
   static validNumericInput(value) {
     return value.length === 0 || /^\d+$/.test(value);
+  }
+
+  /**
+   * Determines if the time is a valid time in the HH:mm (where hasSeconds is false) or
+   * HH:mm:ss (where hasSeconds is true) formats
+   * @param {string} time - The time to validate.
+   * @param {boolean} hasSeconds Whether or not the time should consider having seconds valid
+   * @return {boolean} - True if the time is valid.
+   */
+  static isValidTime(time, hasSeconds) {
+    const timeFormat = hasSeconds ? 'HH:mm:ss' : 'HH:mm';
+    const timeMoment = moment(time, timeFormat, true);
+    return timeMoment.isValid();
   }
 
   /**


### PR DESCRIPTION
### Summary
Resolves #458 

### Additional Details
Date-Time Picker handles missing hour by replacing it with valid hour when entered, however the value in time-input was not updating on re-entering missing hour second time. This was due to the condition in componentDidUpdate() of [TimeInput](https://github.com/cerner/terra-framework/blob/7b1f5660175d02a77a860c81adac5faa962b30a2/packages/terra-time-input/src/TimeInput.jsx#L179)
```javascript
if (this.props.value === prevProps.value && this.props.variant === prevProps.variant) {
    return;
}
```
Since on initial input of missing hour props.value will get updated to valid time value and on re-entering the same missing hour date-time-picker again updates it to valid time value which will be same as previous hour this was preventing component from getting updated to display valid time value.

To fix this issue added prevState in componentDidUpdate() to handle missing hour changes. 

Thanks for contributing to Terra.
@cerner/terra
