### PR TITLE
[terra-application-navigation] Add z-index to drawer avatar

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * add z-index to address ambiguous layers across browsers.
+
 * Changed
   * Updated Swedish translations.
 

--- a/packages/terra-application-navigation/src/drawer-menu/DrawerMenuUser.module.scss
+++ b/packages/terra-application-navigation/src/drawer-menu/DrawerMenuUser.module.scss
@@ -4,6 +4,16 @@
 
 /* stylelint-disable selector-max-compound-selectors */
 :local {
+  // Z-index necessary to avoid browser dependant layout issues concerning images and box-shadow
+  .small-user-layout,
+  .large-user-layout {
+    z-index: 0;
+
+    .avatar-inner {
+      z-index: 0;
+    }
+  }
+
   .large-user-layout {
     align-items: center;
     display: flex;


### PR DESCRIPTION
### Summary
Add z-index to drawer avatar to address embedded browser issue.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
Standard test pass to ensure passivity. Validated against custom hardware setup manually.

Thank you for contributing to Terra.
@cerner/terra
