### PR TITLE
[terra-notification-dialog] Correct upgrade guide

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,7 +10,7 @@ Cerner Corporation
 - Ismail Jones [@papasmile]
 - Alvin Cheung [@pseudofaux]
 - Stephen Esser [@StephenEsser]
-- Nathan Faltermeier [@Blackop778]
+- Nathan Faltermeier [@nfaltermeier]
 - Ben Boersma [@BenBoersma]
 - Alex Brisimitzakis [@AlexBrizi]
 - Adam Parker [@amichaelparker]
@@ -51,7 +51,7 @@ Cerner Corporation
 [@papasmile]: https://github.com/papasmile
 [@pseudofaux]: https://github.com/pseudofaux
 [@StephenEsser]: https://github.com/StephenEsser
-[@Blackop778]: https://github.com/Blackop778
+[@nfaltermeier]: https://github.com/nfaltermeier
 [@BenBoersma]: https://github.com/BenBoersma
 [@AlexBrizi]: https://github.com/AlexBrizi
 [@amichaelparker]: https://github.com/amichaelparker

--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Upgrade guide states to replace `secondaryAction` with `rejectAction` instead of `primaryAction` 
+
 ## 4.14.0 - (June 8, 2021)
 
 * Changed

--- a/packages/terra-notification-dialog/src/terra-dev-site/doc/notification-dialog/UpgradeGuide.2.doc.mdx
+++ b/packages/terra-notification-dialog/src/terra-dev-site/doc/notification-dialog/UpgradeGuide.2.doc.mdx
@@ -30,7 +30,7 @@ The latest changes to the Notification Dialog reflect risk vs non-risk situation
 - Removed `header` - create a custom notification dialog if a custom signal word is needed
 - Removed `customIcon` - use `custom.iconClassName` prop instead
 - Removed `primaryAction` - use `acceptAction` prop instead
-- Removed `secondaryAction` - use `acceptAction` prop instead
+- Removed `secondaryAction` - use `rejectAction` prop instead
 - Removed `message` - use `startMessage` prop instead
 - Removed `isOpen` - render NotificationDialog when it should be open
 


### PR DESCRIPTION
### Summary
The upgrade guide states to use `acceptAction` instead of both `primaryAction` and `secondaryAction`. `secondaryAction` can be seen to map to `rejectAction` [here](https://github.com/cerner/terra-framework/commit/6cd257b69caaffc815be1569edde8e242cbb71d1#diff-74e15fa34d531e4063a7d35c6bf8ff86087bb1647208d939fc45db811a3748bdL279) (expand `NotificationDialog.jsx` and it will jump to the linked line).

I've also updated my github username in the contributors file.

Thank you for contributing to Terra.
@cerner/terra
