### PR TITLE
[terra-abstract-modal] Check whether `focus` is defined for the modal trigger element before restoring focus.

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Check whether `focus` is defined for the modal trigger element before restoring focus.
 
 3.12.0 - (September 19, 2019)
 ------------------

--- a/packages/terra-abstract-modal/src/AbstractModal.jsx
+++ b/packages/terra-abstract-modal/src/AbstractModal.jsx
@@ -154,7 +154,7 @@ class AbstractModal extends React.Component {
     }
 
     setTimeout(() => {
-      if (this.state.modalTrigger) {
+      if (this.state.modalTrigger && this.state.modalTrigger.focus) {
         // Shift focus back to element that was last focused prior to opening the modal
         this.state.modalTrigger.focus();
       }


### PR DESCRIPTION
### Summary
Fixes #901.

### Additional Details
I was able to reproduce this when the modal is disclosed via a non-HTML element (SVG for example). In the test case below, `modalTrigger` is the SVG element (that does not support `focus()`) on IE but it is the `body` element on other major browsers. 

<details> <summary> Reduced Test Case </summary>

```
import React from 'react';
import PropTypes from 'prop-types';
import ContentContainer from 'terra-content-container';
import { withDisclosureManager, disclosureManagerShape } from 'terra-disclosure-manager';
import ModalManager from 'terra-modal-manager';

class DisclosureComponent extends React.Component {
  constructor(props) {
    super(props);

    this.disclose = this.disclose.bind(this);
    this.closeDisclosure = this.closeDisclosure.bind(this);
  }

  disclose(size, dimensions) {
    const { disclosureType, nestedIndex } = this.props;

    const newIndex = nestedIndex + 1;
    return () => {
      this.props.disclosureManager.disclose({
        preferredType: disclosureType,
        size,
        dimensions,
        content: {
          key: `DemoContainer-${newIndex}`,
          component: <WrappedDisclosureComponent identifier={`DemoContainer-${newIndex}`} nestedIndex={newIndex} />,
        },
      });
    };
  }

  closeDisclosure() {
    this.props.disclosureManager.closeDisclosure();
  }

  render() {
    const { disclosureManager, identifier } = this.props;

    return (
      <ContentContainer id={identifier} className="nested-component" fill header={<h2>IE Focus Issue</h2>}>
        <br />
        <div>
          <svg width="75" height="25">
            <g>
              <rect x="0" y="0" width="100%" height="100%" fill="#da552f" />
              <text x="10" y="17" onClick={this.disclose()}>Disclose</text>
            </g>
          </svg>
        </div>
        {disclosureManager && disclosureManager.closeDisclosure ? <button type="button" className="close-disclosure" onClick={this.closeDisclosure}>Close Disclosure</button> : null}
      </ContentContainer>
    );
  }
}

DisclosureComponent.propTypes = {
  disclosureManager: disclosureManagerShape,
  identifier: PropTypes.string,
  disclosureType: PropTypes.string,
  nestedIndex: PropTypes.number,
};

DisclosureComponent.defaultProps = {
  nestedIndex: 0,
};

const WrappedDisclosureComponent = withDisclosureManager(DisclosureComponent);

const ModalManagerDefault = () => (
  <div role="main">
    <ModalManager>
      <WrappedDisclosureComponent identifier="root-component" disclosureType="modal" />
    </ModalManager>
  </div>
);

export default ModalManagerDefault;

```
</details>

<details> <summary> Behavior on IE 10 </summary>

![ie-focus-issue](https://user-images.githubusercontent.com/10090859/65679140-2a2d0d80-e072-11e9-89a5-64a4a31e4288.gif)
</details>

<details> <summary> Behavior on Chrome </summary> 

![chrome-focus-issue](https://user-images.githubusercontent.com/10090859/65679154-31ecb200-e072-11e9-97d8-1242cef792f7.gif)
</details>

I have functionally verified the change, btw. 
