### PR TITLE
snaps changed from recent terra-core changes

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated snaps from consuming updated components.
+
 ## 4.71.0 - (November 16, 2021)
 
 * Changed

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -920,14 +920,12 @@ exports[`should render a DatePickerField with props 1`] = `
           aria-live="assertive"
           className="error-text"
           id="test-date-picker-error"
-          tabIndex="-1"
         >
           Text
         </div>
         <div
           className="help-text"
           id="test-date-picker-help"
-          tabIndex="-1"
         >
           <div
             aria-label="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat, Help"
@@ -1731,7 +1729,6 @@ exports[`should render a default DatePickerField component 1`] = `
         <div
           className="help-text"
           id="test-date-picker-help"
-          tabIndex="-1"
         >
           <div
             aria-label="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat"
@@ -2650,7 +2647,6 @@ exports[`should render a valid DatePickerField with props 1`] = `
         <div
           className="help-text"
           id="test-date-picker-help"
-          tabIndex="-1"
         >
           <div
             aria-label="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat, Help"

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated snaps for consuming updated components.
+
 ## 4.43.0 - (September 20, 2021)
 
 * Changed

--- a/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
+++ b/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
@@ -412,6 +412,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
       </button>
       <button
         aria-disabled="false"
+        aria-pressed="false"
         class="button neutral button-group-button meridiem-button"
         type="button"
       >
@@ -494,6 +495,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
       </button>
       <button
         aria-disabled="false"
+        aria-pressed="false"
         class="button neutral button-group-button meridiem-button"
         type="button"
       >
@@ -576,6 +578,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
       </button>
       <button
         aria-disabled="false"
+        aria-pressed="false"
         class="button neutral button-group-button meridiem-button"
         type="button"
       >
@@ -971,6 +974,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons and seconds in
     </button>
     <button
       aria-disabled="false"
+      aria-pressed="false"
       class="button neutral button-group-button meridiem-button"
       type="button"
     >
@@ -1056,6 +1060,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons when viewed on
     </button>
     <button
       aria-disabled="false"
+      aria-pressed="false"
       class="button neutral button-group-button meridiem-button"
       type="button"
     >


### PR DESCRIPTION
### Summary
While checking on main, I noticed that a couple snaps are different after consuming recent Terra Core changes around buttons. They seem legit to me.

### Deployment Link
TBD


### Additional Details
If I'm correct these update snaps are the result of consuming changes to NOT set tab indexen to -1 as often, and to add the aria-pressed attr to button groups.