### PR TITLE
[terra-date-input] Keyboard shortcut detection fix for firefox

### DIFF
--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Changed keyboard shortcuts to detect via `event.key` instead of `event.keyCode`.
+
 ## 1.32.0 - (January 4, 2022)
 
 * Added

--- a/packages/terra-date-input/src/DateInput.jsx
+++ b/packages/terra-date-input/src/DateInput.jsx
@@ -253,13 +253,13 @@ class DateInput extends React.Component {
    * @param {DateInputUtil.inputType} inputType Type definition of the input that received the keydown event.
    */
   handleInputKeyDown(event, inputType) {
-    if (event.keyCode === KeyCode.KEY_T) {
+    if (event.key === 't' || event.key === 'T') {
       this.setHotKeyDate(event, 0);
       return;
-    } if (event.keyCode === KeyCode.KEY_DASH) {
+    } if (event.key === '-' || event.key === '_') {
       this.setHotKeyDate(event, -1);
       return;
-    } if (event.keyCode === KeyCode.KEY_EQUALS) {
+    } if (event.key === '=' || event.key === '+') {
       this.setHotKeyDate(event, 1);
       return;
     }


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Swaps to using `event.key` to detect keyboard shortcuts instead of `event.keyCode` since KeyCodes can differ between browsers. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
