### PR TITLE
Wrote a test harness for easier dev

### DIFF
--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Changed
   * Changed keyboard shortcuts to detect via `event.key` instead of `event.keyCode`.
+* Added
+  * Preliminary A11Y test harness for future enhancements.
 
 ## 1.32.0 - (January 4, 2022)
 

--- a/packages/terra-date-input/src/terra-dev-site/test/date-input/Accessibility.test.jsx
+++ b/packages/terra-date-input/src/terra-dev-site/test/date-input/Accessibility.test.jsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+
+import DateInputField from 'terra-date-input/lib/DateInputField';
+import DateInput from 'terra-date-input/lib/DateInput';
+import Checkbox from 'terra-form-checkbox';
+import Radio from 'terra-form-radio';
+import RadioField from 'terra-form-radio/lib/RadioField';
+import InputField from 'terra-form-input/lib/InputField';
+import CheckboxField from 'terra-form-checkbox/lib/CheckboxField';
+
+const Accessibility = () => {
+  const [value, setValue] = useState('');
+  const [disabled, setDisabled] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [mutex, setMutex] = useState('optional');
+  const [displayFormat, setDisplayFormat] = useState('month-day-year');
+  const [help, setHelp] = useState('Helpful text.');
+  const [error, setError] = useState('Something went wrong.');
+  const [showDateInput, setShowDateInput] = useState(true);
+  const [showDateInputField, setShowDateInputField] = useState(true);
+
+  function handleMutexChange(e) {
+    setMutex(e.currentTarget.value);
+  }
+
+  return (
+    <>
+      <div
+        id="dateInputFieldContainer"
+        hidden={!showDateInputField}
+      >
+        <h1 aria-hidden>DateInputField</h1>
+        <DateInputField
+          legend="Date of birth"
+          name="date-of-birth-field"
+          value={value}
+          onChange={(event, dateString) => setValue(dateString)}
+          error={error}
+          help={help}
+          isInvalid={isInvalid}
+          disabled={disabled}
+          displayFormat={displayFormat}
+          isIncomplete={mutex.includes('incomplete')}
+          required={mutex.includes('required')}
+        />
+      </div>
+      <div
+        id="dateInputContainer"
+        hidden={!showDateInput}
+      >
+        <h1 aria-hidden>DateInput</h1>
+        <DateInput
+          name="date-of-birth"
+          value={value}
+          onChange={(event, dateString) => setValue(dateString)}
+          isInvalid={isInvalid}
+          disabled={disabled}
+          isIncomplete={mutex.includes('incomplete')}
+          required={mutex.includes('required')}
+          hidden={!showDateInput}
+        />
+      </div>
+
+      <hr role="presentation" />
+
+      <div id="settings" aria-hidden>
+        <h1>Settings</h1>
+
+        <CheckboxField legend="Props">
+          <Checkbox id="disabled" labelText="disabled" onChange={() => setDisabled(val => !val)} />
+          <Checkbox id="isInvalid" labelText="isInvalid" onChange={() => setIsInvalid(val => !val)} />
+        </CheckboxField>
+
+        <InputField type="text" label="Error Message:" inputId="error" placeholder="Message to show when invalid" defaultValue={error} onInput={(e) => setError(e.currentTarget.value)} />
+        <InputField type="text" label="Help Message:" inputId="help" placeholder="Message to provide more detailed help" defaultValue={help} onInput={(e) => setHelp(e.currentTarget.value)} />
+
+        <RadioField legend="Mutually Exclusive">
+          <Radio
+            name="mutex"
+            id="optional"
+            labelText="optional"
+            value="optional"
+            onChange={handleMutexChange}
+            defaultChecked
+          />
+          <Radio
+            name="mutex"
+            id="required"
+            labelText="required"
+            value="required"
+            onChange={handleMutexChange}
+          />
+
+          <Radio
+            name="mutex"
+            id="required-incomplete"
+            labelText="required &amp; incomplete"
+            value="required-incomplete"
+            onChange={handleMutexChange}
+          />
+        </RadioField>
+
+        <RadioField legend="Format">
+          <Radio
+            name="format"
+            id="month-day-year"
+            labelText="month-day-year"
+            value="month-day-year"
+            defaultChecked
+            onChange={(e) => setDisplayFormat(e.currentTarget.value)}
+          />
+
+          <Radio
+            name="format"
+            id="day-month-year"
+            labelText="day-month-year"
+            value="day-month-year"
+            onChange={(e) => setDisplayFormat(e.currentTarget.value)}
+          />
+        </RadioField>
+
+        <CheckboxField legend="Show/Hide">
+          <Checkbox id="showField" labelText="Show DateInputField" defaultChecked onChange={(e) => setShowDateInputField(e.currentTarget.checked)} />
+          <Checkbox id="showInput" labelText="Show DateInput" defaultChecked onChange={(e) => setShowDateInput(e.currentTarget.checked)} />
+        </CheckboxField>
+      </div>
+    </>
+  );
+};
+
+export default Accessibility;

--- a/packages/terra-date-input/src/terra-dev-site/test/date-input/Accessibility.test.jsx
+++ b/packages/terra-date-input/src/terra-dev-site/test/date-input/Accessibility.test.jsx
@@ -19,8 +19,31 @@ const Accessibility = () => {
   const [showDateInput, setShowDateInput] = useState(true);
   const [showDateInputField, setShowDateInputField] = useState(true);
 
-  function handleMutexChange(e) {
-    setMutex(e.currentTarget.value);
+  /**
+   * Use this generator to pump out tedious RadioField + Radios.
+   * @param {string} legend The text of the legend tag.
+   * @param {string} name The name of every Radio
+   * @param {object} options A list of strings to serve as the key, id, labelText, and value of every Radio.
+   * @param {function} onChange The handler you want called for every Radio's `change` event.
+   * @returns A component like <RadioField …><Radio …>, … </RadioField>
+   */
+  function generateRadioField(legend, name, options, onChange) {
+    return (
+      <RadioField legend={legend}>
+        {options.map((opt, index) => (
+          <Radio
+            // https://reactjs.org/docs/lists-and-keys.html#keys
+            key={opt}
+            name={name}
+            id={opt}
+            defaultChecked={index === 0}
+            labelText={opt}
+            value={opt}
+            onChange={onChange}
+          />
+        ))}
+      </RadioField>
+    );
   }
 
   return (
@@ -42,6 +65,8 @@ const Accessibility = () => {
           displayFormat={displayFormat}
           isIncomplete={mutex.includes('incomplete')}
           required={mutex.includes('required')}
+          showOptional={mutex.includes('showOptional')}
+          hideRequired={mutex.includes('hideRequired')}
         />
       </div>
       <div
@@ -54,6 +79,7 @@ const Accessibility = () => {
           value={value}
           onChange={(event, dateString) => setValue(dateString)}
           isInvalid={isInvalid}
+          displayFormat={displayFormat}
           disabled={disabled}
           isIncomplete={mutex.includes('incomplete')}
           required={mutex.includes('required')}
@@ -74,50 +100,19 @@ const Accessibility = () => {
         <InputField type="text" label="Error Message:" inputId="error" placeholder="Message to show when invalid" defaultValue={error} onInput={(e) => setError(e.currentTarget.value)} />
         <InputField type="text" label="Help Message:" inputId="help" placeholder="Message to provide more detailed help" defaultValue={help} onInput={(e) => setHelp(e.currentTarget.value)} />
 
-        <RadioField legend="Mutually Exclusive">
-          <Radio
-            name="mutex"
-            id="optional"
-            labelText="optional"
-            value="optional"
-            onChange={handleMutexChange}
-            defaultChecked
-          />
-          <Radio
-            name="mutex"
-            id="required"
-            labelText="required"
-            value="required"
-            onChange={handleMutexChange}
-          />
+        {generateRadioField('Mutually Exclusive', 'mutex', [
+          'optional',
+          'optional-showOptional',
+          'required',
+          'required-hideRequired',
+          'required-incomplete',
+          'required-incomplete-hideRequired',
+        ], (e) => setMutex(e.currentTarget.value))}
 
-          <Radio
-            name="mutex"
-            id="required-incomplete"
-            labelText="required &amp; incomplete"
-            value="required-incomplete"
-            onChange={handleMutexChange}
-          />
-        </RadioField>
-
-        <RadioField legend="Format">
-          <Radio
-            name="format"
-            id="month-day-year"
-            labelText="month-day-year"
-            value="month-day-year"
-            defaultChecked
-            onChange={(e) => setDisplayFormat(e.currentTarget.value)}
-          />
-
-          <Radio
-            name="format"
-            id="day-month-year"
-            labelText="day-month-year"
-            value="day-month-year"
-            onChange={(e) => setDisplayFormat(e.currentTarget.value)}
-          />
-        </RadioField>
+        {generateRadioField('Format', 'format', [
+          'month-day-year',
+          'day-month-year',
+        ], (e) => setDisplayFormat(e.currentTarget.value))}
 
         <CheckboxField legend="Show/Hide">
           <Checkbox id="showField" labelText="Show DateInputField" defaultChecked onChange={(e) => setShowDateInputField(e.currentTarget.checked)} />


### PR DESCRIPTION
### Summary
I wrote this new test example to make enhancing A11Y easier. The harness gives you (or the tests) easy control over the components under test, and will save a lot of time and boilerplate test code - I can write several test scenarios against this one example. I can also rapidly check my changes against all the state possibilities. It also shows both the Field and the Input on one page so it is easy to see if a change in one plays well with the other.

![8CC8F44E-FB4A-4FB6-A08D-465F9900E740-64038-00003C4177A66BC4](https://user-images.githubusercontent.com/52507228/154734468-12a8b049-5552-4bc5-81b1-7c1be50ed162.gif)


### Deployment Link
TBD

### Testing
This is a test, so no testing :).