### PR TITLE
Allow theme name to be set on the theme context.

### DIFF
--- a/packages/terra-theme-context/CHANGELOG.md
+++ b/packages/terra-theme-context/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Allow theme name to be set on the context.
 
 1.1.0 - (April 28, 2020)
 ------------------

--- a/packages/terra-theme-context/src/ThemeContextProvider.jsx
+++ b/packages/terra-theme-context/src/ThemeContextProvider.jsx
@@ -8,9 +8,10 @@ const propTypes = {
    */
   children: PropTypes.element.isRequired,
   /**
-   * An object containing the className of the selected theme.
+   * An object containing the name and className of the selected theme.
    */
   theme: PropTypes.shape({
+    name: PropTypes.string,
     className: PropTypes.string,
   }),
 };
@@ -20,7 +21,7 @@ const defaultProps = {
 };
 
 const ThemeContextProvider = ({ theme, children }) => {
-  const contextValue = useMemo(() => ({ className: theme.className }), [theme.className]);
+  const contextValue = useMemo(() => ({ name: theme.name, className: theme.className }), [theme.name, theme.className]);
   return (
     <ThemeContext.Provider value={contextValue}>
       {children}

--- a/packages/terra-theme-context/src/terra-dev-site/doc/ThemeContext/ThemeContext.1.doc.mdx
+++ b/packages/terra-theme-context/src/terra-dev-site/doc/ThemeContext/ThemeContext.1.doc.mdx
@@ -32,4 +32,5 @@ The ThemeContext provides an object with the following values:
 
 |Key Name|Type|Is Required|DefaultValue|Description|
 |---|---|---|---|---|
+|`name`|String|optional|undefined|The current application theme name. This field requires use of the terra-toolkit webpack config.|
 |`className`|String|optional|undefined|The current application theme className. The default theme is indicated as undefined or empty string.|

--- a/packages/terra-theme-context/src/terra-dev-site/doc/example/ThemeContextProviderExample.jsx
+++ b/packages/terra-theme-context/src/terra-dev-site/doc/example/ThemeContextProviderExample.jsx
@@ -4,7 +4,7 @@ import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 import ThemedComponent from './ThemedComponent';
 
 const ThemeContextProviderExample = () => (
-  <ThemeContextProvider theme={{ className: 'test-theme' }}>
+  <ThemeContextProvider theme={{ name: 'test-theme', className: 'test-theme' }}>
     <ThemedComponent />
   </ThemeContextProvider>
 );

--- a/packages/terra-theme-context/src/terra-dev-site/doc/example/ThemedComponent.jsx
+++ b/packages/terra-theme-context/src/terra-dev-site/doc/example/ThemedComponent.jsx
@@ -11,7 +11,7 @@ const Themed = () => {
   return (
     <div className={cx('themed', theme.className)}>
       <h1>
-        Themed block
+        {`Theme Name: ${theme.name}`}
       </h1>
       <div className={cx('themed-block')} />
     </div>

--- a/packages/terra-theme-context/tests/jest/ThemeContextProvider.test.jsx
+++ b/packages/terra-theme-context/tests/jest/ThemeContextProvider.test.jsx
@@ -15,7 +15,7 @@ describe('ThemeContextProvider', () => {
 
     it('should render with a theme', () => {
       const wrapper = shallow((
-        <ThemeContextProvider theme={{ className: 'test-theme' }}>
+        <ThemeContextProvider theme={{ name: 'test-theme', className: 'test-theme-class' }}>
           <div />
         </ThemeContextProvider>
       ));

--- a/packages/terra-theme-context/tests/jest/__snapshots__/ThemeContextProvider.test.jsx.snap
+++ b/packages/terra-theme-context/tests/jest/__snapshots__/ThemeContextProvider.test.jsx.snap
@@ -4,7 +4,8 @@ exports[`ThemeContextProvider Snapshots should render with a theme 1`] = `
 <ContextProvider
   value={
     Object {
-      "className": "test-theme",
+      "className": "test-theme-class",
+      "name": "test-theme",
     }
   }
 >
@@ -17,6 +18,7 @@ exports[`ThemeContextProvider Snapshots should render with minimal props 1`] = `
   value={
     Object {
       "className": undefined,
+      "name": undefined,
     }
   }
 >


### PR DESCRIPTION
### Summary
These changes allow a theme name to be set on the theme context

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deploy-pr-1101.herokuapp.com/

### Testing
Jest

### Additional Details
The theme name will be `undefined` in this PR until this PR gets released and consumed in terra-framework. https://github.com/cerner/terra-toolkit-boneyard/pull/33
Related PRs:
https://github.com/cerner/terra-toolkit-boneyard/pull/33
https://github.com/cerner/terra-application/pull/35

Thank you for contributing to Terra.
@cerner/terra
