### PR TITLE
Resolve lint warnings for multiple empty lines

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 3.15.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-abstract-modal/src/terra-dev-site/test/abstract-modal/AbstractModalContentOverflow.test.jsx
+++ b/packages/terra-abstract-modal/src/terra-dev-site/test/abstract-modal/AbstractModalContentOverflow.test.jsx
@@ -47,5 +47,4 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
   }
 }
 
-
 export default ModalContentOverflow;

--- a/packages/terra-abstract-modal/src/terra-dev-site/test/abstract-modal/AbstractModalNoFocusableContent.test.jsx
+++ b/packages/terra-abstract-modal/src/terra-dev-site/test/abstract-modal/AbstractModalNoFocusableContent.test.jsx
@@ -14,7 +14,6 @@ class ModalNoFocusableContent extends React.Component {
     this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
-
   handleOpenModal() {
     this.setState({ isOpen: true });
   }

--- a/packages/terra-abstract-modal/src/terra-dev-site/test/abstract-modal/FullscreenAbstractModal.test.jsx
+++ b/packages/terra-abstract-modal/src/terra-dev-site/test/abstract-modal/FullscreenAbstractModal.test.jsx
@@ -47,5 +47,4 @@ class ModalIsFullscreen extends React.Component {
   }
 }
 
-
 export default ModalIsFullscreen;

--- a/packages/terra-abstract-modal/tests/jest/AbstractModalExample.jsx
+++ b/packages/terra-abstract-modal/tests/jest/AbstractModalExample.jsx
@@ -19,7 +19,6 @@ class ModalExample extends React.Component {
     this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
-
   handleOpenModal() {
     this.setState({ isOpen: true });
   }

--- a/packages/terra-application-layout/CHANGELOG.md
+++ b/packages/terra-application-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 5.17.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-application-layout/src/menu/RoutingMenu.jsx
+++ b/packages/terra-application-layout/src/menu/RoutingMenu.jsx
@@ -108,7 +108,6 @@ class RoutingMenu extends React.Component {
   handleMenuChange(event, data) {
     const { routingStackDelegate, layoutConfig } = this.props;
 
-
     let routeFunc;
     if (data.metaData.externalLink) {
       routeFunc = () => window.open(data.metaData.externalLink.path, data.metaData.externalLink.target || '_blank');

--- a/packages/terra-application-layout/src/terra-dev-site/doc/common/ApplicationContent.jsx
+++ b/packages/terra-application-layout/src/terra-dev-site/doc/common/ApplicationContent.jsx
@@ -19,7 +19,6 @@ const DisclosureComponent = withDisclosureManager(({ disclosureManager }) => (
   </ContentContainer>
 ));
 
-
 const dummyContent = (
   <div>
     <h2>Lorem ipsum dolor sit amet</h2>

--- a/packages/terra-application-layout/src/terra-dev-site/test/application-layout/ApplicationLayoutEmpty.test.jsx
+++ b/packages/terra-application-layout/src/terra-dev-site/test/application-layout/ApplicationLayoutEmpty.test.jsx
@@ -20,7 +20,6 @@ PageContent.propTypes = {
   contentName: PropTypes.string,
 };
 
-
 /**
  * The routingConfig API matches that of the NavigationLayout. Routing specifications for the
  * menu and content regions are supported; the header region is not configurable.

--- a/packages/terra-application-layout/tests/wdio/application-layout-spec.js
+++ b/packages/terra-application-layout/tests/wdio/application-layout-spec.js
@@ -75,7 +75,6 @@ Terra.describeViewports('ApplicationLayout', ['large'], () => {
   });
 });
 
-
 Terra.describeViewports('ApplicationLayout', ['small'], () => {
   describe('Toggles menu when small', () => {
     it('Toggles menu when small', () => {

--- a/packages/terra-application-name/CHANGELOG.md
+++ b/packages/terra-application-name/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 3.21.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-application-name/src/terra-dev-site/doc/example/ApplicationMenuNameStandard.jsx
+++ b/packages/terra-application-name/src/terra-dev-site/doc/example/ApplicationMenuNameStandard.jsx
@@ -25,5 +25,4 @@ const ApplicationMenuNameStandard = () => (
   />
 );
 
-
 export default ApplicationMenuNameStandard;

--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 1.9.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-application-navigation/src/tabs/_TabCount.jsx
+++ b/packages/terra-application-navigation/src/tabs/_TabCount.jsx
@@ -24,7 +24,6 @@ const propTypes = {
   intl: intlShape,
 };
 
-
 const TabCount = ({ value, isRollup, intl }) => {
   const countRef = useRef();
 

--- a/packages/terra-application-navigation/tests/jest/common/PopupListItem.test.jsx
+++ b/packages/terra-application-navigation/tests/jest/common/PopupListItem.test.jsx
@@ -13,7 +13,6 @@ describe('PopupMenuListItem', () => {
     expect(shallowComponent).toMatchSnapshot();
   });
 
-
   it('should render prop data', () => {
     const shallowComponent = shallow(
       <PopupMenuListItem

--- a/packages/terra-application-navigation/tests/jest/header/CompactHeader.test.jsx
+++ b/packages/terra-application-navigation/tests/jest/header/CompactHeader.test.jsx
@@ -25,7 +25,6 @@ describe('CompactHeader', () => {
     expect(mountComponent).toMatchSnapshot();
   });
 
-
   it('should render with function callbacks', () => {
     const mountComponent = mountWithIntl(
       <CompactHeader

--- a/packages/terra-application-utility/CHANGELOG.md
+++ b/packages/terra-application-utility/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 2.25.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-application-utility/src/utility/_UtilityMenuItem.jsx
+++ b/packages/terra-application-utility/src/utility/_UtilityMenuItem.jsx
@@ -179,7 +179,6 @@ class UtilityMenuItem extends React.Component {
     );
     /* eslint-enable jsx-a11y/no-static-element-interactions */
 
-
     const renderFooterButton = (wrapOnKeyDown, handleSelection) => (
       <Button
         {...customProps}

--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 6.16.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -35,7 +35,6 @@ const contextTypes = {
   isCollapsibleMenuItem: PropTypes.bool,
 };
 
-
 class CollapsibleMenuViewItemGroup extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewToggle.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewToggle.jsx
@@ -50,7 +50,6 @@ class CollapsibleMenuViewToggle extends React.Component {
     this.wrappedOnChange = this.wrappedOnChange.bind(this);
   }
 
-
   // Wrapping onChange event so that the same parameters will be given when the display is a checkbox and a menu.item
   wrappedOnChange(event) {
     if (this.props.onChange) {

--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 1.4.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-date-input/src/DateInputUtil.js
+++ b/packages/terra-date-input/src/DateInputUtil.js
@@ -129,7 +129,6 @@ class DateInputUtil {
     return null;
   }
 
-
   /**
    * @param {String} value String to split month value from
    * @return {String} Month value generated from input value

--- a/packages/terra-date-input/src/terra-dev-site/test/date-input/FocusBlurDateInputField.test.jsx
+++ b/packages/terra-date-input/src/terra-dev-site/test/date-input/FocusBlurDateInputField.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DateInputField from 'terra-date-input/lib/DateInputField';
 
-
 class DateInputOnBlur extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 4.17.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-date-picker/src/terra-dev-site/doc/example/DatePickerIncludeDates.jsx
+++ b/packages/terra-date-picker/src/terra-dev-site/doc/example/DatePickerIncludeDates.jsx
@@ -59,5 +59,4 @@ const DatePickerExampleIncludeDates = () => (
   />
 );
 
-
 export default DatePickerExampleIncludeDates;

--- a/packages/terra-date-picker/src/terra-dev-site/test/date-picker/DatePickerExcludeDates.test.jsx
+++ b/packages/terra-date-picker/src/terra-dev-site/test/date-picker/DatePickerExcludeDates.test.jsx
@@ -14,7 +14,6 @@ const DatePickerExcludeDates = () => (
     />
   </div>
 
-
 );
 
 export default DatePickerExcludeDates;

--- a/packages/terra-date-picker/src/terra-dev-site/test/date-picker/DatePickerReadOnly.test.jsx
+++ b/packages/terra-date-picker/src/terra-dev-site/test/date-picker/DatePickerReadOnly.test.jsx
@@ -14,7 +14,6 @@ const DatePickerReadOnlyDate = () => (
     />
   </div>
 
-
 );
 
 export default DatePickerReadOnlyDate;

--- a/packages/terra-date-picker/src/terra-dev-site/test/date-picker/DatePickerStartDate.test.jsx
+++ b/packages/terra-date-picker/src/terra-dev-site/test/date-picker/DatePickerStartDate.test.jsx
@@ -13,7 +13,6 @@ const DatePickerStartDate = () => (
     />
   </div>
 
-
 );
 
 export default DatePickerStartDate;

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 4.18.0 - (October 30, 2019)
 ------------------
@@ -11,7 +13,6 @@ Unreleased
 * Duplicate ID in examples changed.
 * Changed 12-hour format appearance for mobile and desktop.
 * Meridiem select on Desktop has been changed to buttons which means that the WebdriverIO reference screenshots (if any) and/or any code in the consumer application that accesses the old meridiem select functionality on the Desktop view need to be updated.
-* Resolved lint warnings for multiple empty lines
 
 4.17.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 * Duplicate ID in examples changed.
 * Changed 12-hour format appearance for mobile and desktop.
 * Meridiem select on Desktop has been changed to buttons which means that the WebdriverIO reference screenshots (if any) and/or any code in the consumer application that accesses the old meridiem select functionality on the Desktop view need to be updated.
+* Resolved lint warnings for multiple empty lines
 
 4.17.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-date-time-picker/src/terra-dev-site/common/DateTimePickerExampleTemplate.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/common/DateTimePickerExampleTemplate.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import DateTimePicker from 'terra-date-time-picker/lib/DateTimePicker';
 import DateTimeUtils from '../../DateTimeUtils';
 
-
 const propTypes = {
   /**
    * The current entered date time. Use for the selected date message.

--- a/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerExcludeDates.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerExcludeDates.jsx
@@ -55,5 +55,4 @@ const DateTimePickerExampleExcludeDates = () => (
   />
 );
 
-
 export default DateTimePickerExampleExcludeDates;

--- a/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerIncludeDates.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerIncludeDates.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Field from 'terra-form-field';
 import DateTimePicker from 'terra-date-time-picker';
 
-
 const propTypes = {
   /**
    * The current entered date time. Use for the selected date message.
@@ -55,6 +54,5 @@ const DateTimePickerExampleIncludeDates = () => (
     includeDates={[moment().format(), moment().subtract(1, 'days').format(), moment().add(1, 'days').format()]}
   />
 );
-
 
 export default DateTimePickerExampleIncludeDates;

--- a/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerMinMax.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/doc/example/DateTimePickerMinMax.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Field from 'terra-form-field';
 import DateTimePicker from 'terra-date-time-picker';
 
-
 const propTypes = {
   /**
    * The current entered date time. Use for the selected date message.

--- a/packages/terra-date-time-picker/src/terra-dev-site/test/date-time-picker/DateTimePickerExcludeDates.test.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/test/date-time-picker/DateTimePickerExcludeDates.test.jsx
@@ -8,5 +8,4 @@ const DateTimePickerExample = () => (
   />
 );
 
-
 export default DateTimePickerExample;

--- a/packages/terra-date-time-picker/src/terra-dev-site/test/date-time-picker/DateTimePickerIncludeDates.test.jsx
+++ b/packages/terra-date-time-picker/src/terra-dev-site/test/date-time-picker/DateTimePickerIncludeDates.test.jsx
@@ -8,5 +8,4 @@ const DateTimePickerExample = () => (
   />
 );
 
-
 export default DateTimePickerExample;

--- a/packages/terra-date-time-picker/tests/wdio/date-time-picker-mobile-spec.js
+++ b/packages/terra-date-time-picker/tests/wdio/date-time-picker-mobile-spec.js
@@ -56,7 +56,6 @@ Terra.describeViewports('Date Time Picker Twelve Hour Mobile', ['tiny'], () => {
     Terra.it.validatesElement();
   });
 
-
   describe('Date Time Picker Twelve Hour Disabled Mobile - Disabled Styles', () => {
     before(() => {
       browser.url('/#/raw/tests/terra-date-time-picker/date-time-picker/twelve-hour/date-time-picker-disabled-12-hour-mobile');

--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added `rootSelector` prop to help prevent focus from shifting outside of the DialogModal when it is opened.
 
+### Changed
+* Resolved lint warnings for multiple empty lines
+
 3.17.0 - (October 21, 2019)
 ------------------
 ### Changed

--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -3,14 +3,13 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 3.18.0 - (October 30, 2019)
 ------------------
 ### Added
 * Added `rootSelector` prop to help prevent focus from shifting outside of the DialogModal when it is opened.
-
-### Changed
-* Resolved lint warnings for multiple empty lines
 
 3.17.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DialogModalWithLongText.test.jsx
+++ b/packages/terra-dialog-modal/src/terra-dev-site/test/dialog-modal/DialogModalWithLongText.test.jsx
@@ -4,7 +4,6 @@ import ActionHeader from 'terra-action-header';
 import ActionFooter from 'terra-action-footer';
 import DialogModal from '../../../DialogModal';
 
-
 class DialogModalWithLongText extends React.Component {
   constructor() {
     super();

--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 4.25.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-disclosure-manager/tests/jest/DisclosureManager.test.jsx
+++ b/packages/terra-disclosure-manager/tests/jest/DisclosureManager.test.jsx
@@ -617,7 +617,6 @@ describe('DisclosureManager', () => {
       });
   });
 
-
   it('should provide render function with the current state', () => {
     const mockRender = jest.fn();
     mockRender.mockReturnValue(<div />);

--- a/packages/terra-embedded-content-consumer/CHANGELOG.md
+++ b/packages/terra-embedded-content-consumer/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 3.17.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-embedded-content-consumer/tests/wdio/embedded-content-consumer-spec.js
+++ b/packages/terra-embedded-content-consumer/tests/wdio/embedded-content-consumer-spec.js
@@ -15,7 +15,6 @@ Terra.describeViewports('Embedded Content Consumer', ['tiny', 'large'], () => {
 
     Terra.it.matchesScreenshot();
 
-
     it('Provider triggers EventA message', () => {
       const myFrame = browser.element('iframe[src="/#/raw/provider/terra-embedded-content-consumer/embedded-content-consumer/providers/custom-event-provider"]').value;
       browser.frame(myFrame);
@@ -35,7 +34,6 @@ Terra.describeViewports('Embedded Content Consumer', ['tiny', 'large'], () => {
     });
 
     Terra.it.matchesScreenshot();
-
 
     it('Provider triggers EventA message', () => {
       const myFrame = browser.element('iframe[src="/#/raw/provider/terra-embedded-content-consumer/embedded-content-consumer/providers/custom-events-provider"]').value;

--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 1.13.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitDateInput.jsx
+++ b/packages/terra-form-validation/src/terra-dev-site/doc/example/FormSubmitDateInput.jsx
@@ -6,7 +6,6 @@ import DateInputField from 'terra-date-input/lib/DateInputField';
 import Button from 'terra-button';
 import Spacer from 'terra-spacer';
 
-
 /**
  * Ensures the passed in value is an accepted date value
  * @param {string} value The date to validate

--- a/packages/terra-hookshot/CHANGELOG.md
+++ b/packages/terra-hookshot/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 5.20.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-hookshot/src/terra-dev-site/test/common/HookshotTestTemplate.jsx
+++ b/packages/terra-hookshot/src/terra-dev-site/test/common/HookshotTestTemplate.jsx
@@ -102,7 +102,6 @@ class HookshotTemplate extends React.Component {
       </div>
     );
 
-
     return (
       <div id={`${id}-bounds`} className={cx(['wrapper', `hookshot-wrapper-${type}`])}>
         <Hookshot

--- a/packages/terra-hookshot/tests/wdio/hookshot-spec.js
+++ b/packages/terra-hookshot/tests/wdio/hookshot-spec.js
@@ -193,7 +193,6 @@ Terra.describeViewports('Hookshot', ['medium'], () => {
     Terra.it.matchesScreenshot('Bottom End', { selector: '#attachment-margin-bounds' });
   });
 
-
   // boundingRef: test - top bottom start end bounding container adjustments.
   describe('Displays content pushed by bounding container', () => {
     before(() => browser.url('/#/raw/tests/terra-hookshot/hookshot/hookshot-bounding-container'));
@@ -287,7 +286,6 @@ Terra.describeViewports('Hookshot', ['medium'], () => {
 
     Terra.it.matchesScreenshot({ selector: '#EnabledBehaviors-bounds' });
   });
-
 
   // Verify Close Behaviors - ALL
   describe('Closes the hookshot content on ESC when all close behavior is present', () => {

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 6.16.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-menu/src/Menu.jsx
+++ b/packages/terra-menu/src/Menu.jsx
@@ -99,7 +99,6 @@ class Menu extends React.Component {
     }
   }
 
-
   push(item) {
     this.setState((prevState) => {
       const newStack = prevState.stack.slice();

--- a/packages/terra-menu/src/_MenuContent.jsx
+++ b/packages/terra-menu/src/_MenuContent.jsx
@@ -93,7 +93,6 @@ const childContextTypes = {
   isSelectableMenu: PropTypes.bool,
 };
 
-
 class MenuContent extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-navigation-layout/CHANGELOG.md
+++ b/packages/terra-navigation-layout/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 5.15.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-navigation-layout/src/configurationPropTypes.js
+++ b/packages/terra-navigation-layout/src/configurationPropTypes.js
@@ -95,7 +95,6 @@ const navigationLayoutConfigPropType = PropTypes.shape({
   content: routeConfigPropType,
 });
 
-
 /**
  * PropType definition for the processed configuration array created by the NavigationLayout and utilized
  * by the NavigationLayoutContent and RoutingStack. It is an Array containing Objects with data neccessary for the

--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 6.16.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-popup/src/_PopupOverlay.jsx
+++ b/packages/terra-popup/src/_PopupOverlay.jsx
@@ -38,7 +38,6 @@ class PopupOverlay extends React.Component {
     document.documentElement.style.overflow = this.overlayStyle;
   }
 
-
   handleOnClick(event) {
     event.stopPropagation();
     if (this.props.onRequestClose) {

--- a/packages/terra-slide-group/CHANGELOG.md
+++ b/packages/terra-slide-group/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 4.12.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-slide-group/src/SlideGroup.jsx
+++ b/packages/terra-slide-group/src/SlideGroup.jsx
@@ -94,5 +94,4 @@ class SlideGroup extends React.Component {
 SlideGroup.propTypes = propTypes;
 SlideGroup.defaultProps = defaultProps;
 
-
 export default SlideGroup;

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 * Added `aria-label` to the "Main" and "Panel" containers.
 * Added `mainAriaLabel` and `panelAriaLabel` as optional props.
 
+### Changed
+* Resolved lint warnings for multiple empty lines
+
 3.18.0 - (October 16, 2019)
 ------------------
 ### Changed

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -3,15 +3,14 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 3.19.0 - (October 30, 2019)
 ------------------
 ### Added
 * Added `aria-label` to the "Main" and "Panel" containers.
 * Added `mainAriaLabel` and `panelAriaLabel` as optional props.
-
-### Changed
-* Resolved lint warnings for multiple empty lines
 
 3.18.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-slide-panel/src/SlidePanel.jsx
+++ b/packages/terra-slide-panel/src/SlidePanel.jsx
@@ -147,7 +147,6 @@ class SlidePanel extends React.Component {
   }
 }
 
-
 SlidePanel.propTypes = propTypes;
 SlidePanel.defaultProps = defaultProps;
 

--- a/packages/terra-slide-panel/src/terra-dev-site/doc/slide-panel/SlidePanel.1.doc.jsx
+++ b/packages/terra-slide-panel/src/terra-dev-site/doc/slide-panel/SlidePanel.1.doc.jsx
@@ -28,7 +28,6 @@ import SlidePanelFullscreen from '../../test/slide-panel/SlidePanelFullscreen.te
 import SlidePanelFill from '../../test/slide-panel/SlidePanelFill.test';
 import SlidePanelNoFill from '../../test/slide-panel/SlidePanelNoFill.test';
 
-
 const DocPage = () => (
   <DocTemplate
     packageName={name}

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -71,7 +71,6 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     Terra.it.matchesScreenshot();
   });
 
-
   describe('Large size squished slide panel', () => {
     beforeEach(() => {
       browser.url('/#/raw/tests/terra-slide-panel/slide-panel/slide-panel-squish-large');
@@ -79,7 +78,6 @@ Terra.describeViewports('Slide panel', ['large'], () => {
 
     Terra.it.matchesScreenshot();
   });
-
 
   describe('Toggle the slide panel and hidden styles', () => {
     beforeEach(() => {

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * Fixed accessibility issue in the tabs component.
 
+### Changed
+* Resolved lint warnings for multiple empty lines
+
 6.16.0 - (October 21, 2019)
 ------------------
 ### Changed

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -3,14 +3,13 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 6.17.0 - (October 30, 2019)
 ------------------
 ### Fixed
 * Fixed accessibility issue in the tabs component.
-
-### Changed
-* Resolved lint warnings for multiple empty lines
 
 6.16.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -97,7 +97,6 @@ class Tabs extends React.Component {
     return activeIndex;
   }
 
-
   handleOnChange(event, selectedPane) {
     if (!selectedPane.props.isDisabled) {
       if (this.props.onChange) {

--- a/packages/terra-tabs/src/terra-dev-site/doc/example/TabContentTemplate.jsx
+++ b/packages/terra-tabs/src/terra-dev-site/doc/example/TabContentTemplate.jsx
@@ -11,7 +11,6 @@ const propTypes = {
   children: PropTypes.node,
 };
 
-
 const TabContentTemplate = ({ isLabelHidden, label, children }) => (
   <div className={cx('tab-content-template')}>
     {isLabelHidden ? <h3>{label}</h3> : null}

--- a/packages/terra-tabs/src/terra-dev-site/test/tabs/Tabs/TabContentTemplate.jsx
+++ b/packages/terra-tabs/src/terra-dev-site/test/tabs/Tabs/TabContentTemplate.jsx
@@ -11,7 +11,6 @@ const propTypes = {
   id: PropTypes.string,
 };
 
-
 const TabContentTemplate = ({ isLabelHidden, label, id }) => (
   <div className={cx('tab-content')} id={id}>
     {isLabelHidden ? <h3 className="truncationHeader">{label}</h3> : null}

--- a/packages/terra-tabs/tests/jest/TabPane.test.jsx
+++ b/packages/terra-tabs/tests/jest/TabPane.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Pane from '../../src/TabPane';
 
-
 describe('TabPane', () => {
   it('should render a default component with label', () => {
     const wrapper = shallow(<Pane label="Default" />);

--- a/packages/terra-theme-provider/CHANGELOG.md
+++ b/packages/terra-theme-provider/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 3.15.0 - (October 16, 2019)
 ------------------

--- a/packages/terra-theme-provider/src/terra-dev-site/test/theme-provider/GlobalSwitchThemes.test.jsx
+++ b/packages/terra-theme-provider/src/terra-dev-site/test/theme-provider/GlobalSwitchThemes.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ThemeProvider from '../../../ThemeProvider';
 import MockThemeComponent from '../common/MockThemeComponent';
 
-
 class SwitchThemes extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -3,13 +3,14 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Resolved lint warnings for multiple empty lines
 
 4.15.0 - (October 30, 2019)
 ------------------
 ### Changed
 * Changed 12-hour format appearance for mobile and desktop.
 * Meridiem select on Desktop has been changed to buttons which means that the WebdriverIO reference screenshots (if any) and/or any code in the consumer application that accesses the old meridiem select functionality on the Desktop view need to be updated.
-* Resolved lint warnings for multiple empty lines
 
 4.14.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Changed
 * Changed 12-hour format appearance for mobile and desktop.
 * Meridiem select on Desktop has been changed to buttons which means that the WebdriverIO reference screenshots (if any) and/or any code in the consumer application that accesses the old meridiem select functionality on the Desktop view need to be updated.
+* Resolved lint warnings for multiple empty lines
 
 4.14.0 - (October 21, 2019)
 ------------------

--- a/packages/terra-time-input/src/terra-dev-site/doc/time-input/TimeInput.1.doc.jsx
+++ b/packages/terra-time-input/src/terra-dev-site/doc/time-input/TimeInput.1.doc.jsx
@@ -26,7 +26,6 @@ import TimeInputSecondsInvalidSrc from '!raw-loader!../../../../src/terra-dev-si
 import TimeInputSecondsIncomplete from '../example/TimeInputSecondsIncomplete';
 import TimeInputSecondsIncompleteSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/TimeInputSecondsIncomplete';
 
-
 const DocPage = () => (
   <DocTemplate
     packageName={name}


### PR DESCRIPTION
### Summary

This PR removes multiple-empty-line occurrences. A rule override was introduced in [this PR](https://github.com/cerner/eslint-config-terra/pull/41) to disallowed more than 1 consecutive empty newline.

### Additional Details

This change is passive even without the rule override. It removes any duplicate newlines from files with a js/jsx extension.

Thanks for contributing to Terra.
@cerner/terra

