### PR TITLE
Easy jest debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "docs:peerDependencies": "node scripts/peer-dependency-generator/index.js",
     "heroku-postbuild": "npm install --only=dev && npm run compile:prod",
     "jest": "jest",
+    "jest:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "jest:coverage": "jest --coverage",
     "link-parent-bin": "link-parent-bin",
     "lint": "npm run lint:js && npm run lint:scss && npm run lint:package-json",


### PR DESCRIPTION
This PR makes it easy to start our jest task in a debuggable mode. Once `jest:debug` is run, you can [attach a debugger of your choice (e.g. Chrome, VS Code ...)](https://nodejs.org/en/docs/guides/debugging-getting-started/).

**How to use**
Step 1: Run the `jest:debug` task
![image](https://user-images.githubusercontent.com/52507228/150177390-2e4d00f0-428a-4e35-8afb-4794fdb9eb5a.png)

Step 2: Attach your debugger (e.g. in VS Code)
![image](https://user-images.githubusercontent.com/52507228/150178044-954908e4-5edd-4d99-b963-ed02b4904c93.png)
![image](https://user-images.githubusercontent.com/52507228/150178071-c2c81ca4-97bb-436d-8806-0af99d5ce1dc.png)

Step 3: Start the debugger! (e.g. in VS Code)
![image](https://user-images.githubusercontent.com/52507228/150178623-9ef4e8c1-dc12-41de-a9db-c32eb01d43a7.png)


