### PR TITLE
Moved danger step to the end of the build workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,6 +18,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Project
         uses: ./.github/actions/setup
+      - name: Linting Project
+        run: |
+          npm run lint
+      - name: Testing Project
+        run: |
+          npm run jest
       - if: github.event_name == 'pull_request'
         name: Danger
         uses: danger/danger-js@9.1.8
@@ -25,12 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # https://github.com/danger/danger-js/issues/557#issuecomment-664851950
           DANGER_DISABLE_TRANSPILATION: true
-      - name: Linting Project
-        run: |
-          npm run lint
-      - name: Testing Project
-        run: |
-          npm run jest
+
   wdio:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR moves the danger set to the end of the build workflow so that the jest and linter steps may still execute, even with danger failures. This will streamline the build process so that trivial danger failures won't prevent jest & linter steps from running.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
