### PR TITLE
[terra-disclosure-manager] Issue-1228 Typo in API details

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ Cerner Corporation
 - Eric McCullough [@EricM96]
 - Dianna McGinn [@DMcginn]
 - Jeremy Fuksa [@jeremyfuksa]
+- Jason A Savage [@jasonsavage]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -73,3 +74,4 @@ Cerner Corporation
 [@EricM96]: https://github.com/EricM96
 [@DMcginn]: https://github.com/DMcginn
 [@jeremyfuksa]: https://github.com/jeremyfuksa
+[@jasonsavage]: https://github.com/TheSavageDev

--- a/packages/terra-disclosure-manager/CHANGELOG.md
+++ b/packages/terra-disclosure-manager/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Replaced 'size' with 'dimensions' in `disclose` API.
+
 ## 4.36.0 - (October 13, 2020)
 
 * Changed

--- a/packages/terra-disclosure-manager/src/terra-dev-site/doc/disclosure-manager/DisclosureManagerAPI.3.doc.mdx
+++ b/packages/terra-disclosure-manager/src/terra-dev-site/doc/disclosure-manager/DisclosureManagerAPI.3.doc.mdx
@@ -57,7 +57,7 @@ disclosureManager.disclose({
    * disclosure type or the available viewport size.
    * `dimensions` should not be provided if a `size` is specified.
    */
-  size: {
+  dimensions: {
     /**
      * Supported `height` values include: `'240'`, `'420'`, `'600'`, `'690'`, `'780'`, `'870'`, `'960'`,
      * `'1140'`.


### PR DESCRIPTION
- Changed 'size' to 'dimensions' in documentation.

### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Updating documentation to fix a typo.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #1288

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

I only change one word.
![Screen Shot 2020-10-28 at 10 21 59](https://user-images.githubusercontent.com/67115428/97457117-726acf00-1907-11eb-8c0e-383f1ce43806.png)

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra

