### PR TITLE
Reverting a29151d25 (PR 1038) due to unintended animation changes

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -6,9 +6,6 @@ Unreleased
 ### Fixed
 * Fixed `settings` api called when `help` clicked in drawer menu.
 
-### Changed
-* Updated `content-layout` background color.
-
 1.18.0 - (February 4, 2020)
 ------------------
 ### Changed

--- a/packages/terra-application-navigation/src/ApplicationNavigation.module.scss
+++ b/packages/terra-application-navigation/src/ApplicationNavigation.module.scss
@@ -38,7 +38,7 @@
   }
 
   .content-layout {
-    background-color: var(--terra-application-navigation-content-layout-background-color, transparent);
+    background-color: var(--terra-application-navigation-content-layout-background-color, #fff);
     box-shadow: var(--terra-application-navigation-content-layout-box-shadow, 7px 0 7px 10px rgba(0, 0, 0, 0.4));
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Summary

The change to a transparent background color impacts the ApplicationNavigation's menu animations at compact breakpoints.

![nav-background](https://user-images.githubusercontent.com/1711637/74170515-a4f65f80-4bf2-11ea-8ecd-57b49aa186b9.gif)

We need to think about this background color change some more.