### PR TITLE
Do not review - demo of announcing hour/minute/seconds

### DIFF
--- a/packages/terra-time-input/src/TimeInput.jsx
+++ b/packages/terra-time-input/src/TimeInput.jsx
@@ -93,6 +93,14 @@ const propTypes = {
    * If the `variant` prop if set to `12-hour` for one of these supported locales, the variant will be ignored and defaults to `24-hour`.
    */
   variant: PropTypes.oneOf([TimeUtil.FORMAT_12_HOUR, TimeUtil.FORMAT_24_HOUR]),
+
+  /** NEW!
+   * Human-readable label used for assistive technologies.
+   *
+   * If you have a visible label for this TimeInput, you should set this label
+   * to the same value.
+   */
+  label: PropTypes.string,
 };
 
 const defaultProps = {
@@ -112,6 +120,7 @@ const defaultProps = {
   showSeconds: false,
   value: undefined,
   variant: TimeUtil.FORMAT_24_HOUR,
+  label: 'Time Input',
 };
 
 class TimeInput extends React.Component {
@@ -664,6 +673,7 @@ class TimeInput extends React.Component {
       showSeconds,
       value,
       variant,
+      label,
       ...customProps
     } = this.props;
 
@@ -736,7 +746,18 @@ class TimeInput extends React.Component {
         ref={this.timeInputContainer}
         className={cx('time-input-container', theme.className)}
       >
-        <div className={timeInputClassNames}>
+        {/*
+        Grouping the input fields so that all of their values are announced at
+        once when any of the inputs are updated.
+         */}
+        <div
+          className={timeInputClassNames}
+          role="group"
+          aria-label={label}
+          aria-live="polite"
+          aria-atomic
+          aria-relevant="all"
+        >
           <input
             // Create a hidden input for storing the name and value attributes to use when submitting the form.
             // The data stored in the value attribute will be the visible date in the date input but in ISO 8601 format.

--- a/packages/terra-time-input/src/terra-dev-site/doc/example/TimeInputLabel.jsx
+++ b/packages/terra-time-input/src/terra-dev-site/doc/example/TimeInputLabel.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import TimeInput from 'terra-time-input';
+import classNames from 'classnames/bind';
+import styles from './TimeInputDocCommon.module.scss';
+
+const cx = classNames.bind(styles);
+
+class timeInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { time: '12:12' };
+    this.handleTimeChange = this.handleTimeChange.bind(this);
+  }
+
+  handleTimeChange(event, time) {
+    this.setState({ time });
+  }
+
+  render() {
+    return (
+      <div>
+        <p>
+          Time Provided:
+          <span className={cx('time-wrapper')}>{this.state.time}</span>
+        </p>
+        <TimeInput
+          name="time-input-value"
+          label="Wake-up time"
+          value={this.state.time}
+          onChange={this.handleTimeChange}
+        />
+      </div>
+    );
+  }
+}
+
+export default timeInput;

--- a/packages/terra-time-input/src/terra-dev-site/doc/time-input/TimeInput.1.doc.mdx
+++ b/packages/terra-time-input/src/terra-dev-site/doc/time-input/TimeInput.1.doc.mdx
@@ -11,6 +11,7 @@ import TimeInputSecondsWithDefault from '../example/TimeInputSecondsWithDefault?
 import TimeInputSecondsTwelveHour from '../example/TimeInputSecondsTwelveHour?dev-site-example';
 import TimeInputSecondsInvalid from '../example/TimeInputSecondsInvalid?dev-site-example';
 import TimeInputSecondsIncomplete from '../example/TimeInputSecondsIncomplete?dev-site-example';
+import TimeInputLabel from '../example/TimeInputLabel?dev-site-example';
 
 <Badge />
 
@@ -67,6 +68,9 @@ import TimeInput from 'terra-time-input';
 <TimeInputSecondsIncomplete title='Incomplete Time' description= 'Applies theme-specific styling for incomplete. 
 Note: Only use incomplete if given specific guidance, reserved for specific applications when no value has been provided. 
 Not for general use.' />
+
+<TimeInputLabel title='Label' description= 'Specify a label for use with 
+assistive technologies.' />
 
 ## Time Input Props Table 
 <TimeInputPropsTable />


### PR DESCRIPTION
### Summary
Using some aria and props so that the hours, minutes, and seconds are in context of the labeled time input field. Also, when any of those subfields are updated all of those fields will be announced at one time.

Known limitations to address: 
- Does not announce the full initial value when the user first enters the time input, it only announces the subfield.
- Does not announce AM or PM button selection.

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
