### PR TITLE
Update Dangerfile to ignore non-shipped folders

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -4,7 +4,7 @@ import { danger, fail } from 'danger';
 const CHANGELOG_PATTERN = /^packages\/terra-([a-z-0-9])*\/CHANGELOG\.md/i;
 
 const changedFiles = danger.git.created_files.concat(danger.git.modified_files);
-const allowedFilepaths = ['package.json', 'src', 'translations'];
+const allowedFilepaths = ['package.json', 'src', 'translations', 'terra-framework-docs'];
 
 const changedChangelogs = new Set();
 const changedPackages = new Set();

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,31 +1,40 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { danger, fail } from 'danger';
 
-const CHANGELOG_PATTERN = /^packages\/terra-([a-z-])*\/CHANGELOG\.md/i;
+const CHANGELOG_PATTERN = /^packages\/terra-([a-z-0-9])*\/CHANGELOG\.md/i;
 
 const changedFiles = danger.git.created_files.concat(danger.git.modified_files);
+const allowedFilepaths = ['package.json', 'src', 'translations'];
 
 const changedChangelogs = new Set();
 const changedPackages = new Set();
 
 changedFiles.forEach((file) => {
-  // file isn't in a package so it has no changelog, skip further processing
   if (file.substring(0, 9) !== 'packages/') {
+    // file isn't in a package so it has no changelog, skip further processing
+    return;
+  }
+
+  if (!allowedFilepaths.some(filepath => file.includes(filepath))) {
+    // skip further processing if the changed file is not among the allowed filepaths
     return;
   }
 
   const packageName = file.split('packages/')[1].split('/')[0];
 
   if (CHANGELOG_PATTERN.test(file)) {
+    // changed file is the CHANGELOG itself
     changedChangelogs.add(packageName);
-  } else { // file is in a package and was changed - we need a changelog
-    changedPackages.add(packageName);
+    return;
   }
+
+  // for all other files
+  changedPackages.add(packageName);
 });
 
 const missingChangelogs = [...changedPackages].filter(packageName => !changedChangelogs.has(packageName));
 
 // Fail if there are package changes without a CHANGELOG update
 if (missingChangelogs.length > 0) {
-  fail(`Please include a CHANGELOG entry for each changed package this PR. Looks like a CHANGELOG is missing for: \n\n - ${missingChangelogs.join('\n - ')}`);
+  fail(`Please include a CHANGELOG entry for each changed package this PR. Looks like a CHANGELOG entry is missing for: \n\n - ${missingChangelogs.join('\n - ')}`);
 }


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR updates `dangerfile.js` to ignore changes to files outside of `package.json`, `src`, `translations` and `terra-framework-docs`.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
The changes to the logic were tested in https://github.com/cerner/terra-core/pull/3763.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
