### PR TITLE
[Terra-Tabs] Fixed console warnings and travis build issue.

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated jest snapshot for decorative icon changes.
+
 ## 1.60.0 - (December 13, 2022)
 
 * Fixed

--- a/packages/terra-application-navigation/tests/jest/header/__snapshots__/CompactHeader.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/header/__snapshots__/CompactHeader.test.jsx.snap
@@ -214,7 +214,6 @@ exports[`CompactHeader should render title element 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <IconBase
-            ariaLabel={null}
             data-name="Layer 1"
             focusable="false"
             height="1em"
@@ -225,11 +224,11 @@ exports[`CompactHeader should render title element 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
-              aria-hidden="true"
               className="tui-Icon icon"
               data-name="Layer 1"
               focusable="false"
               height="1em"
+              role="presentation"
               viewBox="0 0 48 48"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"
@@ -445,7 +444,6 @@ exports[`CompactHeader should render with function callbacks 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <IconBase
-            ariaLabel={null}
             data-name="Layer 1"
             focusable="false"
             height="1em"
@@ -456,11 +454,11 @@ exports[`CompactHeader should render with function callbacks 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
-              aria-hidden="true"
               className="tui-Icon icon"
               data-name="Layer 1"
               focusable="false"
               height="1em"
+              role="presentation"
               viewBox="0 0 48 48"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"
@@ -831,7 +829,6 @@ exports[`CompactHeader should render with ids for navigation and extension items
           xmlns="http://www.w3.org/2000/svg"
         >
           <IconBase
-            ariaLabel={null}
             data-name="Layer 1"
             focusable="false"
             height="1em"
@@ -842,11 +839,11 @@ exports[`CompactHeader should render with ids for navigation and extension items
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
-              aria-hidden="true"
               className="tui-Icon icon"
               data-name="Layer 1"
               focusable="false"
               height="1em"
+              role="presentation"
               viewBox="0 0 48 48"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"
@@ -1161,7 +1158,6 @@ exports[`CompactHeader should render with menu callback 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <IconBase
-            ariaLabel={null}
             data-name="Layer 1"
             focusable="false"
             height="1em"
@@ -1172,11 +1168,11 @@ exports[`CompactHeader should render with menu callback 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
-              aria-hidden="true"
               className="tui-Icon icon"
               data-name="Layer 1"
               focusable="false"
               height="1em"
+              role="presentation"
               viewBox="0 0 48 48"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-application-navigation/tests/jest/header/__snapshots__/Header.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/header/__snapshots__/Header.test.jsx.snap
@@ -1067,7 +1067,6 @@ exports[`Header should render with function callbacks 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <IconBase
-                  ariaLabel={null}
                   className="caret-icon"
                   focusable="false"
                   height="1em"
@@ -1078,10 +1077,10 @@ exports[`Header should render with function callbacks 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <svg
-                    aria-hidden="true"
                     className="tui-Icon icon is-bidi caret-icon"
                     focusable="false"
                     height="1em"
+                    role="presentation"
                     viewBox="0 0 48 48"
                     width="1em"
                     xmlns="http://www.w3.org/2000/svg"
@@ -1854,7 +1853,6 @@ exports[`Header should render with navigation and extension item ids 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <IconBase
-                  ariaLabel={null}
                   className="caret-icon"
                   focusable="false"
                   height="1em"
@@ -1865,10 +1863,10 @@ exports[`Header should render with navigation and extension item ids 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <svg
-                    aria-hidden="true"
                     className="tui-Icon icon is-bidi caret-icon"
                     focusable="false"
                     height="1em"
+                    role="presentation"
                     viewBox="0 0 48 48"
                     width="1em"
                     xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
@@ -596,7 +596,6 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <IconBase
-                            ariaLabel={null}
                             data-name="Layer 1"
                             focusable="false"
                             height="1em"
@@ -607,11 +606,11 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-hidden="true"
                               className="tui-Icon icon"
                               data-name="Layer 1"
                               focusable="false"
                               height="1em"
+                              role="presentation"
                               viewBox="0 0 48 48"
                               width="1em"
                               xmlns="http://www.w3.org/2000/svg"
@@ -678,7 +677,6 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <IconBase
-                            ariaLabel={null}
                             focusable="false"
                             height="1em"
                             isBidi={false}
@@ -688,10 +686,10 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-hidden="true"
                               className="tui-Icon icon"
                               focusable="false"
                               height="1em"
+                              role="presentation"
                               viewBox="0 0 48 48"
                               width="1em"
                               xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenuHeaderButton.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenuHeaderButton.test.jsx.snap
@@ -79,7 +79,6 @@ exports[`UtilityMenuHeaderButton should render default element 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <IconBase
-            ariaLabel={null}
             className="IconRollup rollup-icon"
             focusable="false"
             height="1em"
@@ -90,10 +89,10 @@ exports[`UtilityMenuHeaderButton should render default element 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
-              aria-hidden="true"
               className="tui-Icon icon IconRollup rollup-icon"
               focusable="false"
               height="1em"
+              role="presentation"
               viewBox="0 0 48 48"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"
@@ -193,7 +192,6 @@ exports[`UtilityMenuHeaderButton should render with click callback 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <IconBase
-            ariaLabel={null}
             className="IconRollup rollup-icon"
             focusable="false"
             height="1em"
@@ -204,10 +202,10 @@ exports[`UtilityMenuHeaderButton should render with click callback 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
-              aria-hidden="true"
               className="tui-Icon icon IconRollup rollup-icon"
               focusable="false"
               height="1em"
+              role="presentation"
               viewBox="0 0 48 48"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"
@@ -391,7 +389,6 @@ exports[`UtilityMenuHeaderButton should render with function callbacks 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <IconBase
-          ariaLabel={null}
           className="caret-icon"
           focusable="false"
           height="1em"
@@ -402,10 +399,10 @@ exports[`UtilityMenuHeaderButton should render with function callbacks 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <svg
-            aria-hidden="true"
             className="tui-Icon icon is-bidi caret-icon"
             focusable="false"
             height="1em"
+            role="presentation"
             viewBox="0 0 48 48"
             width="1em"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated jest snapshot for decorative icon changes.
+
 ## 4.75.0 - (December 13, 2022)
 
 * Fixed

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -349,7 +349,6 @@ exports[`correctly applies the theme context className 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <IconBase
-                      ariaLabel={null}
                       className="icon-svg"
                       focusable="false"
                       height="1em"
@@ -360,10 +359,10 @@ exports[`correctly applies the theme context className 1`] = `
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <svg
-                        aria-hidden="true"
                         className="tui-Icon icon icon-svg"
                         focusable="false"
                         height="1em"
+                        role="presentation"
                         viewBox="0 0 48 48"
                         width="1em"
                         xmlns="http://www.w3.org/2000/svg"
@@ -413,10 +412,10 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
                 class="icon"
               >
                 <svg
-                  aria-hidden="true"
                   class="tui-Icon icon icon-svg"
                   focusable="false"
                   height="1em"
+                  role="presentation"
                   viewBox="0 0 48 48"
                   width="1em"
                   xmlns="http://www.w3.org/2000/svg"
@@ -738,10 +737,10 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
                       class="icon"
                     >
                       <svg
-                        aria-hidden="true"
                         class="tui-Icon icon icon-svg"
                         focusable="false"
                         height="1em"
+                        role="presentation"
                         viewBox="0 0 48 48"
                         width="1em"
                         xmlns="http://www.w3.org/2000/svg"
@@ -794,7 +793,6 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <IconBase
-                  ariaLabel={null}
                   className="icon-svg"
                   focusable="false"
                   height="1em"
@@ -805,10 +803,10 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <svg
-                    aria-hidden="true"
                     className="tui-Icon icon icon-svg"
                     focusable="false"
                     height="1em"
+                    role="presentation"
                     viewBox="0 0 48 48"
                     width="1em"
                     xmlns="http://www.w3.org/2000/svg"
@@ -916,10 +914,10 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
           class="icon"
         >
           <svg
-            aria-hidden="true"
             class="tui-Icon icon icon-svg"
             focusable="false"
             height="1em"
+            role="presentation"
             viewBox="0 0 48 48"
             width="1em"
             xmlns="http://www.w3.org/2000/svg"
@@ -1023,10 +1021,10 @@ exports[`should render a date input with isInvalid prop 1`] = `
           class="icon"
         >
           <svg
-            aria-hidden="true"
             class="tui-Icon icon icon-svg"
             focusable="false"
             height="1em"
+            role="presentation"
             viewBox="0 0 48 48"
             width="1em"
             xmlns="http://www.w3.org/2000/svg"
@@ -1130,10 +1128,10 @@ exports[`should render a default date input 1`] = `
           class="icon"
         >
           <svg
-            aria-hidden="true"
             class="tui-Icon icon icon-svg"
             focusable="false"
             height="1em"
+            role="presentation"
             viewBox="0 0 48 48"
             width="1em"
             xmlns="http://www.w3.org/2000/svg"
@@ -1178,10 +1176,10 @@ exports[`should render a default date input with all props 1`] = `
                 class="icon"
               >
                 <svg
-                  aria-hidden="true"
                   class="tui-Icon icon icon-svg"
                   focusable="false"
                   height="1em"
+                  role="presentation"
                   viewBox="0 0 48 48"
                   width="1em"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1526,10 +1524,10 @@ exports[`should render a default date input with all props 1`] = `
                       class="icon"
                     >
                       <svg
-                        aria-hidden="true"
                         class="tui-Icon icon icon-svg"
                         focusable="false"
                         height="1em"
+                        role="presentation"
                         viewBox="0 0 48 48"
                         width="1em"
                         xmlns="http://www.w3.org/2000/svg"
@@ -1582,7 +1580,6 @@ exports[`should render a default date input with all props 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <IconBase
-                  ariaLabel={null}
                   className="icon-svg"
                   focusable="false"
                   height="1em"
@@ -1593,10 +1590,10 @@ exports[`should render a default date input with all props 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <svg
-                    aria-hidden="true"
                     className="tui-Icon icon icon-svg"
                     focusable="false"
                     height="1em"
+                    role="presentation"
                     viewBox="0 0 48 48"
                     width="1em"
                     xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -572,7 +572,6 @@ exports[`correctly applies the theme context className 1`] = `
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <IconBase
-                                    ariaLabel={null}
                                     className="icon-svg"
                                     focusable="false"
                                     height="1em"
@@ -583,10 +582,10 @@ exports[`correctly applies the theme context className 1`] = `
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <svg
-                                      aria-hidden="true"
                                       className="tui-Icon icon icon-svg"
                                       focusable="false"
                                       height="1em"
+                                      role="presentation"
                                       viewBox="0 0 48 48"
                                       width="1em"
                                       xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -203,7 +203,6 @@ exports[`should render a DatePickerField with props 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <IconBase
-                ariaLabel={null}
                 className="IconError"
                 focusable="false"
                 height="1em"
@@ -214,10 +213,10 @@ exports[`should render a DatePickerField with props 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <svg
-                  aria-hidden="true"
                   className="tui-Icon icon IconError"
                   focusable="false"
                   height="1em"
+                  role="presentation"
                   viewBox="0 0 48 48"
                   width="1em"
                   xmlns="http://www.w3.org/2000/svg"
@@ -876,7 +875,6 @@ exports[`should render a DatePickerField with props 1`] = `
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
                                         <IconBase
-                                          ariaLabel={null}
                                           className="icon-svg"
                                           focusable="false"
                                           height="1em"
@@ -887,10 +885,10 @@ exports[`should render a DatePickerField with props 1`] = `
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            aria-hidden="true"
                                             className="tui-Icon icon icon-svg"
                                             focusable="false"
                                             height="1em"
+                                            role="presentation"
                                             viewBox="0 0 48 48"
                                             width="1em"
                                             xmlns="http://www.w3.org/2000/svg"
@@ -1067,7 +1065,6 @@ exports[`should render a default DatePickerField component 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <IconBase
-                ariaLabel={null}
                 className="IconError"
                 focusable="false"
                 height="1em"
@@ -1078,10 +1075,10 @@ exports[`should render a default DatePickerField component 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <svg
-                  aria-hidden="true"
                   className="tui-Icon icon IconError"
                   focusable="false"
                   height="1em"
+                  role="presentation"
                   viewBox="0 0 48 48"
                   width="1em"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1685,7 +1682,6 @@ exports[`should render a default DatePickerField component 1`] = `
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
                                         <IconBase
-                                          ariaLabel={null}
                                           className="icon-svg"
                                           focusable="false"
                                           height="1em"
@@ -1696,10 +1692,10 @@ exports[`should render a default DatePickerField component 1`] = `
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            aria-hidden="true"
                                             className="tui-Icon icon icon-svg"
                                             focusable="false"
                                             height="1em"
+                                            role="presentation"
                                             viewBox="0 0 48 48"
                                             width="1em"
                                             xmlns="http://www.w3.org/2000/svg"
@@ -1951,7 +1947,6 @@ exports[`should render a valid DatePickerField with props 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <IconBase
-                ariaLabel={null}
                 className="IconError"
                 focusable="false"
                 height="1em"
@@ -1962,10 +1957,10 @@ exports[`should render a valid DatePickerField with props 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <svg
-                  aria-hidden="true"
                   className="tui-Icon icon IconError"
                   focusable="false"
                   height="1em"
+                  role="presentation"
                   viewBox="0 0 48 48"
                   width="1em"
                   xmlns="http://www.w3.org/2000/svg"
@@ -2604,7 +2599,6 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
                                         <IconBase
-                                          ariaLabel={null}
                                           className="icon-svg"
                                           focusable="false"
                                           height="1em"
@@ -2615,10 +2609,10 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            aria-hidden="true"
                                             className="tui-Icon icon icon-svg"
                                             focusable="false"
                                             height="1em"
+                                            role="presentation"
                                             viewBox="0 0 48 48"
                                             width="1em"
                                             xmlns="http://www.w3.org/2000/svg"

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Fixed
+  * Fixed link to terra-tabs badge.
 
 ## 1.13.0 - (February 1, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/Tabs.1.doc.mdx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/Tabs.1.doc.mdx
@@ -9,6 +9,7 @@ import TabsWithFilledContent from './example/TabsWithFilledContent?dev-site-exam
 import IconOnlyTabs from './example/IconOnlyTabs?dev-site-example';
 import ResponsiveTabsVariant from './example/ResponsiveTabsVariant?dev-site-example';
 import IconsInMenuTabs from './example/IconsInMenuTabs?dev-site-example';
+
 <Badge />
 
 # Terra Tabs

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed console warning `React does not recognize the `showIcon` prop on a DOM element`.
+
 ## 6.62.0 - (February 1, 2023)
 
 * Added

--- a/packages/terra-tabs/src/TabPane.jsx
+++ b/packages/terra-tabs/src/TabPane.jsx
@@ -61,6 +61,7 @@ const TabPane = ({
   isDisabled,
   isIconOnly,
   isActive,
+  showIcon,
   ...customProps
 }) => {
   const attributes = { ...customProps };

--- a/packages/terra-tabs/tests/jest/__snapshots__/TabPane.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/TabPane.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`TabPane correctly applies the theme context className 1`] = `
   aria-selected={false}
   className="tab is-text-only orion-fusion-theme customClass"
   role="tab"
-  showIcon={false}
 >
   <span
     className="label"
@@ -20,7 +19,6 @@ exports[`TabPane should render a default component with label 1`] = `
   aria-selected={false}
   className="tab is-text-only"
   role="tab"
-  showIcon={false}
 >
   <span
     className="label"
@@ -35,7 +33,6 @@ exports[`TabPane should render as disabled when indicated 1`] = `
   aria-selected={false}
   className="tab is-disabled is-text-only"
   role="tab"
-  showIcon={false}
 >
   <span
     className="label"
@@ -50,7 +47,6 @@ exports[`TabPane should render with a custom display when provided 1`] = `
   aria-selected={false}
   className="tab is-text-only"
   role="tab"
-  showIcon={false}
 >
   <div>
     Custom Display
@@ -63,7 +59,6 @@ exports[`TabPane should render with custom props 1`] = `
   aria-selected={false}
   className="tab is-text-only customClass"
   role="tab"
-  showIcon={false}
 >
   <span
     className="label"
@@ -78,7 +73,6 @@ exports[`TabPane should render with icon and label 1`] = `
   aria-selected={false}
   className="tab"
   role="tab"
-  showIcon={false}
 >
   <div>
     Fake icon
@@ -97,7 +91,6 @@ exports[`TabPane should render with icon only when indicated 1`] = `
   aria-selected={false}
   className="tab is-icon-only"
   role="tab"
-  showIcon={false}
 >
   <div>
     Fake icon

--- a/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
@@ -124,7 +124,6 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <IconBase
-                        ariaLabel={null}
                         className=""
                         focusable="false"
                         height="1em"
@@ -135,10 +134,10 @@ exports[`Tabs Responsiveness correctly applies the theme context className 1`] =
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <svg
-                          aria-hidden="true"
                           className="tui-Icon icon is-bidi"
                           focusable="false"
                           height="1em"
+                          role="presentation"
                           viewBox="0 0 48 48"
                           width="1em"
                           xmlns="http://www.w3.org/2000/svg"

--- a/scripts/release/gitTagMonoRepo.js
+++ b/scripts/release/gitTagMonoRepo.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 const fs = require('fs');
 const { execSync } = require('child_process');


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
```jsx
  const attributes = { ...customProps };
 <div {...attributes} role="tab" className={paneClassNames}>
```
since `showIcon` was not extracted as props it got added as customProps (attributes) to [tabPane's div](https://github.com/cerner/terra-framework/blob/2b54fee079a7c76c9aae9ea7ea219f9893412cb5/packages/terra-tabs/src/TabPane.jsx#L84) causing below warnings on console.

``js
Warning: React does not recognize the `showIcon` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `showicon` instead. If you accidentally passed it from a parent component, remove it from the DOM element.  
``

Consuming project has below config which will make jest to fail for console warnings / errors.

```js
console.error = (message, props) => {
  // An error occurred in the console, please fix the error. The error description should be above this message.
  throw (message instanceof Error ? message : new Error(message.replaceAll('%s', props)));
};
```
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #[UXPLATFORM-8297]()

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Verified with project which had jest failures.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

This PR fixes the build failure happening due to decorative icon changes.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
