### PR TITLE
Updated jest snapshots for Terra-Date-Input Terra-Date-Picker Terra-Tabs

### DIFF
--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed 
+* Updated Jest Snapshots
 
 1.14.0 - (June 2, 2020)
 ------------------

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed 
+* Updated Jest Snapshots
 
 4.39.0 - (June 9, 2020)
 ------------------
@@ -142,6 +144,7 @@ Unreleased
 
 4.17.0 - (October 21, 2019)
 ------------------
+
 ### Changed
 * Duplicate IDs in examples changed.
 * Updated previous and next buttons in the calendar back to a HTML button instead of using the terra-button component due to discrepancies with the hover styling in low-light theme.

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -153,7 +153,7 @@ exports[`correctly applies the theme context className 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      className="tui-Icon icon icon-svg"
+                      className="tui-Icon icon orion-fusion-theme icon-svg"
                       focusable="false"
                       height="1em"
                       viewBox="0 0 48 48"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -380,7 +380,7 @@ exports[`correctly applies the theme context className 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    className="tui-Icon icon icon-svg"
+                                    className="tui-Icon icon orion-fusion-theme icon-svg"
                                     focusable="false"
                                     height="1em"
                                     viewBox="0 0 48 48"

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed 
+* Updated Jest Snapshots
 
 6.37.0 - (June 9, 2020)
 ------------------

--- a/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
@@ -122,7 +122,7 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
                       >
                         <svg
                           aria-hidden="true"
-                          className="tui-Icon icon is-bidi"
+                          className="tui-Icon icon is-bidi orion-fusion-theme"
                           focusable="false"
                           height="1em"
                           viewBox="0 0 48 48"


### PR DESCRIPTION
### Summary
Updated Jest snapshots failing due to the changes of terra-icon : https://github.com/cerner/terra-core/pull/3023/files 
