### PR TITLE
Updates Jest Snapshots for terra-button A11y changes

### DIFF
--- a/packages/terra-application-navigation/CHANGELOG.md
+++ b/packages/terra-application-navigation/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 1.62.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-application-navigation/tests/jest/common/__snapshots__/PopupMenu.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/common/__snapshots__/PopupMenu.test.jsx.snap
@@ -33,6 +33,7 @@ exports[`PopupMenu should render prop data 1`] = `
       end={
         <Button
           data-navigation-utility-item-logout={true}
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}

--- a/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
@@ -297,6 +297,7 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
           end={
             <Button
               data-navigation-utility-item-logout={true}
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -734,6 +735,7 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
             end={
               <Button
                 data-navigation-utility-item-logout={true}
+                iconType="decorative"
                 isBlock={false}
                 isCompact={false}
                 isDisabled={false}
@@ -759,6 +761,7 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                 >
                   <Button
                     data-navigation-utility-item-logout={true}
+                    iconType="decorative"
                     isBlock={false}
                     isCompact={false}
                     isDisabled={false}
@@ -856,6 +859,7 @@ exports[`UtilityMenu should render with skip callback 1`] = `
           end={
             <Button
               data-navigation-utility-item-logout={true}
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -979,6 +983,7 @@ exports[`UtilityMenu should render with skip callback 1`] = `
             end={
               <Button
                 data-navigation-utility-item-logout={true}
+                iconType="decorative"
                 isBlock={false}
                 isCompact={false}
                 isDisabled={false}
@@ -1004,6 +1009,7 @@ exports[`UtilityMenu should render with skip callback 1`] = `
                 >
                   <Button
                     data-navigation-utility-item-logout={true}
+                    iconType="decorative"
                     isBlock={false}
                     isCompact={false}
                     isDisabled={false}

--- a/packages/terra-application-utility/CHANGELOG.md
+++ b/packages/terra-application-utility/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 2.48.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-application-utility/tests/jest/__snapshots__/UtilityMenuItem.test.jsx.snap
+++ b/packages/terra-application-utility/tests/jest/__snapshots__/UtilityMenuItem.test.jsx.snap
@@ -93,6 +93,7 @@ exports[`UtilityMenuItem should pass in a custom prop 1`] = `
 exports[`UtilityMenuItem should render with a content location 1`] = `
 <Button
   className="header-utility-footer-item"
+  iconType="decorative"
   isBlock={false}
   isCompact={false}
   isDisabled={false}

--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 6.63.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
@@ -335,6 +335,7 @@ exports[`CollapsibleMenuViewItem should merge custom props 1`] = `
 >
   <Button
     className="Testing"
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},
@@ -379,6 +380,7 @@ exports[`CollapsibleMenuViewItem should not set isSelected on button outside of 
   className="face-up-item"
 >
   <Button
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},
@@ -464,6 +466,7 @@ exports[`CollapsibleMenuViewItem should render a button with icon and text when 
         xmlns="http://www.w3.org/2000/svg"
       />
     }
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},
@@ -508,6 +511,7 @@ exports[`CollapsibleMenuViewItem should render a default component 1`] = `
   className="face-up-item"
 >
   <Button
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},
@@ -586,6 +590,7 @@ exports[`CollapsibleMenuViewItem should render a disabled button when isDisabled
   className="face-up-item"
 >
   <Button
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},
@@ -629,6 +634,7 @@ exports[`CollapsibleMenuViewItem should render a menu when subMenuItems are give
 <CollapsibleMenu
   button={
     <Button
+      iconType="decorative"
       intl={
         Object {
           "defaultFormats": Object {},
@@ -690,6 +696,7 @@ exports[`CollapsibleMenuViewItem should set icon prop on button 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       />
     }
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},
@@ -741,6 +748,7 @@ exports[`CollapsibleMenuViewItem should set isReversed prop on button 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       />
     }
+    iconType="decorative"
     intl={
       Object {
         "defaultFormats": Object {},

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 4.77.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -311,6 +311,7 @@ exports[`correctly applies the theme context className 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               />
             }
+            iconType="decorative"
             isBlock={false}
             isCompact={true}
             isDisabled={false}
@@ -324,7 +325,6 @@ exports[`correctly applies the theme context className 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="Terra.datePicker.openCalendar"
               className="button neutral compact orion-fusion-theme button"
               data-terra-open-calendar-button={true}
               disabled={false}
@@ -399,7 +399,6 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
         Array [
           <button
             aria-disabled="false"
-            aria-label="Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
             title="Terra.datePicker.openCalendar"
@@ -711,6 +710,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             xmlns="http://www.w3.org/2000/svg"
           />
         }
+        iconType="decorative"
         isBlock={false}
         isCompact={true}
         isDisabled={false}
@@ -724,7 +724,6 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
               Array [
                 <button
                   aria-disabled="false"
-                  aria-label="Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
                   title="Terra.datePicker.openCalendar"
@@ -768,7 +767,6 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
       >
         <button
           aria-disabled={false}
-          aria-label="Terra.datePicker.openCalendar"
           className="button neutral compact button"
           data-terra-open-calendar-button={true}
           disabled={false}
@@ -901,7 +899,6 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
       title="Terra.datePicker.openCalendar"
@@ -1008,7 +1005,6 @@ exports[`should render a date input with isInvalid prop 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.openCalendar"
       class="button neutral compact button is-invalid"
       data-terra-open-calendar-button="true"
       title="Terra.datePicker.openCalendar"
@@ -1115,7 +1111,6 @@ exports[`should render a default date input 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
       title="Terra.datePicker.openCalendar"
@@ -1163,7 +1158,6 @@ exports[`should render a default date input with all props 1`] = `
         Array [
           <button
             aria-disabled="false"
-            aria-label="Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
             title="Terra.datePicker.openCalendar"
@@ -1496,6 +1490,7 @@ exports[`should render a default date input with all props 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           />
         }
+        iconType="decorative"
         isBlock={false}
         isCompact={true}
         isDisabled={false}
@@ -1511,7 +1506,6 @@ exports[`should render a default date input with all props 1`] = `
               Array [
                 <button
                   aria-disabled="false"
-                  aria-label="Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
                   title="Terra.datePicker.openCalendar"
@@ -1555,7 +1549,6 @@ exports[`should render a default date input with all props 1`] = `
       >
         <button
           aria-disabled={false}
-          aria-label="Terra.datePicker.openCalendar"
           className="button neutral compact button"
           data-terra-open-calendar-button={true}
           disabled={false}

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -531,6 +531,7 @@ exports[`correctly applies the theme context className 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             />
                           }
+                          iconType="decorative"
                           isBlock={false}
                           isCompact={true}
                           isDisabled={false}
@@ -547,7 +548,6 @@ exports[`correctly applies the theme context className 1`] = `
                         >
                           <button
                             aria-disabled={false}
-                            aria-label="Terra.datePicker.openCalendar"
                             className="button neutral compact orion-fusion-theme button"
                             data-terra-open-calendar-button={true}
                             disabled={false}

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -833,6 +833,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                     xmlns="http://www.w3.org/2000/svg"
                                   />
                                 }
+                                iconType="decorative"
                                 isBlock={false}
                                 isCompact={true}
                                 isDisabled={true}
@@ -849,7 +850,6 @@ exports[`should render a DatePickerField with props 1`] = `
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button is-invalid"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}
@@ -1641,6 +1641,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                     xmlns="http://www.w3.org/2000/svg"
                                   />
                                 }
+                                iconType="decorative"
                                 isBlock={false}
                                 isCompact={true}
                                 isDisabled={false}
@@ -1657,7 +1658,6 @@ exports[`should render a default DatePickerField component 1`] = `
                               >
                                 <button
                                   aria-disabled={false}
-                                  aria-label="Terra.datePicker.openCalendar"
                                   className="button neutral compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={false}
@@ -2557,6 +2557,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                     xmlns="http://www.w3.org/2000/svg"
                                   />
                                 }
+                                iconType="decorative"
                                 isBlock={false}
                                 isCompact={true}
                                 isDisabled={true}
@@ -2573,7 +2574,6 @@ exports[`should render a valid DatePickerField with props 1`] = `
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 4.80.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-date-time-picker/tests/jest/__snapshots__/TimeClarification.test.jsx.snap
+++ b/packages/terra-date-time-picker/tests/jest/__snapshots__/TimeClarification.test.jsx.snap
@@ -37,6 +37,7 @@ exports[`should render a default date time picker 1`] = `
       >
         <Button
           className="button-daylight"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -49,6 +50,7 @@ exports[`should render a default date time picker 1`] = `
         />
         <Button
           className="button-standard"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -68,6 +70,7 @@ exports[`should render a default date time picker 1`] = `
     <Button
       aria-label=""
       className="button-offset button-offset-hidden"
+      iconType="decorative"
       isBlock={false}
       isCompact={true}
       isDisabled={false}
@@ -120,6 +123,7 @@ exports[`should render a disabled time clarification 1`] = `
       >
         <Button
           className="button-daylight"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -132,6 +136,7 @@ exports[`should render a disabled time clarification 1`] = `
         />
         <Button
           className="button-standard"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -151,6 +156,7 @@ exports[`should render a disabled time clarification 1`] = `
     <Button
       aria-label=""
       className="button-offset button-offset-hidden"
+      iconType="decorative"
       isBlock={false}
       isCompact={true}
       isDisabled={true}
@@ -203,6 +209,7 @@ exports[`should render offset button after daylight savings button clicked 1`] =
       >
         <Button
           className="button-daylight"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -215,6 +222,7 @@ exports[`should render offset button after daylight savings button clicked 1`] =
         />
         <Button
           className="button-standard"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -234,6 +242,7 @@ exports[`should render offset button after daylight savings button clicked 1`] =
     <Button
       aria-label="America/Chicago CDT -05:00"
       className="button-offset button-offset-hidden"
+      iconType="decorative"
       isBlock={false}
       isCompact={true}
       isDisabled={true}
@@ -286,6 +295,7 @@ exports[`should render offset button after daylight savings button clicked in th
       >
         <Button
           className="button-daylight"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -298,6 +308,7 @@ exports[`should render offset button after daylight savings button clicked in th
         />
         <Button
           className="button-standard"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -317,6 +328,7 @@ exports[`should render offset button after daylight savings button clicked in th
     <Button
       aria-label="Australia/Sydney AEDT +11:00"
       className="button-offset button-offset-hidden"
+      iconType="decorative"
       isBlock={false}
       isCompact={true}
       isDisabled={true}
@@ -369,6 +381,7 @@ exports[`should render offset button after standard time button clicked 1`] = `
       >
         <Button
           className="button-daylight"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -381,6 +394,7 @@ exports[`should render offset button after standard time button clicked 1`] = `
         />
         <Button
           className="button-standard"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -400,6 +414,7 @@ exports[`should render offset button after standard time button clicked 1`] = `
     <Button
       aria-label="America/Chicago CST -06:00"
       className="button-offset button-offset-hidden"
+      iconType="decorative"
       isBlock={false}
       isCompact={true}
       isDisabled={true}
@@ -452,6 +467,7 @@ exports[`should render offset button after standard time button clicked in the s
       >
         <Button
           className="button-daylight"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -464,6 +480,7 @@ exports[`should render offset button after standard time button clicked in the s
         />
         <Button
           className="button-standard"
+          iconType="decorative"
           isBlock={false}
           isCompact={false}
           isDisabled={false}
@@ -483,6 +500,7 @@ exports[`should render offset button after standard time button clicked in the s
     <Button
       aria-label="Australia/Sydney AEST +10:00"
       className="button-offset button-offset-hidden"
+      iconType="decorative"
       isBlock={false}
       isCompact={true}
       isDisabled={true}

--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 3.78.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-dialog-modal/tests/jest/__snapshots__/DialogModal.test.jsx.snap
+++ b/packages/terra-dialog-modal/tests/jest/__snapshots__/DialogModal.test.jsx.snap
@@ -23,6 +23,7 @@ exports[`correctly applies the theme context className 1`] = `
       width="1120"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -83,6 +84,7 @@ exports[`should mount an open dialogModal 1`] = `
       width="1120"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -145,6 +147,7 @@ exports[`should mount an open dialogModal 320 width 1`] = `
       width="320"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -207,6 +210,7 @@ exports[`should mount an open dialogModal 960 width 1`] = `
       width="960"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -269,6 +273,7 @@ exports[`should mount an open dialogModal 1280 width 1`] = `
       width="1280"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -331,6 +336,7 @@ exports[`should mount an open dialogModal 1600 width 1`] = `
       width="1600"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -393,6 +399,7 @@ exports[`should mount an open dialogModal 1600 width 2`] = `
       width="1600"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -455,6 +462,7 @@ exports[`should set the rootSelector 1`] = `
       width="1120"
     />
     <Button
+      iconType="decorative"
       isBlock={false}
       isCompact={false}
       isDisabled={false}
@@ -526,6 +534,7 @@ exports[`should shallow an open dialogModal 1`] = `
     </p>
   </DialogModal>
   <Button
+    iconType="decorative"
     isBlock={false}
     isCompact={false}
     isDisabled={false}
@@ -573,6 +582,7 @@ exports[`should shallow an open dialogModal 320 width 1`] = `
     </p>
   </DialogModal>
   <Button
+    iconType="decorative"
     isBlock={false}
     isCompact={false}
     isDisabled={false}
@@ -620,6 +630,7 @@ exports[`should shallow an open dialogModal 960 width 1`] = `
     </p>
   </DialogModal>
   <Button
+    iconType="decorative"
     isBlock={false}
     isCompact={false}
     isDisabled={false}
@@ -667,6 +678,7 @@ exports[`should shallow an open dialogModal 1280 width 1`] = `
     </p>
   </DialogModal>
   <Button
+    iconType="decorative"
     isBlock={false}
     isCompact={false}
     isDisabled={false}
@@ -714,6 +726,7 @@ exports[`should shallow an open dialogModal 1600 width 1`] = `
     </p>
   </DialogModal>
   <Button
+    iconType="decorative"
     isBlock={false}
     isCompact={false}
     isDisabled={false}

--- a/packages/terra-dialog-modal/tests/wdio/dialog-modal-spec.js
+++ b/packages/terra-dialog-modal/tests/wdio/dialog-modal-spec.js
@@ -40,7 +40,7 @@ describe('Dialog Modal', () => {
 
     it('focuses on interactive elements within the modal', () => {
       browser.keys(['Tab']);
-      expect($('[type="button"][aria-label="Close"]').isFocused()).toEqual(true);
+      expect($('[type="button"][data-terra-action-header]').isFocused()).toEqual(true);
       Terra.validates.element('modal button focused', { selector: '#root' });
     });
 
@@ -51,7 +51,7 @@ describe('Dialog Modal', () => {
 
     it('shifts focus back onto interactive elements within the modal', () => {
       browser.keys(['Shift', 'Tab']);
-      expect($('[type="button"][aria-label="Close"]').isFocused()).toEqual(true);
+      expect($('[type="button"][data-terra-action-header]').isFocused()).toEqual(true);
       Terra.validates.element('modal button focused again', { selector: '#root' });
     });
   });

--- a/packages/terra-navigation-side-menu/CHANGELOG.md
+++ b/packages/terra-navigation-side-menu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 2.43.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-navigation-side-menu/tests/jest/__snapshots__/NavigationSideMenu.test.jsx.snap
+++ b/packages/terra-navigation-side-menu/tests/jest/__snapshots__/NavigationSideMenu.test.jsx.snap
@@ -276,6 +276,7 @@ exports[`Layout correctly applies the theme context className 1`] = `
                             className="header-icon back"
                           />
                         }
+                        iconType="decorative"
                         isBlock={false}
                         isCompact={false}
                         isDisabled={false}
@@ -308,6 +309,7 @@ exports[`Layout correctly applies the theme context className 1`] = `
                               className="header-icon back"
                             />
                           }
+                          iconType="decorative"
                           isBlock={false}
                           isCompact={false}
                           isDisabled={false}
@@ -320,7 +322,6 @@ exports[`Layout correctly applies the theme context className 1`] = `
                         >
                           <button
                             aria-disabled={false}
-                            aria-label="Terra.actionHeader.back"
                             className="button utility orion-fusion-theme header-button back-button"
                             data-terra-action-header="back-button"
                             disabled={false}

--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 4.25.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-notification-dialog/tests/jest/__snapshots__/NotificationDialog.test.jsx.snap
+++ b/packages/terra-notification-dialog/tests/jest/__snapshots__/NotificationDialog.test.jsx.snap
@@ -81,6 +81,7 @@ exports[`Notification Dialog correctly applies the theme context className 1`] =
           >
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -226,6 +227,7 @@ exports[`Notification Dialog shallow renders an custom notification-dialog 1`] =
           >
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -239,6 +241,7 @@ exports[`Notification Dialog shallow renders an custom notification-dialog 1`] =
             />
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -341,6 +344,7 @@ exports[`Notification Dialog shallow renders an error notification-dialog 1`] = 
           >
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -354,6 +358,7 @@ exports[`Notification Dialog shallow renders an error notification-dialog 1`] = 
             />
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -456,6 +461,7 @@ exports[`Notification Dialog shallow renders an hazard-high notification-dialog 
           >
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -469,6 +475,7 @@ exports[`Notification Dialog shallow renders an hazard-high notification-dialog 
             />
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -571,6 +578,7 @@ exports[`Notification Dialog shallow renders an hazard-low notification-dialog 1
           >
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -584,6 +592,7 @@ exports[`Notification Dialog shallow renders an hazard-low notification-dialog 1
             />
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -686,6 +695,7 @@ exports[`Notification Dialog shallow renders an hazard-medium notification-dialo
           >
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -699,6 +709,7 @@ exports[`Notification Dialog shallow renders an hazard-medium notification-dialo
             />
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -801,6 +812,7 @@ exports[`Notification Dialog shallow renders dialog with reject button first 1`]
           >
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -814,6 +826,7 @@ exports[`Notification Dialog shallow renders dialog with reject button first 1`]
             />
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -923,6 +936,7 @@ exports[`Notification Dialog shallow renders dialog with startMessage, content, 
           >
             <Button
               data-terra-notification-dialog-button="accept"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -936,6 +950,7 @@ exports[`Notification Dialog shallow renders dialog with startMessage, content, 
             />
             <Button
               data-terra-notification-dialog-button="reject"
+              iconType="decorative"
               isBlock={false}
               isCompact={false}
               isDisabled={false}
@@ -1323,6 +1338,7 @@ exports[`correctly applies the theme context className 1`] = `
                         >
                           <Button
                             data-terra-notification-dialog-button="accept"
+                            iconType="decorative"
                             isBlock={false}
                             isCompact={false}
                             isDisabled={false}
@@ -1360,6 +1376,7 @@ exports[`correctly applies the theme context className 1`] = `
                           </Button>
                           <Button
                             data-terra-notification-dialog-button="reject"
+                            iconType="decorative"
                             isBlock={false}
                             isCompact={false}
                             isDisabled={false}

--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated Jest snapshot for terra-button changes
+
 ## 6.62.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-popup/tests/jest/__snapshots__/PopupContent.test.jsx.snap
+++ b/packages/terra-popup/tests/jest/__snapshots__/PopupContent.test.jsx.snap
@@ -273,7 +273,6 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                   >
                     <button
                       aria-disabled="false"
-                      aria-label="Terra.popup.header.close"
                       class="button utility"
                       title="Terra.popup.header.close"
                       type="button"
@@ -396,7 +395,6 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                         >
                           <button
                             aria-disabled="false"
-                            aria-label="Terra.popup.header.close"
                             class="button utility"
                             title="Terra.popup.header.close"
                             type="button"
@@ -511,7 +509,6 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                           >
                             <button
                               aria-disabled="false"
-                              aria-label="Terra.popup.header.close"
                               class="button utility"
                               title="Terra.popup.header.close"
                               type="button"
@@ -634,6 +631,7 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                               className="close-icon"
                             />
                           }
+                          iconType="decorative"
                           isBlock={false}
                           isCompact={false}
                           isDisabled={false}
@@ -646,7 +644,6 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                         >
                           <button
                             aria-disabled={false}
-                            aria-label="Terra.popup.header.close"
                             className="button utility"
                             disabled={false}
                             onBlur={[Function]}


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
PR updates Jest failures happening due to release of terra-button. A11y features added to button has introduced new prop `iconType` for button which has been updated in all consuming component jest snapshots to fix test failures.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-framework-deployed-pr-45.herokuapp.com/ -->
https://terra-framework-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
