### PR TITLE
[terra-application-navigation] Apply theme context to popupmenu and drawermenu

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Changed
   * Updated Jest command
 
+* Fixed
+  * Applied theme context to drawer menu and popup menu
+
 ## 1.47.0 - (March 9, 2021)
 
 * Changed
@@ -14,7 +17,7 @@
   * Remove extraneous application bases from tests.
 
 * Added
-  * Adding an id to ApplicationNavigation now causes navigation, extesion, and utility items to have a unique id.
+  * Adding an id to ApplicationNavigation now causes navigation, extension, and utility items to have a unique id.
 
 * Fixed
   * Prevent error when using focus trap with react-intl v5

--- a/packages/terra-application-navigation/src/common/_PopupMenu.jsx
+++ b/packages/terra-application-navigation/src/common/_PopupMenu.jsx
@@ -2,7 +2,8 @@ import React, {
   useRef,
 } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames/bind';
+import classNamesBind from 'classnames/bind';
+import ThemeContext from 'terra-theme-context';
 import ActionFooter from 'terra-action-footer';
 import ContentContainer from 'terra-content-container';
 import Button from 'terra-button';
@@ -21,7 +22,7 @@ import PopupMenuUser from './_PopupMenuUser';
 
 import styles from './PopupMenu.module.scss';
 
-const cx = classNames.bind(styles);
+const cx = classNamesBind.bind(styles);
 
 const propTypes = {
   /**
@@ -184,6 +185,7 @@ const PopupMenu = ({
     );
   }
 
+  const theme = React.useContext(ThemeContext);
   /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
   /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
   return (
@@ -191,7 +193,7 @@ const PopupMenu = ({
       header={<ActionHeader aria-hidden title={title} />}
       footer={<ActionFooter end={endContent} />}
       fill={isHeightBounded}
-      className={cx('container')}
+      className={cx('container', theme.className)}
     >
       <div className={cx('content')}>
         {customContent ? (

--- a/packages/terra-application-navigation/src/drawer-menu/_DrawerMenu.jsx
+++ b/packages/terra-application-navigation/src/drawer-menu/_DrawerMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames/bind';
+import classNamesBind from 'classnames/bind';
+import ThemeContext from 'terra-theme-context';
 import IconSettings from 'terra-icon/lib/icon/IconSettings';
 import IconQuestionOutline from 'terra-icon/lib/icon/IconQuestionOutline';
 import { injectIntl } from 'react-intl';
@@ -19,7 +20,7 @@ import {
 
 import styles from './DrawerMenu.module.scss';
 
-const cx = classNames.bind(styles);
+const cx = classNamesBind.bind(styles);
 
 const propTypes = {
   /**
@@ -191,9 +192,10 @@ const DrawerMenu = ({
     );
   }
 
+  const theme = React.useContext(ThemeContext);
   /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
   return (
-    <div className={cx('drawer-container')}>
+    <div className={cx('drawer-container', theme.className)}>
       <div className={cx('drawer-menu')} role={hasItems ? 'dialog' : null} tabIndex={0} data-navigation-drawer-menu>
         <div className={cx('vertical-overflow-container')}>
           <div className={cx('header')}>

--- a/packages/terra-application-navigation/tests/jest/__snapshots__/ApplicationNavigation.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/__snapshots__/ApplicationNavigation.test.jsx.snap
@@ -104,7 +104,7 @@ exports[`ApplicationNavigation correctly applies the theme context className 1`]
                 utilityItems={Array []}
               >
                 <div
-                  className="drawer-container"
+                  className="drawer-container clinical-lowlight-theme"
                 >
                   <div
                     className="drawer-menu"


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Theme context was missing for the `_DrawerMenu` and the `_PopupMenu`, therefore making the application navigation popup menu and drawer menu appear to not be themed when dynamically switching themes with devsite. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #1394   _(originally [Terra-Application#133](https://github.com/cerner/terra-application/issues/133) )_

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framew-applicatio-68zdqb.herokuapp.com/components/terra-application-navigation/application-navigation/example

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
1. Go to deployment link
2. Change to lowlight-theme
3. Open User/Utilities Popup menu at large screen size
3. Open Navigation drawer at small screen size


### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
