### PR TITLE
Fix lint warnings throughout terra-framework

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 * Update underlying structure to handle new theme variables.
 * Revert test wrapper changes.
 * Removed `details` tag from doc-site.
+* Corrected lint warnings
 
 1.4.0 - (September 6, 2019)
 ------------------

--- a/packages/terra-application-navigation/src/ApplicationNavigation.jsx
+++ b/packages/terra-application-navigation/src/ApplicationNavigation.jsx
@@ -337,7 +337,9 @@ const ApplicationNavigation = ({
    * accurate.
    */
   useLayoutEffect(() => {
-    if (!contentLayoutRef.current) {
+    const contentLayoutElement = contentLayoutRef.current;
+
+    if (!contentLayoutElement) {
       return undefined;
     }
 
@@ -351,12 +353,12 @@ const ApplicationNavigation = ({
       }
     }
 
-    contentLayoutRef.current.addEventListener('transitionend', cleanupContentTransition);
+    contentLayoutElement.addEventListener('transitionend', cleanupContentTransition);
 
     return () => {
-      contentLayoutRef.current.removeEventListener('transitionend', cleanupContentTransition);
+      contentLayoutElement.removeEventListener('transitionend', cleanupContentTransition);
     };
-  }, [contentLayoutRef.current]);
+  }, [contentLayoutRef]);
 
   /**
    * If the ApplicationNavigation is rendering at non-compact breakpoints, and the drawer menu is still

--- a/packages/terra-application-navigation/src/utils/helpers.js
+++ b/packages/terra-application-navigation/src/utils/helpers.js
@@ -40,21 +40,25 @@ const generateKeyDownSelection = onSelect => (
 const useAnimatedCount = (countRef, countValue) => {
   const previousValueRef = useRef(countValue);
 
-  function handleAnimation() {
-    if (countRef.current) {
-      countRef.current.setAttribute('data-count-pulse', 'false');
-      countRef.current.removeEventListener('animationend', handleAnimation);
-    }
-  }
-
   useLayoutEffect(() => {
-    if (countValue > previousValueRef.current && countRef.current) {
-      countRef.current.setAttribute('data-count-pulse', 'true');
-      countRef.current.addEventListener('animationend', handleAnimation);
+    const countElement = countRef.current;
+
+    if (!countElement) {
+      return;
+    }
+
+    function handleAnimation() {
+      countElement.setAttribute('data-count-pulse', 'false');
+      countElement.removeEventListener('animationend', handleAnimation);
+    }
+
+    if (countValue > previousValueRef.current) {
+      countElement.setAttribute('data-count-pulse', 'true');
+      countElement.addEventListener('animationend', handleAnimation);
     }
 
     previousValueRef.current = countValue;
-  }, [countValue]);
+  }, [countRef, countValue]);
 };
 
 export default {

--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -3,5 +3,6 @@ ChangeLog
 
 Unreleased
 -----------------
-* Initial stable release
+* Initial stable release 
 * Removed `details` tag from doc-site.
+* Corrected lint warnings

--- a/packages/terra-date-input/src/DateInput.jsx
+++ b/packages/terra-date-input/src/DateInput.jsx
@@ -344,8 +344,6 @@ class DateInput extends React.Component {
       return;
     }
 
-    console.log('day change');
-
     const inputValue = event.target.value;
     const stateValue = this.state.day;
     const maxValue = 31;

--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Removed `details` tag from doc-site.
+* Corrected lint warnings
 
 4.20.0 - (September 6, 2019)
 ------------------

--- a/packages/terra-disclosure-manager/src/DisclosureManagerHeaderAdapter.jsx
+++ b/packages/terra-disclosure-manager/src/DisclosureManagerHeaderAdapter.jsx
@@ -21,7 +21,7 @@ const DisclosureManagerHeaderAdapter = ({ title, collapsibleMenuView }) => {
 
   useLayoutEffect(() => {
     adapterContext.register({ title, collapsibleMenuView });
-  }, [title, collapsibleMenuView]);
+  }, [title, collapsibleMenuView, adapterContext]);
 
   return null;
 };


### PR DESCRIPTION
### Summary
I noticed we had a few new eslint warnings around our current hooks implementations (and a random console log). This PR cleans those up.