### PR TITLE
[terra-abstract-modal] Fix CSP unsafe-inline violation.

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed
+  * Provide [inert styles](https://github.com/WICG/inert/pull/148/files#diff-04c6e90faac2675aa89e2176d2eec7d8R101-R111) as global styles.
+  * Injecting an empty link with id `inert-style` to head in order avoid CSP violations. 
+
 ## 3.28.0 - (August 4, 2020)
 
 * Changed

--- a/packages/terra-abstract-modal/src/AbstractModal.jsx
+++ b/packages/terra-abstract-modal/src/AbstractModal.jsx
@@ -93,6 +93,12 @@ const AbstractModal = (props) => {
   useLayoutEffect(() => {
     // eslint-disable-next-line no-prototype-builtins
     if (!Element.prototype.hasOwnProperty('inert')) {
+      const { head } = document;
+      if (!head.querySelector('link#inert-style')) {
+        const link = document.createElement('link');
+        link.id = 'inert-style';
+        head.appendChild(link);
+      }
       // IE10 throws an error if wicg-inert is imported too early, as wicg-inert tries to set an observer on document.body which may not exist on import
       // eslint-disable-next-line global-require
       require('wicg-inert/dist/inert');

--- a/packages/terra-abstract-modal/src/ModalContent.module.scss
+++ b/packages/terra-abstract-modal/src/ModalContent.module.scss
@@ -36,3 +36,19 @@
     }
   }
 }
+
+:global {
+  [inert] {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  [inert],
+  [inert] * {
+    /* stylelint-disable property-no-vendor-prefix */
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR provides [inert styles](https://github.com/WICG/inert/pull/148/files#diff-04c6e90faac2675aa89e2176d2eec7d8R101-R111) as global styles and injects an empty link with id inert-style to head to avoid CSP violation.

**Note:** Currently the deployed PR will have a style tag in head. It will be removed once the [overlay PR-3166](https://github.com/cerner/terra-core/pull/3166) and [application PR-89](https://github.com/cerner/terra-application/pull/89) are merged.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #1253 

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
