### PR TITLE
[Do Not Merge] Add browser to webpack module list

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@cerner/eslint-config-terra": "^4.0.0",
     "@cerner/terra-cli": "^1.1.0",
     "@cerner/terra-open-source-scripts": "^1.1.0",
-    "@cerner/webpack-config-terra": "^1.0.0-alpha.0",
+    "@cerner/webpack-config-terra": "https://github.com/cerner/terra-toolkit/blob/test-mainfields/packages/webpack-config-terra/cerner-webpack-config-terra-1.2.0.tgz?raw=true",
     "babel-jest": "^24.8.0",
     "check-installed-dependencies": "^1.0.0",
     "core-js": "^3.1.3",


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR is to test that adding `browser` to `resolve.mainFields` in `webpack-config-terra` doesn't break anything in the mono-repo.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Related to [terra-toolkit issue #522](https://github.com/cerner/terra-toolkit/issues/522)

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
