### PR TITLE
[terra-dialog-modal] - Add rootSelector prop

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@ Cerner Corporation
 - Avinash Gupta [@avinashg1994]
 - Lokesh P [@lokesh-0813]
 - Saket Bajaj [@saket2403]
+- Phil Dodderidge [@pdodde]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -62,4 +63,5 @@ Cerner Corporation
 [@pranav300]: https://github.com/pranav300
 [@avinashg1994]: https://github.com/avinashg1994
 [@lokesh-0813]: https://github.com/lokesh-0813
-[@saket2403]:https://github.com/saket2403
+[@saket2403]: https://github.com/saket2403
+[@pdodde]: https://github.com/pdodde

--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added `rootSelector` prop to help prevent focus from shifting outside of the DialogModal when it is opened.
 
 3.17.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-dialog-modal/src/DialogModal.jsx
+++ b/packages/terra-dialog-modal/src/DialogModal.jsx
@@ -50,6 +50,10 @@ const propTypes = {
    * If set to true, the modal will close when a mouse click is triggered outside the modal.
    */
   closeOnOutsideClick: PropTypes.bool,
+  /**
+   * Used to select the root mount DOM node. This is used to help prevent focus from shifting outside of the DialogModal when it is opened.
+   */
+  rootSelector: PropTypes.string,
 };
 
 const defaultProps = {
@@ -57,6 +61,7 @@ const defaultProps = {
   isOpen: false,
   width: '1120',
   closeOnOutsideClick: false,
+  rootSelector: '#root',
 };
 
 const DialogModal = (props) => {
@@ -69,6 +74,7 @@ const DialogModal = (props) => {
     ariaLabel,
     width,
     closeOnOutsideClick,
+    rootSelector,
     ...customProps
   } = props;
 
@@ -85,7 +91,7 @@ const DialogModal = (props) => {
   }
 
   return (
-    <AbstractModal ariaLabel={ariaLabel} role="dialog" classNameModal={cx(classArray)} isOpen={isOpen} onRequestClose={onRequestClose} zIndex="7000" closeOnOutsideClick={closeOnOutsideClick}>
+    <AbstractModal ariaLabel={ariaLabel} role="dialog" classNameModal={cx(classArray)} isOpen={isOpen} onRequestClose={onRequestClose} zIndex="7000" closeOnOutsideClick={closeOnOutsideClick} rootSelector={rootSelector}>
       <div {...customProps} className={cx('dialog-modal-inner-wrapper', customProps.className)}>
         <div className={cx('dialog-modal-container')}>
           <div>{header}</div>

--- a/packages/terra-dialog-modal/tests/jest/DialogModal.test.jsx
+++ b/packages/terra-dialog-modal/tests/jest/DialogModal.test.jsx
@@ -55,3 +55,8 @@ it('should mount an open dialogModal 1600 width', () => {
   const dialogModal = mount(<DialogModalExample width="1600" />);
   expect(dialogModal).toMatchSnapshot();
 });
+
+it('should set the rootSelector', () => {
+  const dialogModal = mount(<DialogModalExample rootSelector="#myroot" />);
+  expect(dialogModal).toMatchSnapshot();
+});

--- a/packages/terra-dialog-modal/tests/jest/__snapshots__/DialogModal.test.jsx.snap
+++ b/packages/terra-dialog-modal/tests/jest/__snapshots__/DialogModal.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`should mount an open dialogModal 1`] = `
       }
       isOpen={false}
       onRequestClose={[Function]}
+      rootSelector="#root"
       width="1120"
     />
     <Button
@@ -82,6 +83,7 @@ exports[`should mount an open dialogModal 320 width 1`] = `
       }
       isOpen={false}
       onRequestClose={[Function]}
+      rootSelector="#root"
       width="320"
     />
     <Button
@@ -144,6 +146,7 @@ exports[`should mount an open dialogModal 960 width 1`] = `
       }
       isOpen={false}
       onRequestClose={[Function]}
+      rootSelector="#root"
       width="960"
     />
     <Button
@@ -206,6 +209,7 @@ exports[`should mount an open dialogModal 1280 width 1`] = `
       }
       isOpen={false}
       onRequestClose={[Function]}
+      rootSelector="#root"
       width="1280"
     />
     <Button
@@ -268,6 +272,7 @@ exports[`should mount an open dialogModal 1600 width 1`] = `
       }
       isOpen={false}
       onRequestClose={[Function]}
+      rootSelector="#root"
       width="1600"
     />
     <Button
@@ -330,7 +335,71 @@ exports[`should mount an open dialogModal 1600 width 2`] = `
       }
       isOpen={false}
       onRequestClose={[Function]}
+      rootSelector="#root"
       width="1600"
+    />
+    <Button
+      isBlock={false}
+      isCompact={false}
+      isDisabled={false}
+      isIconOnly={false}
+      isReversed={false}
+      onClick={[Function]}
+      text="Trigger Dialog Modal"
+      type="button"
+      variant="neutral"
+    >
+      <button
+        aria-disabled={false}
+        className="button neutral"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        type="button"
+      >
+        <span
+          className="button-label text-only"
+        >
+          <span
+            className=""
+          >
+            Trigger Dialog Modal
+          </span>
+        </span>
+      </button>
+    </Button>
+  </div>
+</DialogModalExample>
+`;
+
+exports[`should set the rootSelector 1`] = `
+<DialogModalExample
+  rootSelector="#myroot"
+>
+  <div>
+    <DialogModal
+      ariaLabel="Dialog Modal Example"
+      closeOnOutsideClick={false}
+      footer={
+        <ActionFooter
+          start="Footer Goes here"
+        />
+      }
+      header={
+        <ActionHeader
+          level={1}
+          onClose={[Function]}
+          title="Action Header used here"
+        />
+      }
+      isOpen={false}
+      onRequestClose={[Function]}
+      rootSelector="#root"
+      width="1120"
     />
     <Button
       isBlock={false}
@@ -389,6 +458,7 @@ exports[`should shallow an open dialogModal 1`] = `
     }
     isOpen={false}
     onRequestClose={[Function]}
+    rootSelector="#root"
     width="1120"
   >
     <p>
@@ -436,6 +506,7 @@ exports[`should shallow an open dialogModal 320 width 1`] = `
     }
     isOpen={false}
     onRequestClose={[Function]}
+    rootSelector="#root"
     width="320"
   >
     <p>
@@ -483,6 +554,7 @@ exports[`should shallow an open dialogModal 960 width 1`] = `
     }
     isOpen={false}
     onRequestClose={[Function]}
+    rootSelector="#root"
     width="960"
   >
     <p>
@@ -530,6 +602,7 @@ exports[`should shallow an open dialogModal 1280 width 1`] = `
     }
     isOpen={false}
     onRequestClose={[Function]}
+    rootSelector="#root"
     width="1280"
   >
     <p>
@@ -577,6 +650,7 @@ exports[`should shallow an open dialogModal 1600 width 1`] = `
     }
     isOpen={false}
     onRequestClose={[Function]}
+    rootSelector="#root"
     width="1600"
   >
     <p>


### PR DESCRIPTION
### Summary
Ran into a problem where the root element is not being found and so the form is still tabbable when the modal is displaying because it doesn't add the inert attribute.

Found a relevant discussion here: https://github.com/cerner/terra-core/pull/2288/files#r269104366

Can we set a default in Base that will make this just work so we don't have to add this to every dialog box? Seems like this would be a pretty common mistake.
