### PR TITLE
Fix wdio test url.

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 * Adjusted title margin and padding
 * Update tests and screenshots to support theme tests
 
+### Fixed
+* Fix wdio test url.
+
 1.6.0 - (September 26, 2019)
 ------------------
 ### Changed

--- a/packages/terra-application-navigation/tests/wdio/application-navigation-spec.js
+++ b/packages/terra-application-navigation/tests/wdio/application-navigation-spec.js
@@ -123,7 +123,7 @@ Terra.describeViewports('ApplicationNavigation - Small', ['small'], () => {
   });
 
   describe('Nav drawer button should be displayed when only help, settings or logout utilities are present', () => {
-    before(() => browser.url('/raw/tests/terra-application-navigation/application-navigation/no-custom-utility-items'));
+    before(() => browser.url('/#/raw/tests/terra-application-navigation/application-navigation/no-custom-utility-items'));
 
     it('open drawer', () => {
       browser.waitForVisible('[data-compact-header-toggle="true"]');

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Removed extra comma from scss file.
 
 6.13.0 - (September 26, 2019)
 ------------------

--- a/packages/terra-menu/src/MenuItem.module.scss
+++ b/packages/terra-menu/src/MenuItem.module.scss
@@ -56,7 +56,7 @@
     }
 
     .start-icon {
-      color: var(--terra-menu-item-disabled-start-icon-color, #9b9fa1);;
+      color: var(--terra-menu-item-disabled-start-icon-color, #9b9fa1);
     }
   }
 

--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* Removed extra comma from scss file.
 
 3.13.0 - (September 26, 2019)
 ------------------

--- a/packages/terra-notification-dialog/src/NotificationDialog.module.scss
+++ b/packages/terra-notification-dialog/src/NotificationDialog.module.scss
@@ -63,7 +63,7 @@
       display: inline-block;
       height: var(--terra-notification-dialog-icon-height, 2rem);
       margin-right: var(--terra-notification-dialog-icon-margin-right, 1.25rem);
-      width: var(--terra-notification-dialog-icon-width, 2rem);;
+      width: var(--terra-notification-dialog-icon-width, 2rem);
     }
 
     > .alert {


### PR DESCRIPTION
### Summary
- Fix wdio test url in terra-application-navigation.
- Remove extra comma in scss files.

### Additional Details
- The following error occurs in the clinical theme repo. The cause appears to be having an incorrect test url. I would expect the same test in terra-frame to fail but that's not the case. Not sure why it is only happening for the clinical theme. The header toggle button does appear in the clinical theme dev site.

```
1) [small] ApplicationNavigation - Small Nav drawer button should be displayed when only help, settings or logout utilities are present open drawer:
element ("[data-compact-header-toggle="true"]") still not visible after 3000ms
running chrome
Error: element ("[data-compact-header-toggle="true"]") still not visible after 3000ms
    at elements("[data-compact-header-toggle="true"]") - isVisible.js:54:17
    at isVisible("[data-compact-header-toggle="true"]") - waitForVisible.js:73:22
```

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Please add an entry in the CHANGELOG.md file in each package you modify.

Thanks for contributing to Terra.
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
