### PR TITLE
Remove babel-eslint dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,6 @@
     ],
     "rules": {
       "react/forbid-prop-types": "off"
-    },
-    "settings": {
-      "polyfills": [
-        "Promise",
-        "Map"
-      ]
     }
   },
   "stylelint": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "rules": {
       "react/forbid-prop-types": "off"
     },
-    "parser": "babel-eslint",
     "settings": {
       "polyfills": [
         "Promise",
@@ -114,7 +113,6 @@
     "@babel/preset-env": "^7.5.0",
     "@babel/preset-react": "^7.0.0",
     "@cerner/eslint-config-terra": "^4.0.0",
-    "babel-eslint": "^10.1.0",
     "babel-jest": "^24.8.0",
     "browserslist-config-terra": "^1.0.0",
     "check-installed-dependencies": "^1.0.0",


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
eslint-config-terra now contains the dependency on babel-eslint and defaults it as our lint parser. we can remove those from this repo now.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #1203 

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
