### PR TITLE
[terra-slide-panel] Contain focus in panel content when fullscreen

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,8 @@ Cerner Corporation
 - Gage Phillips [@gagerdude]
 - Art Parkeenvincha [@artpark]
 - Andrew Tran [@trandrew1023]
+- Steven Mason [@smason0]
+- Alla Doroshkevych [@adoroshk]
 
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
@@ -93,3 +95,5 @@ Cerner Corporation
 [@gagerdude]: https://github.com/gagerdude
 [@artpark]: https://github.com/artpark
 [@trandrew1023]: https://github.com/trandrew1023
+[@smason0]: https://github.com/smason0
+[@adoroshk]: https://github.com/adoroshk

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Changed
   * Updated examples for `terra-slide-panel-manager`.
 
+* Added
+  * Added a `terra-slide-panel` example where the panel is open on page load and fullscreen.
+
 ## 1.19.0 - (April 12, 2023)
 
 * Added

--- a/packages/terra-framework-docs/src/terra-dev-site/test/slide-panel/SlidePanelToggledOnFullscreen.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/slide-panel/SlidePanelToggledOnFullscreen.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import SlidePanel from 'terra-slide-panel';
+import styles from './SlidePanelDocCommon.test.module.scss';
+
+const cx = classNames.bind(styles);
+
+class SlidePanelDemo extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { panelIsOpen: true };
+    this.handlePanelToggle = this.handlePanelToggle.bind(this);
+  }
+
+  handlePanelToggle() {
+    this.setState(prevState => ({ panelIsOpen: !prevState.panelIsOpen }));
+  }
+
+  render() {
+    return (
+      <div id="main-div" className={cx('content-wrapper-toggle')}>
+        <SlidePanel
+          id="test-slide"
+          mainContent={<div className={cx('main-content')}><button type="button" id="toggle-panel-button" className={cx('button')} onClick={this.handlePanelToggle}>toggle</button></div>}
+          panelContent={(
+            <div id="panel-content" className={cx('panel-content')}>
+              <button id="close-panel-button" type="button" className={cx('button')} onClick={this.handlePanelToggle}>Close panel</button>
+            </div>
+          )}
+          panelAriaLabel="Panel content area"
+          mainAriaLabel="Main content area"
+          panelSize="small"
+          panelBehavior="overlay"
+          isOpen={this.state.panelIsOpen}
+          fill
+          isFullscreen
+        />
+      </div>
+    );
+  }
+}
+
+export default SlidePanelDemo;

--- a/packages/terra-slide-panel-manager/tests/jest/__snapshots__/SlidePanelManager.test.jsx.snap
+++ b/packages/terra-slide-panel-manager/tests/jest/__snapshots__/SlidePanelManager.test.jsx.snap
@@ -160,6 +160,7 @@ exports[`SlidePanelManager should disclose content in SlidePanel 1`] = `
           data-slide-panel-panel-size="large"
         >
           <div
+            aria-hidden="false"
             className="main"
             key="main"
             onClick={[Function]}
@@ -497,6 +498,7 @@ exports[`SlidePanelManager should render a SlidePanelManager with level three he
           id="my-slide-panel-manager"
         >
           <div
+            aria-hidden="false"
             className="main"
             key="main"
             onClick={[Function]}
@@ -629,6 +631,7 @@ exports[`SlidePanelManager should render the SlidePanelManager with custom props
           id="my-slide-panel-manager"
         >
           <div
+            aria-hidden="false"
             className="main"
             key="main"
             onClick={[Function]}
@@ -756,6 +759,7 @@ exports[`SlidePanelManager should render the SlidePanelManager with defaults 1`]
           data-slide-panel-panel-size="small"
         >
           <div
+            aria-hidden="false"
             className="main"
             key="main"
             onClick={[Function]}
@@ -883,6 +887,7 @@ exports[`SlidePanelManager should render the SlidePanelManager with squish overr
           data-slide-panel-panel-size="small"
         >
           <div
+            aria-hidden="false"
             className="main"
             key="main"
             onClick={[Function]}

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added
   * Added roles and visually hidden text to slide panel.
 
+* Changed
+  * Updated main content to not be focus-able when panel content is fullscreen.
+
 ## 3.38.1 - (April 12, 2023)
 
 * Fixed

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Added roles and visually hidden text to slide panel.
 
 * Changed
-  * Updated main content to not be focus-able when panel content is fullscreen.
+  * Updated main content to not be focusable when panel content is fullscreen.
 
 ## 3.38.1 - (April 12, 2023)
 

--- a/packages/terra-slide-panel/src/SlidePanel.jsx
+++ b/packages/terra-slide-panel/src/SlidePanel.jsx
@@ -175,6 +175,7 @@ class SlidePanel extends React.Component {
         key="main"
         tabIndex="-1"
         aria-label={mainAriaLabel}
+        aria-hidden={isOpen && isFullscreen ? 'true' : 'false'}
         ref={this.mainNode}
         role="main"
         onClick={this.setLastClicked}

--- a/packages/terra-slide-panel/src/SlidePanel.module.scss
+++ b/packages/terra-slide-panel/src/SlidePanel.module.scss
@@ -77,9 +77,8 @@
     }
   }
 
-  // Focus trap
+  // Remove main content from tab order when it's covered by slide panel on narrow screen
   .is-open {
-    // Removes main content from tab access when it's covered by slide panel on narrow screen
     // max-width is set to 1 pixel less than "min-width: 768px" breakpoint to avoid the main content being invisible at width 768px when the panel has already moved to the side, as both max-width and max-width include that width
     @media (max-width: 767px), print {
       > .main {

--- a/packages/terra-slide-panel/src/SlidePanel.module.scss
+++ b/packages/terra-slide-panel/src/SlidePanel.module.scss
@@ -77,6 +77,23 @@
     }
   }
 
+  // Focus trap 
+  .is-open {
+    // Removes main content elements from tab order as slide panel lays over them on narrow screen
+    @media (min-width: 0px), print {
+      > .main {
+        visibility: hidden;
+      } 
+    }
+
+    // Returns main content elements to tab order
+    @media (min-width: 768px), print {
+      > .main {
+        visibility: visible;
+      }
+    }
+  }
+
   // Overlay
   /* stylelint-disable max-nesting-depth */
   .is-open[data-slide-panel-panel-behavior='overlay'] {
@@ -151,6 +168,10 @@
   }
 
   .panel[aria-hidden='true'] {
+    visibility: hidden;
+  }
+
+  .main[aria-hidden='true'] {
     visibility: hidden;
   }
 }

--- a/packages/terra-slide-panel/src/SlidePanel.module.scss
+++ b/packages/terra-slide-panel/src/SlidePanel.module.scss
@@ -77,7 +77,7 @@
     }
   }
 
-  // Focus trap 
+  // Focus trap
   .is-open {
     // Removes main content from tab access when it's covered by slide panel on narrow screen
     // max-width is set to 1 pixel less than "min-width: 768px" breakpoint to avoid the main content being invisible at width 768px when the panel has already moved to the side, as both max-width and max-width include that width

--- a/packages/terra-slide-panel/src/SlidePanel.module.scss
+++ b/packages/terra-slide-panel/src/SlidePanel.module.scss
@@ -79,17 +79,11 @@
 
   // Focus trap 
   .is-open {
-    // Removes main content elements from tab order as slide panel lays over them on narrow screen
-    @media (min-width: 0px), print {
+    // Removes main content from tab access when it's covered by slide panel on narrow screen
+    // max-width is set to 1 pixel less than "min-width: 768px" breakpoint to avoid the main content being invisible at width 768px when the panel has already moved to the side, as both max-width and max-width include that width
+    @media (max-width: 767px), print {
       > .main {
         visibility: hidden;
-      } 
-    }
-
-    // Returns main content elements to tab order
-    @media (min-width: 768px), print {
-      > .main {
-        visibility: visible;
       }
     }
   }

--- a/packages/terra-slide-panel/tests/jest/SlidePanel.test.jsx
+++ b/packages/terra-slide-panel/tests/jest/SlidePanel.test.jsx
@@ -4,71 +4,80 @@ import SlidePanel from '../../src/SlidePanel';
 
 it('should render a default SlidePanel with no props', () => {
   const slidePanel = <SlidePanel />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelBehavior = squish', () => {
   const slidePanel = <SlidePanel panelBehavior="squish" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-behavior')).toEqual('squish');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelBehavior = overlay', () => {
   const slidePanel = <SlidePanel panelBehavior="overlay" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-behavior')).toEqual('overlay');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelPosition = start', () => {
   const slidePanel = <SlidePanel panelPosition="start" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-position')).toEqual('start');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelPosition = end', () => {
   const slidePanel = <SlidePanel panelPosition="end" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-position')).toEqual('end');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelSize = small', () => {
   const slidePanel = <SlidePanel panelSize="small" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-size')).toEqual('small');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelSize = large', () => {
   const slidePanel = <SlidePanel panelSize="large" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-size')).toEqual('large');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with an open state', () => {
   const slidePanel = <SlidePanel isOpen />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('className')).toEqual('slide-panel is-open');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with a fullscreen state', () => {
   const slidePanel = <SlidePanel isFullscreen />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('className')).toEqual('slide-panel is-fullscreen');
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with fill', () => {
   const slidePanel = <SlidePanel fill />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('className')).toEqual('slide-panel fill');
   expect(wrapper).toMatchSnapshot();
 });
 
@@ -78,8 +87,11 @@ it('should render a SlidePanel with main content', () => {
       mainContent={<p>Main Content</p>}
     />
   );
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  const mainContent = wrapper.find('.main').childAt(0);
+
+  expect(mainContent.equals(<p>Main Content</p>)).toBe(true);
   expect(wrapper).toMatchSnapshot();
 });
 
@@ -89,15 +101,40 @@ it('should render a SlidePanel with panel content', () => {
       panelContent={<p>Panel Content</p>}
     />
   );
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  const panelContent = wrapper.find('.panel').childAt(1);
+
+  expect(panelContent.equals(<p>Panel Content</p>)).toBe(true);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should render a SlidePanel with main content and panel content', () => {
+  const slidePanel = (
+    <SlidePanel
+      mainContent={<p>Main Content</p>}
+      panelContent={<p>Panel Content</p>}
+    />
+  );
+  const wrapper = shallow(slidePanel);
+
+  const panelContent = wrapper.find('.panel').childAt(1);
+  const mainContent = wrapper.find('.main').childAt(0);
+
+  expect(panelContent.equals(<p>Panel Content</p>)).toBe(true);
+  expect(mainContent.equals(<p>Main Content</p>)).toBe(true);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('should render a SlidePanel with panelAriaLabel and mainAriaLabel specified', () => {
   const slidePanel = <SlidePanel panelAriaLabel="Panel content area" mainAriaLabel="Main content area" />;
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  const panelDiv = wrapper.find('.panel');
+  const mainDiv = wrapper.find('.main');
+
+  expect(panelDiv.prop('aria-label')).toEqual('Panel content area');
+  expect(mainDiv.prop('aria-label')).toEqual('Main content area');
   expect(wrapper).toMatchSnapshot();
 });
 
@@ -105,8 +142,12 @@ it('should render a SlidePanel with the given extra attributes', () => {
   const slidePanel = (
     <SlidePanel panelBehavior="overlay" id="my-slide-panel" className="pad-this-slide-panel" data-test-attr="ahoy thar" />
   );
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-behavior')).toEqual('overlay');
+  expect(wrapper.prop('id')).toEqual('my-slide-panel');
+  expect(wrapper.prop('className')).toEqual('slide-panel pad-this-slide-panel');
+  expect(wrapper.prop('data-test-attr')).toEqual('ahoy thar');
   expect(wrapper).toMatchSnapshot();
 });
 
@@ -114,8 +155,21 @@ it('should override user provided attributes that aren\'t className', () => {
   const slidePanel = (
     <SlidePanel panelBehavior="overlay" className="pad-this-slide-panel" data-test-attr="ahoy thar" data-slide-panel-panel-behavior="i am not good with slide panel" />
   );
-  const wrapper = render(slidePanel);
+  const wrapper = shallow(slidePanel);
 
+  expect(wrapper.prop('data-slide-panel-panel-behavior')).toEqual('overlay');
+  expect(wrapper.prop('className')).toEqual('slide-panel pad-this-slide-panel');
+  expect(wrapper.prop('data-test-attr')).toEqual('ahoy thar');
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('sets aria-hidden to true on main content div when isOpen and isFullscreen props are both true', () => {
+  const slidePanel = <SlidePanel isOpen isFullscreen />;
+  const wrapper = shallow(slidePanel);
+
+  const mainDiv = wrapper.find('.main');
+
+  expect(mainDiv.prop('aria-hidden')).toEqual('true');
   expect(wrapper).toMatchSnapshot();
 });
 

--- a/packages/terra-slide-panel/tests/jest/__snapshots__/SlidePanel.test.jsx.snap
+++ b/packages/terra-slide-panel/tests/jest/__snapshots__/SlidePanel.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`correctly applies the theme context className 1`] = `
       data-slide-panel-panel-size="small"
     >
       <div
+        aria-hidden="false"
         className="main"
         key="main"
         onClick={[Function]}
@@ -45,118 +46,162 @@ exports[`correctly applies the theme context className 1`] = `
 </ThemeContextProvider>
 `;
 
+exports[`sets aria-hidden to true on main content div when isOpen and isFullscreen props are both true 1`] = `
+<div
+  className="slide-panel is-open is-fullscreen"
+  data-slide-panel-panel-behavior="overlay"
+  data-slide-panel-panel-position="end"
+  data-slide-panel-panel-size="small"
+>
+  <div
+    aria-hidden="true"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
+    role="main"
+    tabIndex="-1"
+  />
+  <div
+    aria-hidden="false"
+    className="panel"
+    key="panel"
+    role="region"
+    tabIndex="-1"
+  >
+    <VisuallyHiddenText />
+  </div>
+</div>
+`;
+
 exports[`should override user provided attributes that aren't className 1`] = `
 <div
-  class="slide-panel pad-this-slide-panel"
+  className="slide-panel pad-this-slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
   data-test-attr="ahoy thar"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with a fullscreen state 1`] = `
 <div
-  class="slide-panel is-fullscreen"
+  className="slide-panel is-fullscreen"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with an open state 1`] = `
 <div
-  class="slide-panel is-open"
+  className="slide-panel is-open"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="false"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with fill 1`] = `
 <div
-  class="slide-panel fill"
+  className="slide-panel fill"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with main content 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   >
     <p>
       Main Content
@@ -164,38 +209,75 @@ exports[`should render a SlidePanel with main content 1`] = `
   </div>
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
+  </div>
+</div>
+`;
+
+exports[`should render a SlidePanel with main content and panel content 1`] = `
+<div
+  className="slide-panel"
+  data-slide-panel-panel-behavior="overlay"
+  data-slide-panel-panel-position="end"
+  data-slide-panel-panel-size="small"
+>
+  <div
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
+    role="main"
+    tabIndex="-1"
+  >
+    <p>
+      Main Content
+    </p>
+  </div>
+  <div
+    aria-hidden="true"
+    className="panel"
+    key="panel"
+    role="region"
+    tabIndex="-1"
+  >
+    <VisuallyHiddenText />
+    <p>
+      Panel Content
+    </p>
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with panel content 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
     <p>
       Panel Content
     </p>
@@ -205,186 +287,207 @@ exports[`should render a SlidePanel with panel content 1`] = `
 
 exports[`should render a SlidePanel with panelAriaLabel and mainAriaLabel specified 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
+    aria-hidden="false"
     aria-label="Main content area"
-    class="main"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
     aria-label="Panel content area"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    >
-      Panel content area
-    </span>
+    <VisuallyHiddenText
+      text="Panel content area"
+    />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with panelBehavior = overlay 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with panelBehavior = squish 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="squish"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with panelPosition = end 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with panelPosition = start 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="start"
   data-slide-panel-panel-size="small"
 >
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
 </div>
 `;
 
 exports[`should render a SlidePanel with panelSize = large 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="large"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with panelSize = small 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a SlidePanel with the given extra attributes 1`] = `
 <div
-  class="slide-panel pad-this-slide-panel"
+  className="slide-panel pad-this-slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
@@ -392,44 +495,50 @@ exports[`should render a SlidePanel with the given extra attributes 1`] = `
   id="my-slide-panel"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;
 
 exports[`should render a default SlidePanel with no props 1`] = `
 <div
-  class="slide-panel"
+  className="slide-panel"
   data-slide-panel-panel-behavior="overlay"
   data-slide-panel-panel-position="end"
   data-slide-panel-panel-size="small"
 >
   <div
-    class="main"
+    aria-hidden="false"
+    className="main"
+    key="main"
+    onClick={[Function]}
+    onKeyUp={[Function]}
     role="main"
-    tabindex="-1"
+    tabIndex="-1"
   />
   <div
     aria-hidden="true"
-    class="panel"
+    className="panel"
+    key="panel"
     role="region"
-    tabindex="-1"
+    tabIndex="-1"
   >
-    <span
-      class="visually-hidden-text"
-    />
+    <VisuallyHiddenText />
   </div>
 </div>
 `;

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -177,4 +177,19 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       expect($('[aria-label="Main content area"]').isFocused()).toBeTruthy();
     });
   });
+
+  describe('Main content is not focusable when fullscreen panel is open', () => {
+    it('Tabs back out of panel content and does not select main content button element', () => {
+      browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggled-on-fullscreen');
+
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
+      browser.keys(['Tab']);
+
+      expect($('#close-panel-button').isFocused()).toBeTruthy();
+      browser.keys(['Shift', 'Tab']);
+
+      expect($('#close-panel-button').isFocused()).toBeFalsy();
+      expect($('#toggle-panel-button').isFocused()).toBeFalsy();
+    });
+  });
 });

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -53,7 +53,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
 
   it('Toggles the slide panel and hidden styles', () => {
     browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
-    $('#test-slide [aria-hidden="true"]').waitForExist();
+    $('[aria-label="Main content area"]').waitForExist();
     Terra.validates.element('toggle and hidden styles', { selector: '#root' });
   });
 
@@ -61,13 +61,13 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     it('Opens panel and focuses on panel', () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
       $('#test-toggle').click();
-      $('#test-slide [aria-hidden="false"]').waitForExist();
+      $('[aria-label="Panel content area"]').waitForExist();
       browser.pause(150);
-      $('#panel-content').isFocused();
+      expect($('[aria-label="Panel content area"]').isFocused()).toBeTruthy();
 
       // On Tab Press focuses on the button inside the panel
       browser.keys(['Tab']);
-      $('#focus-button').isFocused();
+      expect($('#focus-button').isFocused()).toBeTruthy();
 
       Terra.validates.element('panel focused', { selector: '#root' });
     });
@@ -75,17 +75,17 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
 
       browser.keys(['Tab']);
-      $('#test-toggle').isFocused();
+      expect($('#test-toggle').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('#test-slide [aria-hidden="false"]').waitForExist();
+      $('[aria-label="Panel content area"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Tab']);
-      $('#focus-button').isFocused();
+      expect($('#focus-button').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('#test-slide [aria-hidden="true"]').waitForExist();
+      $('[aria-label="Main content area"]').waitForExist();
 
-      $('#test-toggle').isFocused();
+      expect($('#test-toggle').isFocused()).toBeTruthy();
 
       browser.pause(150);
 
@@ -94,13 +94,13 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     it('Closes panel and focuses on toggle button with mouse controls', () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
       $('#test-toggle').click();
-      $('#test-slide [aria-hidden="false"]').waitForExist();
+      $('[aria-label="Panel content area"]').waitForExist();
       browser.pause(150);
 
       $('#focus-button').click();
-      $('#test-slide [aria-hidden="true"]').waitForExist();
+      $('[aria-label="Main content area"]').waitForExist();
 
-      $('#test-toggle').isFocused();
+      expect($('#test-toggle').isFocused()).toBeTruthy();
 
       browser.pause(150);
 
@@ -110,22 +110,22 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-multiple-buttons-toggle');
 
       browser.keys(['Tab', 'Tab']);
-      $('#test-toggle').isFocused();
+      expect($('#test-toggle').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('#test-slide [aria-hidden="false"]').waitForExist();
+      $('[aria-label="Panel content area"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Shift', 'Tab']);
-      $('#another-button').isFocused();
+      expect($('#another-button').isFocused()).toBeTruthy();
 
       browser.keys(['Tab', 'Tab']);
-      $('#focus-button').isFocused();
+      expect($('#focus-button').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('#test-slide [aria-hidden="true"]').waitForExist();
+      $('[aria-label="Main content area"]').waitForExist();
 
       browser.pause(150);
 
-      $('#test-toggle').isFocused();
+      expect($('#test-toggle').isFocused()).toBeTruthy();
 
       Terra.validates.element('toggle button focused with multiple buttons', { selector: '#root' });
     });
@@ -133,18 +133,18 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-multiple-buttons-toggle');
 
       $('#test-toggle').click();
-      $('#test-slide [aria-hidden="false"]').waitForExist();
+      $('[aria-label="Panel content area"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Shift', 'Tab']);
-      $('#another-button').isFocused();
+      expect($('#another-button').isFocused()).toBeTruthy();
 
       $('#focus-button').click();
-      $('#test-slide [aria-hidden="true"]').waitForExist();
+      $('[aria-label="Main content area"]').waitForExist();
 
       browser.pause(150);
 
-      $('#test-toggle').isFocused();
+      expect($('#test-toggle').isFocused()).toBeTruthy();
 
       Terra.validates.element('toggle button focused with multiple buttons', { selector: '#root' });
     });

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -53,7 +53,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
 
   it('Toggles the slide panel and hidden styles', () => {
     browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
-    $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
+    $('#test-slide [aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
     Terra.validates.element('toggle and hidden styles', { selector: '#root' });
   });
 
@@ -61,7 +61,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     it('Opens panel and focuses on panel', () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
       $('#test-toggle').click();
-      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
       expect($('[aria-label="Panel content area"]').isFocused()).toBeTruthy();
 
@@ -77,13 +77,13 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.keys(['Tab']);
       expect($('#test-toggle').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Tab']);
       expect($('#focus-button').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       expect($('#test-toggle').isFocused()).toBeTruthy();
 
@@ -94,11 +94,11 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     it('Closes panel and focuses on toggle button with mouse controls', () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
       $('#test-toggle').click();
-      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       $('#focus-button').click();
-      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       expect($('#test-toggle').isFocused()).toBeTruthy();
 
@@ -112,7 +112,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.keys(['Tab', 'Tab']);
       expect($('#test-toggle').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Shift', 'Tab']);
@@ -121,7 +121,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.keys(['Tab', 'Tab']);
       expect($('#focus-button').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       browser.pause(150);
 
@@ -133,14 +133,14 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-multiple-buttons-toggle');
 
       $('#test-toggle').click();
-      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Shift', 'Tab']);
       expect($('#another-button').isFocused()).toBeTruthy();
 
       $('#focus-button').click();
-      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
+      $('#test-slide [aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       browser.pause(150);
 

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -53,7 +53,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
 
   it('Toggles the slide panel and hidden styles', () => {
     browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
-    $('[aria-label="Main content area"]').waitForExist();
+    $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
     Terra.validates.element('toggle and hidden styles', { selector: '#root' });
   });
 
@@ -61,7 +61,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     it('Opens panel and focuses on panel', () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
       $('#test-toggle').click();
-      $('[aria-label="Panel content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
       expect($('[aria-label="Panel content area"]').isFocused()).toBeTruthy();
 
@@ -77,13 +77,13 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.keys(['Tab']);
       expect($('#test-toggle').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Panel content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Tab']);
       expect($('#focus-button').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Main content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       expect($('#test-toggle').isFocused()).toBeTruthy();
 
@@ -94,11 +94,11 @@ Terra.describeViewports('Slide panel', ['large'], () => {
     it('Closes panel and focuses on toggle button with mouse controls', () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-toggle');
       $('#test-toggle').click();
-      $('[aria-label="Panel content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       $('#focus-button').click();
-      $('[aria-label="Main content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       expect($('#test-toggle').isFocused()).toBeTruthy();
 
@@ -112,7 +112,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.keys(['Tab', 'Tab']);
       expect($('#test-toggle').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Panel content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Shift', 'Tab']);
@@ -121,7 +121,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.keys(['Tab', 'Tab']);
       expect($('#focus-button').isFocused()).toBeTruthy();
       browser.keys(['Enter']);
-      $('[aria-label="Main content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       browser.pause(150);
 
@@ -133,14 +133,14 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       browser.url('/raw/tests/cerner-terra-framework-docs/slide-panel/slide-panel-multiple-buttons-toggle');
 
       $('#test-toggle').click();
-      $('[aria-label="Panel content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="false"]').waitForExist();
       browser.pause(150);
 
       browser.keys(['Shift', 'Tab']);
       expect($('#another-button').isFocused()).toBeTruthy();
 
       $('#focus-button').click();
-      $('[aria-label="Main content area"]').waitForExist();
+      $('[aria-label="Panel content area"][aria-hidden="true"]').waitForExist();
 
       browser.pause(150);
 

--- a/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
+++ b/packages/terra-slide-panel/tests/wdio/slide-panel-spec.js
@@ -161,7 +161,7 @@ Terra.describeViewports('Slide panel', ['large'], () => {
       Terra.validates.element('panel with end position', { selector: '#root' });
 
       $('#test-toggle').click();
-      $('#test-slide [aria-hidden="false"]').waitForExist();
+      $('#panel-content').waitForExist();
       expect($('#panel-content').getText()).toEqual('Increase Count 1');
 
       Terra.validates.element('panel with start position', { selector: '#root' });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Changes how SlidePanel handles tab order when the panel content is open and fullscreen. Prevents main content (under panel content) from being focused when panel content is fullscreen either via `isFullscreen` prop or a narrow viewport size.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Tested manually in Chrome/Firefox/Safari on MacOS, and in Edge on Windows 10.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
Preview: https://engineering.cerner.com/terra-framework/pull/1638

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
