### PR TITLE
Resolved dependency error

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Minor dependency version bump
+
 ## 1.59.0 - (November 16, 2021)
 
 * Changed

--- a/packages/terra-application-navigation/package.json
+++ b/packages/terra-application-navigation/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/cerner/terra-framework#readme",
   "devDependencies": {
-    "terra-application": "^1.12.0"
+    "terra-application": "^1.48.0"
   },
   "peerDependencies": {
     "react": "^16.8.5",


### PR DESCRIPTION
### Summary
I saw this error when running a fresh `npm install`:

```
lerna WARN EHOIST_ROOT_VERSION The repository root depends on terra-application@^1.48.0, which differs from the more common terra-application@^1.12.0.
lerna WARN EHOIST_PKG_VERSION "terra-application-navigation" package depends on terra-application@^1.12.0, which differs from the hoisted terra-application@^1.48.0.
```

This change fixes that error.

### Deployment Link
TBD

### Testing
No new tests. It's a minor version dependency change so I'm not too worried. Let's see how the CI does.