### PR TITLE
[date-picker] Fix clinical-theme test

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Fix wdio test for clinical-theme
+
 4.31.0 - (March 10, 2020)
 ------------------
 ### Changed

--- a/packages/terra-date-picker/tests/wdio/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/wdio/date-picker-spec.js
@@ -219,6 +219,7 @@ Terra.describeViewports('Date Picker', ['medium'], () => {
       browser.click('input[name="terra-date-date-input-onchange"]');
       browser.keys('Backspace');
       browser.keys('Backspace');
+      browser.keys('Backspace');
       // Ensures the mouse pointer doesn't appear in the screenshot
       browser.click('h3');
       expect(browser.getText('#iso')).to.equal('');


### PR DESCRIPTION
### Summary
The sizing of the date picker's input appears to result in the cursor to be placed one character over from where it does when clicking the input in the default theme. The ends up causing a `0` to remain in the input. Adding an extra backspace fixes this.
