### PR TITLE
[terra-tabs, terra-menu] allow icons in terra-menu, show icons when tabs collapsed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ Cerner Corporation
 - Luissette Figueroa [@lfigueroa]
 - Andrew Shoemake [@ashoemake]
 - Ryan Rickard [@RLRickard]
+- Kevin Schuster [@kschuste]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -83,3 +84,4 @@ Cerner Corporation
 [@lfigueroa]: https://github.com/lcf-1
 [@ashoemake]: https://github.com/Andrew-Shoemake
 [@RLRickard]: https://github.com/RLRickard
+[@kschuste]: https://github.com/kschuste

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/menu/Menu.1.doc.mdx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/menu/Menu.1.doc.mdx
@@ -9,6 +9,7 @@ import BasicMenu from './example/BasicMenu?dev-site-example';
 import MenuBounded from './example/MenuBounded?dev-site-example';
 import MenuWidths from './example/MenuWidths?dev-site-example';
 import MenuWithInstructionsForUse from './example/MenuWithInstructionsForUse?dev-site-example';
+import MenuWithCustomIcons from './example/MenuWithCustomIcons?dev-site-example';
 
 <Badge />
 
@@ -51,6 +52,8 @@ import Menu from 'terra-menu';
 description="The Electronic Instructions For Use (eIFU) icon is a regulatory requirement for CE Mark Certification and Compliance, 
 and is used to indicate Help content that is the equivalent of a manufacturer\'s instruction manual. 
 The label for the Help menu option should be the name of the application followed by 'Help.'"  />
+<MenuWithCustomIcons title='Custom Icons for Menu Items'
+description="Allow for custom icons for menu items in the menu" />
 
 ## Menu Props Table 
 <MenuPropsTable />

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/menu/example/MenuWithCustomIcons.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/menu/example/MenuWithCustomIcons.jsx
@@ -1,0 +1,168 @@
+/* eslint-disable react/no-access-state-in-setstate */
+import React from 'react';
+import Button from 'terra-button';
+import PropTypes from 'prop-types';
+import IconWarning from 'terra-icon/lib/icon/IconWarning';
+import IconError from 'terra-icon/lib/icon/IconError';
+import IconAlert from 'terra-icon/lib/icon/IconAlert';
+import IconHelp from 'terra-icon/lib/icon/IconHelp';
+import IconRequired from 'terra-icon/lib/icon/IconRequired';
+import classNames from 'classnames/bind';
+import styles from './BasicMenu.module.scss';
+import Menu from '../../../../../../terra-menu/lib/Menu';
+
+const cx = classNames.bind(styles);
+
+const propTypes = {
+  isArrowDisplayed: PropTypes.bool,
+  contentWidth: PropTypes.string,
+  boundingRef: PropTypes.func,
+};
+
+class MenuWithCustomIcons extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleButtonClick = this.handleButtonClick.bind(this);
+    this.handleRequestClose = this.handleRequestClose.bind(this);
+    this.setButtonNode = this.setButtonNode.bind(this);
+    this.getButtonNode = this.getButtonNode.bind(this);
+    this.handleAction = this.handleAction.bind(this);
+    this.handleCloseOnClick = this.handleCloseOnClick.bind(this);
+    this.handleErrorClick = this.handleErrorClick.bind(this);
+    this.handleAlertClick = this.handleAlertClick.bind(this);
+    this.handleHelpClick = this.handleHelpClick.bind(this);
+    this.handleRequiredClick = this.handleRequiredClick.bind(this);
+    this.handleWarningClick = this.handleWarningClick.bind(this);
+    this.state = {
+      open: false,
+      actionClickCount: 0,
+      errorSelected: false,
+      alertSelected: false,
+      helpSelected: false,
+      requiredSelected: false,
+      warningSelected: false,
+    };
+  }
+
+  handleButtonClick() {
+    this.setState({ open: true });
+  }
+
+  handleErrorClick(event) {
+    event.preventDefault();
+    this.setState({ errorSelected: !this.state.errorSelected });
+    this.handleRequestClose();
+  }
+
+  handleAlertClick(event) {
+    event.preventDefault();
+    this.setState({ alertSelected: !this.state.alertSelected });
+    this.handleRequestClose();
+  }
+
+  handleHelpClick(event) {
+    event.preventDefault();
+    this.setState({ helpSelected: !this.state.helpSelected });
+    this.handleRequestClose();
+  }
+
+  handleRequiredClick(event) {
+    event.preventDefault();
+    this.setState({ requiredSelected: !this.state.requiredSelected });
+    this.handleRequestClose();
+  }
+
+  handleWarningClick(event) {
+    event.preventDefault();
+    this.setState({ warningSelected: !this.state.warningSelected });
+    this.handleRequestClose();
+  }
+
+  handleRequestClose() {
+    this.setState({ open: false });
+  }
+
+  handleCloseOnClick(event) {
+    event.preventDefault();
+    this.handleRequestClose();
+  }
+
+  handleAction(event) {
+    event.preventDefault();
+    const newState = this.state;
+    newState.actionClickCount += 1;
+    this.setState(newState);
+    this.handleRequestClose();
+  }
+
+  setButtonNode(node) {
+    this.buttonNode = node;
+  }
+
+  getButtonNode() {
+    return this.buttonNode;
+  }
+
+  render() {
+    return (
+      <div>
+        <div className={cx('menu-wrapper')} ref={this.setButtonNode}>
+          <Menu
+            isOpen={this.state.open}
+            targetRef={this.getButtonNode}
+            onRequestClose={this.handleRequestClose}
+            contentWidth={this.props.contentWidth}
+            isArrowDisplayed={this.props.isArrowDisplayed}
+            boundingRef={this.props.boundingRef}
+          >
+            <Menu.Item
+              text="Error Icon"
+              key="Error"
+              isSelected={this.state.errorSelected}
+              isSelectable
+              onClick={this.handleErrorClick}
+              menuIcon={<IconError className={cx('start-icon')} />}
+            />
+            <Menu.Item
+              text="Alert Icon"
+              key="Alert"
+              isSelected={this.state.alertSelected}
+              isSelectable
+              onClick={this.handleAlertClick}
+              menuIcon={<IconAlert className={cx('start-icon')} />}
+            />
+            <Menu.Item
+              text="Warning Icon"
+              key="Warning"
+              isSelected={this.state.warningSelected}
+              isSelectable
+              onClick={this.handleWarningClick}
+              menuIcon={<IconWarning className={cx('start-icon')} />}
+            />
+            <Menu.Item
+              text="Help Icon"
+              key="Help"
+              isSelected={this.state.helpSelected}
+              isSelectable
+              onClick={this.handleHelpClick}
+              menuIcon={<IconHelp className={cx('start-icon')} />}
+            />
+            <Menu.Item
+              text="Required Icon"
+              key="Required"
+              isSelected={this.state.requiredSelected}
+              isSelectable
+              onClick={this.handleRequiredClick}
+              menuIcon={<IconRequired className={cx('start-icon')} />}
+            />
+          </Menu>
+          <Button onClick={this.handleButtonClick} text="Help" />
+        </div>
+      </div>
+    );
+  }
+}
+
+MenuWithCustomIcons.propTypes = propTypes;
+
+export default MenuWithCustomIcons;

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/Tabs.1.doc.mdx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/Tabs.1.doc.mdx
@@ -8,6 +8,7 @@ import TabsTemplateExpanded from './example/TabsTemplateExpanded?dev-site-exampl
 import TabsWithFilledContent from './example/TabsWithFilledContent?dev-site-example';
 import IconOnlyTabs from './example/IconOnlyTabs?dev-site-example';
 import ResponsiveTabsVariant from './example/ResponsiveTabsVariant?dev-site-example';
+import IconsOnlyAndInMenuTabs from './example/IconsOnlyAndInMenuTabs?dev-site-example';
 
 <Badge />
 
@@ -71,6 +72,7 @@ import Tabs from 'terra-tabs';
 <IconOnlyTabs title='Icon Only' />
 <TabsWithFilledContent title='Fill Parent Container' />
 <ResponsiveTabsVariant title='Toggle responsiveTo Variants' />
+<IconsOnlyAndInMenuTabs title='Will Display Icons in Tab and Menu When Collapsed' />
 
 ## Tabs Props Table 
 <TabsPropsTable />

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/IconsOnlyAndInMenuTabs.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/IconsOnlyAndInMenuTabs.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import PropTypes from 'prop-types';
+import IconBriefcase from 'terra-icon/lib/icon/IconBriefcase';
+import IconSearch from 'terra-icon/lib/icon/IconSearch';
+import IconBookmark from 'terra-icon/lib/icon/IconBookmark';
+import IconCalendar from 'terra-icon/lib/icon/IconCalendar';
+import TabContent from './TabContentTemplate';
+import styles from './common/TabExample.module.scss';
+import Tabs from '../../../../../../terra-tabs/lib/Tabs';
+
+const propTypes = { responsiveTo: PropTypes.string };
+
+const cx = classNames.bind(styles);
+
+const IconsOnlyAndInMenuTabs = (props) => {
+  const searchTab = (
+    <Tabs.Pane label="Search" icon={<IconSearch />} showIconInTabAndMenuWhenCollapsed key="Search">
+      <TabContent label="Search" />
+    </Tabs.Pane>
+  );
+
+  const briefcaseTab = (
+    <Tabs.Pane label="Briefcase" icon={<IconBriefcase />} showIconInTabAndMenuWhenCollapsed key="Briefcase">
+      <TabContent label="Briefcase" />
+    </Tabs.Pane>
+  );
+
+  const bookmarkTab = (
+    <Tabs.Pane label="Bookmark" icon={<IconBookmark />} showIconInTabAndMenuWhenCollapsed key="Bookmark">
+      <TabContent label="Bookmark" />
+    </Tabs.Pane>
+  );
+
+  const calendarTab = (
+    <Tabs.Pane label="Calendar" icon={<IconCalendar />} showIconInTabAndMenuWhenCollapsed key="Calendar">
+      <TabContent label="Calendar" />
+    </Tabs.Pane>
+  );
+
+  return (
+    <div className={cx('content-wrapper')}>
+      <Tabs responsiveTo={props.responsiveTo}>
+        {searchTab}
+        {briefcaseTab}
+        {bookmarkTab}
+        {calendarTab}
+      </Tabs>
+    </div>
+  );
+};
+
+IconsOnlyAndInMenuTabs.propTypes = propTypes;
+
+export default IconsOnlyAndInMenuTabs;

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Allow for custom icons to be shown in menu
+
 ## 6.61.0 - (March 15, 2022)
 
 * Added

--- a/packages/terra-menu/package.json
+++ b/packages/terra-menu/package.json
@@ -34,6 +34,7 @@
     "terra-icon": "^3.19.0",
     "terra-list": "^4.0.0",
     "terra-popup": "^6.61.0",
+    "terra-spacer": "^3.0.0",
     "terra-theme-context": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/terra-menu/src/Menu.jsx
+++ b/packages/terra-menu/src/Menu.jsx
@@ -58,6 +58,10 @@ const propTypes = {
    * Header Title will only be visible if the main-menu contains at least one sub-menu.
    */
   headerTitle: PropTypes.string,
+  /**
+   * Custom icon to display in the menu
+   */
+  menuIcon: PropTypes.element,
 };
 
 const defaultProps = {
@@ -125,6 +129,7 @@ class Menu extends React.Component {
       targetRef,
       isArrowDisplayed,
       contentWidth,
+      menuIcon,
       ...customProps
     } = this.props;
     const arrowClass = cx([
@@ -151,6 +156,7 @@ class Menu extends React.Component {
         boundingRef={boundingRef}
         isFocused={index === visiblePage}
         headerTitle={this.props.headerTitle}
+        menuIcon={menuIcon}
       >
         {item.props.children || item.props.subMenuItems}
       </MenuContent>

--- a/packages/terra-menu/src/MenuItem.jsx
+++ b/packages/terra-menu/src/MenuItem.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
 import * as KeyCode from 'keycode-js';
+import Spacer from 'terra-spacer';
 import styles from './MenuItem.module.scss';
 
 const cx = classNamesBind.bind(styles);
@@ -62,6 +63,11 @@ const propTypes = {
    * Indicates if the item has focus. This is used internally to control focus and does not set initial focus.
    */
   isActive: PropTypes.bool,
+
+  /**
+   * Custom icon to display in the menu
+   */
+  menuIcon: PropTypes.element,
 };
 
 const defaultProps = {
@@ -165,6 +171,7 @@ class MenuItem extends React.Component {
       isSelectable,
       subMenuItems,
       isActive,
+      menuIcon,
       ...customProps
     } = this.props;
 
@@ -201,10 +208,14 @@ class MenuItem extends React.Component {
     ]);
 
     let content = textContainer;
-    if (hasChevron || isSelectableMenu || isInstructionsForUse) {
+    if (hasChevron || isSelectableMenu || isInstructionsForUse || menuIcon) {
       let fitStartIcon = null;
       if (isInstructionsForUse) {
         fitStartIcon = <InstructionsForUseIcon className={cx('start-icon')} />;
+      } else if (menuIcon && isSelectableMenu && markAsSelected) {
+        fitStartIcon = <CheckIcon className={cx(['checkmark', 'start-icon'])} />;
+      } else if (menuIcon) {
+        fitStartIcon = (<Spacer marginLeft="small">{menuIcon}</Spacer>);
       } else if (isSelectableMenu) {
         fitStartIcon = <CheckIcon className={cx(['checkmark', 'start-icon'])} />;
       }

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Allow for icons to be shown in tabs when collapsed
+
 ## 6.61.0 - (March 15, 2022)
 
 * Added

--- a/packages/terra-tabs/package.json
+++ b/packages/terra-tabs/package.json
@@ -35,6 +35,7 @@
     "terra-icon": "^3.19.0",
     "terra-menu": "^6.61.0",
     "terra-responsive-element": "^5.0.0",
+    "terra-spacer": "^3.0.0",
     "terra-theme-context": "^1.8.0"
   },
   "scripts": {

--- a/packages/terra-tabs/src/TabPane.jsx
+++ b/packages/terra-tabs/src/TabPane.jsx
@@ -40,12 +40,17 @@ const propTypes = {
    * If enabled, this prop will apply the `aria-selected` style to the pane.
    */
   isActive: PropTypes.bool,
+  /**
+   * If enabled, this prop will show the icon when the tab is collapsed when it is selected and in the drop down menu.
+   */
+  showIconInTabAndMenuWhenCollapsed: PropTypes.bool,
 };
 
 const defaultProps = {
   isDisabled: false,
   isIconOnly: false,
   isActive: false,
+  showIconInTabAndMenuWhenCollapsed: false,
 };
 
 const TabPane = ({

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -206,7 +206,11 @@ class Tabs extends React.Component {
 
       if (responsiveTo === 'parent' || responsiveTo === 'window') {
         const collapsedTabs = (
-          <CollapsedTabs activeKey={activeKey || this.state.activeKey} onTruncationChange={this.handleTruncationChange}>
+          <CollapsedTabs
+            activeKey={activeKey || this.state.activeKey}
+            activeIndex={this.getActiveTabIndex()}
+            onTruncationChange={this.handleTruncationChange}
+          >
             {clonedPanes}
           </CollapsedTabs>
         );

--- a/packages/terra-tabs/src/Tabs.module.scss
+++ b/packages/terra-tabs/src/Tabs.module.scss
@@ -5,6 +5,12 @@
 @import './orion-fusion-theme/Tabs.module';
 
 :local {
+  .active-tab-icon {  
+    svg {
+      font-size: initial !important;
+    }
+  }
+  
   .tabs-container {
     width: 100%;
   }

--- a/packages/terra-tabs/src/_CollapsedTabs.jsx
+++ b/packages/terra-tabs/src/_CollapsedTabs.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
-import Menu from './_TabMenu';
+import TabMenu from './_TabMenu';
 import styles from './Tabs.module.scss';
 
 const cx = classNames.bind(styles);
@@ -12,6 +12,11 @@ const propTypes = {
    * Key of the current active tab.
    */
   activeKey: PropTypes.string,
+
+  /**
+   * Index of the current active tab.
+   */
+  activeIndex: PropTypes.number.isRequired,
 
   /**
    * Tabs to display in menu.
@@ -28,11 +33,13 @@ const propTypes = {
 const CollapsedTabs = (props) => {
   props.onTruncationChange(false);
   const theme = React.useContext(ThemeContext);
+
+  const selectedTab = props.children[props.activeIndex];
   return (
     <div className={cx('collapsed-tabs-container', theme.className)}>
-      <Menu activeKey={props.activeKey}>
+      <TabMenu activeKey={props.activeKey} selectedTab={selectedTab}>
         {props.children}
-      </Menu>
+      </TabMenu>
     </div>
   );
 };

--- a/packages/terra-tabs/src/_CollapsibleTabs.jsx
+++ b/packages/terra-tabs/src/_CollapsibleTabs.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
 import ResizeObserver from 'resize-observer-polyfill';
 import * as KeyCode from 'keycode-js';
-import Menu from './_TabMenu';
+import TabMenu from './_TabMenu';
 import styles from './Tabs.module.scss';
 
 const cx = classNames.bind(styles);
@@ -259,11 +259,17 @@ class CollapsibleTabs extends React.Component {
       }
     });
     const theme = this.context;
+    const selectedTab = this.props.children[this.props.activeIndex];
 
     const menu = this.menuHidden ? null : (
-      <Menu onKeyDown={this.handleMenuOnKeyDown} refCallback={this.setMenuRef} activeKey={this.props.activeKey}>
+      <TabMenu
+        onKeyDown={this.handleMenuOnKeyDown}
+        refCallback={this.setMenuRef}
+        activeKey={this.props.activeKey}
+        selectedTab={selectedTab}
+      >
         {hiddenChildren}
-      </Menu>
+      </TabMenu>
     );
 
     const selectionBar = this.props.variant === 'modular-centered' || this.props.variant === 'modular-left-aligned' ? (

--- a/packages/terra-tabs/src/_TabMenu.jsx
+++ b/packages/terra-tabs/src/_TabMenu.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
-import Menu from 'terra-menu';
 import IconCaretDown from 'terra-icon/lib/icon/IconCaretDown';
 import * as KeyCode from 'keycode-js';
 import { FormattedMessage } from 'react-intl';
+import Spacer from 'terra-spacer';
 import styles from './Tabs.module.scss';
+import Menu from '../../terra-menu/lib/Menu';
 
 const cx = classNames.bind(styles);
 
@@ -25,6 +26,11 @@ const propTypes = {
    * Ref callback for menu toggle.
    */
   refCallback: PropTypes.func,
+
+  /**
+   * The current active tab
+   */
+  selectedTab: PropTypes.element,
 };
 
 class TabMenu extends React.Component {
@@ -86,7 +92,7 @@ class TabMenu extends React.Component {
 
     React.Children.forEach(this.props.children, (child) => {
       const {
-        label, customDisplay, icon, isIconOnly, ...otherProps
+        label, customDisplay, icon, isIconOnly, showIconInTabAndMenuWhenCollapsed, ...otherProps
       } = child.props;
       let isSelected = false;
 
@@ -103,10 +109,17 @@ class TabMenu extends React.Component {
           isSelected={isSelected}
           isSelectable
           key={child.key}
+          menuIcon={(showIconInTabAndMenuWhenCollapsed) ? icon : null}
         />
       ));
     });
     const theme = this.context;
+    let icon = null;
+    if (this.props.selectedTab) {
+      if (this.props.selectedTab.props.icon && this.props.selectedTab.props.showIconInTabAndMenuWhenCollapsed) {
+        icon = (<Spacer className={cx('active-tab-icon')} marginRight="small">{this.props.selectedTab.props.icon}</Spacer>);
+      }
+    }
 
     return (
       <div
@@ -118,6 +131,7 @@ class TabMenu extends React.Component {
         className={cx('tab-menu', { 'is-active': menuActive }, theme.className)}
         data-terra-tabs-menu
       >
+        {icon}
         <FormattedMessage id="Terra.tabs.more">
           {menuToggleText => (
             <span>{toggleText || menuToggleText}</span>
@@ -128,6 +142,7 @@ class TabMenu extends React.Component {
           onRequestClose={this.handleOnRequestClose}
           targetRef={this.getTargetRef}
           isOpen={this.state.isOpen}
+          menuIcon={icon}
         >
           {menuItems}
         </Menu>

--- a/packages/terra-tabs/tests/jest/__snapshots__/TabPane.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/TabPane.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`TabPane correctly applies the theme context className 1`] = `
   aria-selected={false}
   className="tab is-text-only orion-fusion-theme customClass"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <span
     className="label"
@@ -19,6 +20,7 @@ exports[`TabPane should render a default component with label 1`] = `
   aria-selected={false}
   className="tab is-text-only"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <span
     className="label"
@@ -33,6 +35,7 @@ exports[`TabPane should render as disabled when indicated 1`] = `
   aria-selected={false}
   className="tab is-disabled is-text-only"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <span
     className="label"
@@ -47,6 +50,7 @@ exports[`TabPane should render with a custom display when provided 1`] = `
   aria-selected={false}
   className="tab is-text-only"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <div>
     Custom Display
@@ -59,6 +63,7 @@ exports[`TabPane should render with custom props 1`] = `
   aria-selected={false}
   className="tab is-text-only customClass"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <span
     className="label"
@@ -73,6 +78,7 @@ exports[`TabPane should render with icon and label 1`] = `
   aria-selected={false}
   className="tab"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <div>
     Fake icon
@@ -91,6 +97,7 @@ exports[`TabPane should render with icon only when indicated 1`] = `
   aria-selected={false}
   className="tab is-icon-only"
   role="tab"
+  showIconInTabAndMenuWhenCollapsed={false}
 >
   <div>
     Fake icon

--- a/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
@@ -50,6 +50,7 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
           responsiveTo="parent"
         >
           <CollapsedTabs
+            activeIndex={0}
             activeKey="default"
             onTruncationChange={[Function]}
           >
@@ -60,6 +61,7 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
               isIconOnly={false}
               label="Default"
               onClick={[Function]}
+              showIconInTabAndMenuWhenCollapsed={false}
             />
           </CollapsedTabs>
         </ResponsiveElement>
@@ -78,6 +80,7 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
             responsiveTo="parent"
           >
             <CollapsedTabs
+              activeIndex={0}
               activeKey="default"
               onTruncationChange={[Function]}
             >
@@ -86,6 +89,17 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
               >
                 <TabMenu
                   activeKey="default"
+                  selectedTab={
+                    <TabPane
+                      className="is-active"
+                      isActive={true}
+                      isDisabled={false}
+                      isIconOnly={false}
+                      label="Default"
+                      onClick={[Function]}
+                      showIconInTabAndMenuWhenCollapsed={false}
+                    />
+                  }
                 >
                   <div
                     className="tab-menu is-active orion-fusion-theme"
@@ -140,6 +154,7 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
                       headerTitle=""
                       isArrowDisplayed={false}
                       isOpen={false}
+                      menuIcon={null}
                       onRequestClose={[Function]}
                       targetRef={[Function]}
                     >
@@ -213,6 +228,7 @@ exports[`Tabs Responsiveness should render tabs that are responsive to the paren
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsibleTabs>
     </ResponsiveElement>
@@ -275,6 +291,7 @@ exports[`Tabs Responsiveness should render tabs that are responsive to the windo
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsibleTabs>
     </ResponsiveElement>
@@ -333,6 +350,7 @@ exports[`Tabs Responsiveness should render tabs that do not completely collapse 
         isIconOnly={false}
         label="Default"
         onClick={[Function]}
+        showIconInTabAndMenuWhenCollapsed={false}
       />
     </CollapsibleTabs>
   }
@@ -394,6 +412,7 @@ exports[`Tabs Variants should render modular-centered tabs 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsibleTabs>
     </ResponsiveElement>
@@ -444,6 +463,7 @@ exports[`Tabs Variants should render modular-left-aligned tabs 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -454,6 +474,7 @@ exports[`Tabs Variants should render modular-left-aligned tabs 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -504,6 +525,7 @@ exports[`Tabs Variants should render structural tabs 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -514,6 +536,7 @@ exports[`Tabs Variants should render structural tabs 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -577,6 +600,7 @@ exports[`Tabs should render a controlled component when onChange and activeKey a
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsibleTabs>
     </ResponsiveElement>
@@ -639,6 +663,7 @@ exports[`Tabs should render a default component 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsibleTabs>
     </ResponsiveElement>
@@ -688,6 +713,7 @@ exports[`Tabs should render an id based on the Tabs id and the Tab key 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -698,6 +724,7 @@ exports[`Tabs should render an id based on the Tabs id and the Tab key 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -749,6 +776,7 @@ exports[`Tabs should render an uncontrolled component when defaultActiveKey is s
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -759,6 +787,7 @@ exports[`Tabs should render an uncontrolled component when defaultActiveKey is s
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -808,6 +837,7 @@ exports[`Tabs should render with content filled when indicated 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -818,6 +848,7 @@ exports[`Tabs should render with content filled when indicated 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -867,6 +898,7 @@ exports[`Tabs should render with tabs filled when indicated 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -877,6 +909,7 @@ exports[`Tabs should render with tabs filled when indicated 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -927,6 +960,7 @@ exports[`Tabs should set custom props 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -937,6 +971,7 @@ exports[`Tabs should set custom props 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>
@@ -986,6 +1021,7 @@ exports[`Tabs should set custom props for child Tab Pane 1`] = `
       responsiveTo="parent"
     >
       <CollapsedTabs
+        activeIndex={0}
         activeKey="default"
         onTruncationChange={[Function]}
       >
@@ -996,6 +1032,7 @@ exports[`Tabs should set custom props for child Tab Pane 1`] = `
           isIconOnly={false}
           label="Default"
           onClick={[Function]}
+          showIconInTabAndMenuWhenCollapsed={false}
         />
       </CollapsedTabs>
     </ResponsiveElement>


### PR DESCRIPTION
### Summary
We currently have a use case where we want to warning icons in the tabs component. This included when the tabs are collapsed and the menu shown. We may have different types of warning icons across multiple tabs. Currently, when the tabs are collapsed, they are not shown in the tab or in the menu. This PR will allow for the icons to still display when the tabs are collapsed into 1 and to display the icons in the menu as well.

Closes #1569 
Closes #1570 

### Deployment Link
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
Have tested these changes locally that they are passive.

### Additional Details
<img width="578" alt="Screen Shot 2022-09-12 at 2 58 05 PM" src="https://user-images.githubusercontent.com/1711642/189906529-9354a6c6-c29a-4bcc-852b-c222963453fc.png">


![Screen Shot 2022-09-13 at 7 54 37 AM](https://user-images.githubusercontent.com/1711642/189906628-2895f6a0-690c-4290-bf1a-814545438ed9.png)

Thank you for contributing to Terra.
@cerner/terra
