### PR TITLE
[terra-application-navigation]Updated Jest snapshots failing in master.

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Updated Jest Snapshots due to changes in `avatar`.
 
 1.13.0 - (November 20, 2019)
 ------------------

--- a/packages/terra-application-navigation/tests/jest/header/__snapshots__/Header.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/header/__snapshots__/Header.test.jsx.snap
@@ -1226,28 +1226,20 @@ exports[`Header should render with function callbacks 1`] = `
                       src="user-src"
                       variant="default"
                     >
-                      <div>
-                        <div
-                          className="hidden"
-                        >
-                          <img
-                            alt="user-name"
-                            className="image cover default image"
-                            onError={[Function]}
-                            onLoad={[Function]}
-                            src="user-src"
-                          />
-                        </div>
-                        <div>
-                          <span
-                            alt="user-name"
-                            aria-hidden={false}
-                            aria-label="user-name"
-                            className="icon user"
-                            role="img"
-                          />
-                        </div>
-                      </div>
+                      <img
+                        alt="user-name"
+                        className="image cover default image hidden"
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="user-src"
+                      />
+                      <span
+                        alt="user-name"
+                        aria-hidden={false}
+                        aria-label="user-name"
+                        className="icon user"
+                        role="img"
+                      />
                     </Image>
                   </div>
                 </Avatar>

--- a/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
@@ -383,28 +383,20 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                             src="user-src"
                             variant="default"
                           >
-                            <div>
-                              <div
-                                className="hidden"
-                              >
-                                <img
-                                  alt="user-name"
-                                  className="image cover default image"
-                                  onError={[Function]}
-                                  onLoad={[Function]}
-                                  src="user-src"
-                                />
-                              </div>
-                              <div>
-                                <span
-                                  alt="user-name"
-                                  aria-hidden={false}
-                                  aria-label="user-name"
-                                  className="icon user"
-                                  role="img"
-                                />
-                              </div>
-                            </div>
+                            <img
+                              alt="user-name"
+                              className="image cover default image hidden"
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              src="user-src"
+                            />
+                            <span
+                              alt="user-name"
+                              aria-hidden={false}
+                              aria-label="user-name"
+                              className="icon user"
+                              role="img"
+                            />
                           </Image>
                         </div>
                       </Avatar>

--- a/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenuHeaderButton.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenuHeaderButton.test.jsx.snap
@@ -357,28 +357,20 @@ exports[`UtilityMenuHeaderButton should render with function callbacks 1`] = `
               src="user-src"
               variant="default"
             >
-              <div>
-                <div
-                  className="hidden"
-                >
-                  <img
-                    alt="user-name"
-                    className="image cover default image"
-                    onError={[Function]}
-                    onLoad={[Function]}
-                    src="user-src"
-                  />
-                </div>
-                <div>
-                  <span
-                    alt="user-name"
-                    aria-hidden={false}
-                    aria-label="user-name"
-                    className="icon user"
-                    role="img"
-                  />
-                </div>
-              </div>
+              <img
+                alt="user-name"
+                className="image cover default image hidden"
+                onError={[Function]}
+                onLoad={[Function]}
+                src="user-src"
+              />
+              <span
+                alt="user-name"
+                aria-hidden={false}
+                aria-label="user-name"
+                className="icon user"
+                role="img"
+              />
             </Image>
           </div>
         </Avatar>


### PR DESCRIPTION
### Summary
Jest snapshots failing in master. Updated Jest snapshot due to changes in PR [#2762](https://github.com/cerner/terra-core/pull/2762/files) for terra-avatar. 