### PR TITLE
Remove yarn ref in docs

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Changed
 * Update screenshots
 
+### Removed
+* Removed yarn reference in docs
+
 3.18.0 - (December 16, 2019)
 ------------------
 ### Changed

--- a/packages/terra-abstract-modal/docs/README.md
+++ b/packages/terra-abstract-modal/docs/README.md
@@ -8,7 +8,6 @@ Our recommendation for HOC is the [terra-modal-manager][1], as it provides sizin
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-abstract-modal`
-  - `yarn add terra-abstract-modal`
 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed yarn reference in docs
 
 4.24.0 - (December 16, 2019)
 ------------------

--- a/packages/terra-date-picker/docs/DatePickerField.md
+++ b/packages/terra-date-picker/docs/DatePickerField.md
@@ -7,7 +7,6 @@
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-date-picker`
-  - `yarn add terra-date-picker`
 
 ## Implementation Notes:
 DatePickerField is required to be composed inside the [Base](https://github.com/cerner/terra-core/tree/master/packages/terra-base/docs) component with locale in order for it to load the correct date format and translation strings.

--- a/packages/terra-date-picker/docs/README.md
+++ b/packages/terra-date-picker/docs/README.md
@@ -18,7 +18,6 @@ In a controlled date picker, the consumer is responsible for managing the state 
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-date-picker`
-  - `yarn add terra-date-picker`
 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies

--- a/packages/terra-slide-group/CHANGELOG.md
+++ b/packages/terra-slide-group/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed yarn reference in docs
 
 4.14.0 - (December 10, 2019)
 ------------------

--- a/packages/terra-slide-group/docs/README.md
+++ b/packages/terra-slide-group/docs/README.md
@@ -12,7 +12,6 @@ As a utility component, any component utilizing the SlideGroup will need to hand
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-slide-group`
-  - `yarn add terra-slide-group`
 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added new WDIO screenshots
 
+### Removed
+* Removed yarn reference in docs
+
 4.18.0 - (December 10, 2019)
 ------------------
 ### Added

--- a/packages/terra-time-input/docs/README.md
+++ b/packages/terra-time-input/docs/README.md
@@ -14,7 +14,6 @@ If a 12 hour clock is chosen, the hour will be displayed between 01 and 12 inclu
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-time-input`
-  - `yarn add terra-time-input`
 
 <!-- AUTO-GENERATED-CONTENT:START Peer Dependencies -->
 ## Peer Dependencies


### PR DESCRIPTION
### Summary
Remove yarn reference in docs. We don't support yarn first-class.