### PR TITLE
[terra-application-name] Update wdio tests to fix failing tests in themes

### DIFF
--- a/packages/terra-application-name/CHANGELOG.md
+++ b/packages/terra-application-name/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated `waitForDisplayed` to `waitForExist` to fix failing tests in themes.
+
 ## 3.38.0 - (June 8, 2021)
 
 * Changed

--- a/packages/terra-application-name/CHANGELOG.md
+++ b/packages/terra-application-name/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Updated `waitForDisplayed` to `waitForExist` to fix failing tests in themes.
+  * Updated `waitForDisplayed` to `waitForExist` to fix failing tests in cerner clinical theme.
 
 ## 3.38.0 - (June 8, 2021)
 

--- a/packages/terra-application-name/tests/wdio/application-header-name-spec.js
+++ b/packages/terra-application-name/tests/wdio/application-header-name-spec.js
@@ -1,7 +1,7 @@
 Terra.describeViewports('ApplicationHeaderName', ['tiny', 'medium'], () => {
   it('Displays a default application header name', () => {
     browser.url('/raw/tests/terra-application-name/application-name/application-header-name-default');
-    $('[class*="demo-image-container"]').waitForDisplayed();
+    $('[class*="demo-image-container"]').waitForExist();
     Terra.validates.element('application header name', { selector: '#default' });
   });
 


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR changes `waitForDisplayed` to `waitForExist` in wdio tests as [this](https://github.com/cerner/terra-framework/blob/main/packages/terra-application-name/src/ApplicationHeaderName.module.scss#L26) property in themes is set to `none`. Because of this tests are failing in themes.
### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
