### PR TITLE
[terra-modal-manager] Changed modal name to be the same as h1 title of the modal dialog

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-  * Changed
-    * Updated to read the title of the modal by the screen reader when a modal is opened.
+  * Added
+    * Added screen reader support to read the title of the modal when it is open.
 
 ## 3.39.0 - (February 14, 2023)
 

--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+  * Changed
+    * Updated to read the title of the modal by the screen reader when a modal is opened.
+
 ## 3.39.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-abstract-modal/src/_ModalContent.jsx
+++ b/packages/terra-abstract-modal/src/_ModalContent.jsx
@@ -138,9 +138,8 @@ const ModalContent = forwardRef((props, ref) => {
         ref={ref}
       >
         {
-          /* UXPLATFORM-8733: Adding an empty span with data-terra-abstract-modal-begin attribute
-             to receive focus when the dialog is opened.
-          */
+          // This empty span with data-terra-abstract-modal-begin attribute
+          //  receives focus when the dialog is opened.
         }
         <span data-terra-abstract-modal-begin tabIndex="-1" />
         <FormattedMessage id="Terra.AbstractModal.BeginModalDialog">

--- a/packages/terra-abstract-modal/src/_ModalContent.jsx
+++ b/packages/terra-abstract-modal/src/_ModalContent.jsx
@@ -137,6 +137,12 @@ const ModalContent = forwardRef((props, ref) => {
         role={role}
         ref={ref}
       >
+        {
+          /* UXPLATFORM-8733: Adding an empty span with data-terra-abstract-modal-begin attribute
+             to receive focus when the dialog is opened.
+          */
+        }
+        <span data-terra-abstract-modal-begin tabIndex="-1" />
         <FormattedMessage id="Terra.AbstractModal.BeginModalDialog">
           {text => {
             // In the latest version of react-intl this param is an array, when previous versions it was a string.

--- a/packages/terra-abstract-modal/src/inertHelpers.js
+++ b/packages/terra-abstract-modal/src/inertHelpers.js
@@ -17,8 +17,7 @@ function showModalDomUpdates(modalElement, rootSelector) {
 
     mainDocumentElement.setAttribute('data-abstract-modal-overlay-count', `${dataOverlayCount + 1}`);
 
-    // Handle focus shift for VoiceOver on iOS
-    if ('ontouchstart' in window) {
+    if (modalElement.querySelector('[data-terra-abstract-modal-begin]')) {
       modalElement.querySelector('[data-terra-abstract-modal-begin]').focus();
     } else {
       // Shift focus to modal dialog

--- a/packages/terra-abstract-modal/tests/jest/__snapshots__/AbstractModal.test.jsx.snap
+++ b/packages/terra-abstract-modal/tests/jest/__snapshots__/AbstractModal.test.jsx.snap
@@ -89,6 +89,10 @@ exports[`correctly applies the theme context className 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -200,6 +204,10 @@ exports[`correctly applies the theme context className 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -347,6 +355,10 @@ exports[`should mount an open modal 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -458,6 +470,10 @@ exports[`should mount an open modal 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -606,6 +622,10 @@ exports[`should mount an open modal 7000 z-index 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -717,6 +737,10 @@ exports[`should mount an open modal 7000 z-index 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -865,6 +889,10 @@ exports[`should mount an open modal 8000 z-index 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -976,6 +1004,10 @@ exports[`should mount an open modal 8000 z-index 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -1124,6 +1156,10 @@ exports[`should mount an open modal 9000 z-index 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -1235,6 +1271,10 @@ exports[`should mount an open modal 9000 z-index 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -1383,6 +1423,10 @@ exports[`should mount an open modal set to fullscreen 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -1494,6 +1538,10 @@ exports[`should mount an open modal set to fullscreen 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -1644,6 +1692,10 @@ exports[`should mount an open modal with custom props 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -1757,6 +1809,10 @@ exports[`should mount an open modal with custom props 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -1905,6 +1961,10 @@ exports[`should mount an open modal with modal class name 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -2016,6 +2076,10 @@ exports[`should mount an open modal with modal class name 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -2164,6 +2228,10 @@ exports[`should mount an open modal with overlay class name 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -2275,6 +2343,10 @@ exports[`should mount an open modal with overlay class name 1`] = `
               role="dialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -2423,6 +2495,10 @@ exports[`should mount an open modal with role 1`] = `
                 tabindex="0"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -2534,6 +2610,10 @@ exports[`should mount an open modal with role 1`] = `
               role="alertdialog"
               tabIndex="0"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -2681,6 +2761,10 @@ exports[`should render the correct snapshot for iPads 1`] = `
                 tabindex="-1"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -2792,6 +2876,10 @@ exports[`should render the correct snapshot for iPads 1`] = `
               role="dialog"
               tabIndex="-1"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -2939,6 +3027,10 @@ exports[`should render the correct snapshot for iPhones 1`] = `
                 tabindex="-1"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -3050,6 +3142,10 @@ exports[`should render the correct snapshot for iPhones 1`] = `
               role="dialog"
               tabIndex="-1"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}
@@ -3197,6 +3293,10 @@ exports[`should render the correct snapshot for iPods 1`] = `
                 tabindex="-1"
               >
                 <span
+                  data-terra-abstract-modal-begin="true"
+                  tabindex="-1"
+                />
+                <span
                   class="visually-hidden-text"
                   data-terra-abstract-modal-begin="true"
                   tabindex="-1"
@@ -3308,6 +3408,10 @@ exports[`should render the correct snapshot for iPods 1`] = `
               role="dialog"
               tabIndex="-1"
             >
+              <span
+                data-terra-abstract-modal-begin={true}
+                tabIndex="-1"
+              />
               <FormattedMessage
                 id="Terra.AbstractModal.BeginModalDialog"
                 values={Object {}}

--- a/packages/terra-abstract-modal/tests/jest/inertHelpers.test.jsx
+++ b/packages/terra-abstract-modal/tests/jest/inertHelpers.test.jsx
@@ -5,8 +5,13 @@ describe('showModalDomUpdates', () => {
   const mockGetAttribute = jest.fn();
   const mockSetAttribute = jest.fn();
   const mockModalElementFocus = jest.fn();
+  const mockChildElementFocus = jest.fn();
   const mockModalElement = {
-    querySelector: jest.fn().mockReturnValue({ focus: mockModalElementFocus }),
+    querySelector: jest.fn().mockReturnValue({ focus: mockChildElementFocus }),
+    focus: mockModalElementFocus,
+  };
+  const mockModalElementWithoutAbstractModalBeginAttribute = {
+    querySelector: jest.fn().mockReturnValue(null),
     focus: mockModalElementFocus,
   };
 
@@ -49,7 +54,7 @@ describe('showModalDomUpdates', () => {
     });
 
     it('sets focus to modal when on browser', () => {
-      showModalDomUpdates(mockModalElement, '#root');
+      showModalDomUpdates(mockModalElementWithoutAbstractModalBeginAttribute, '#root');
       expect(mockModalElementFocus).toHaveBeenCalled();
     });
 
@@ -57,8 +62,13 @@ describe('showModalDomUpdates', () => {
       const defaultOnTouchStart = window.ontouchstart;
       window.ontouchstart = true;
       showModalDomUpdates(mockModalElement, '#root');
-      expect(mockModalElementFocus).toHaveBeenCalled();
+      expect(mockChildElementFocus).toHaveBeenCalled();
       window.ontouchstart = defaultOnTouchStart;
+    });
+
+    it('sets focus to first element in dialog with data-terra-abstract-modal-begin attribute', () => {
+      showModalDomUpdates(mockModalElement, '#root');
+      expect(mockChildElementFocus).toHaveBeenCalled();
     });
   });
 });

--- a/packages/terra-abstract-modal/tests/wdio/abstract-modal-spec.js
+++ b/packages/terra-abstract-modal/tests/wdio/abstract-modal-spec.js
@@ -23,7 +23,7 @@ Terra.describeViewports('Abstract Modal', ['medium'], () => {
       $('[aria-modal="true"][role="dialog"]').waitForDisplayed();
       expect($('#root').getAttribute('inert')).toEqual('true');
       expect($('#root').getAttribute('aria-hidden')).toEqual('true');
-      expect($('[aria-modal="true"][role="dialog"]').isFocused()).toBeTruthy();
+      expect($('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]').isFocused()).toBeTruthy();
     });
 
     it('closes modal on ESC', () => {
@@ -56,7 +56,7 @@ Terra.describeViewports('Abstract Modal', ['medium'], () => {
       $('[role="dialog"]').waitForDisplayed();
       expect($('#root').getAttribute('inert')).toEqual('true');
       expect($('#root').getAttribute('aria-hidden')).toEqual('true');
-      expect($('[role="dialog"]').isFocused()).toBeTruthy();
+      expect($('[role="dialog"] [data-terra-abstract-modal-begin="true"]').isFocused()).toBeTruthy();
     });
 
     it('closes modal on ESC', () => {
@@ -105,7 +105,7 @@ Terra.describeViewports('Abstract Modal', ['medium'], () => {
       });
 
       it('focuses on the modal when opened', () => {
-        expect($('[aria-modal="true"][role="dialog"]').isFocused()).toBeTruthy();
+        expect($('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]').isFocused()).toBeTruthy();
         Terra.validates.element('modal focused', { selector });
       });
 
@@ -146,7 +146,7 @@ Terra.describeViewports('Abstract Modal', ['medium'], () => {
     describe('No Focusable Content', () => {
       it('does focus on the modal when opened', () => {
         browser.url('/raw/tests/terra-abstract-modal/abstract-modal/abstract-modal-no-focusable-content');
-        expect($('[aria-modal="true"][role="dialog"]').isFocused()).toBeTruthy();
+        expect($('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]').isFocused()).toBeTruthy();
         Terra.validates.element('focus on modal', { selector });
       });
     });

--- a/packages/terra-dialog-modal/tests/wdio/dialog-modal-spec.js
+++ b/packages/terra-dialog-modal/tests/wdio/dialog-modal-spec.js
@@ -34,7 +34,7 @@ describe('Dialog Modal', () => {
     it('focuses on the modal when opened', () => {
       browser.url('/raw/tests/terra-dialog-modal/dialog-modal/default-dialog-modal');
       $('#trigger-dialog-modal').click();
-      expect($('[aria-modal="true"][role="dialog"]').isFocused()).toEqual(true);
+      expect($('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]').isFocused()).toEqual(true);
       Terra.validates.element('modal is focused on open', { selector: '#root' });
     });
 

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+  * Changed
+    * Updated to read the title of the modal by the screen reader when a modal is opened.
+
 ## 6.60.0 - (March 29, 2023)
 
 * Changed

--- a/packages/terra-modal-manager/src/ModalManager.jsx
+++ b/packages/terra-modal-manager/src/ModalManager.jsx
@@ -93,7 +93,7 @@ class ModalManager extends React.Component {
           }}
           closeOnEsc
           closeOnOutsideClick={false}
-          ariaLabel="Modal"
+          ariaLabel={headerDataForPresentedComponent?.title || 'Modal'}
         >
           <ContentContainer
             fill

--- a/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
+++ b/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
@@ -192,6 +192,10 @@ exports[`ModalManager should disclose content in Modal 1`] = `
                     tabindex="0"
                   >
                     <span
+                      data-terra-abstract-modal-begin="true"
+                      tabindex="-1"
+                    />
+                    <span
                       class="visually-hidden-text"
                       data-terra-abstract-modal-begin="true"
                       tabindex="-1"
@@ -271,6 +275,10 @@ exports[`ModalManager should disclose content in Modal 1`] = `
                   role="dialog"
                   tabIndex="0"
                 >
+                  <span
+                    data-terra-abstract-modal-begin={true}
+                    tabIndex="-1"
+                  />
                   <FormattedMessage
                     id="Terra.AbstractModal.BeginModalDialog"
                     values={Object {}}

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -316,13 +316,13 @@ Terra.describeViewports('ModalManager - Behaviors', ['large'], () => {
       it(' is on the first element when modal when opened', () => {
         $('#root-component .disclose-small').click();
         $('[class*="slide-group"] #DemoContainer-1 .maximize').waitForDisplayed({ timeout: 1000 });
-        
-        const firstElementWithModalBeginAttribute =  $('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]');
+
+        const firstElementWithModalBeginAttribute = $('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]');
         expect(firstElementWithModalBeginAttribute.getText() === '').toEqual(true);
-        
+
         const expectedParentElement = $('[aria-modal="true"][role="dialog"]');
         expect(firstElementWithModalBeginAttribute.parentElement().getHTML() === expectedParentElement.getHTML()).toEqual(true);
-        
+
         Terra.validates.element('modal is focused', { selector });
         browser.keys('Escape');
       });

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -318,7 +318,7 @@ Terra.describeViewports('ModalManager - Behaviors', ['large'], () => {
         $('[class*="slide-group"] #DemoContainer-1 .maximize').waitForDisplayed({ timeout: 1000 });
 
         const firstElementWithModalBeginAttribute = $('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]');
-        expect(firstElementWithModalBeginAttribute.getText() === '').toEqual(true);
+        expect(firstElementWithModalBeginAttribute.getText()).toBe('');
 
         const expectedParentElement = $('[aria-modal="true"][role="dialog"]');
         expect(firstElementWithModalBeginAttribute.parentElement().getHTML() === expectedParentElement.getHTML()).toEqual(true);

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -321,7 +321,7 @@ Terra.describeViewports('ModalManager - Behaviors', ['large'], () => {
         expect(firstElementWithModalBeginAttribute.getText()).toBe('');
 
         const expectedParentElement = $('[aria-modal="true"][role="dialog"]');
-        expect(firstElementWithModalBeginAttribute.parentElement().getHTML() === expectedParentElement.getHTML()).toEqual(true);
+        expect(firstElementWithModalBeginAttribute.parentElement().getHTML()).toBe(expectedParentElement.getHTML());
 
         Terra.validates.element('modal is focused', { selector });
         browser.keys('Escape');

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -313,10 +313,16 @@ Terra.describeViewports('ModalManager - Behaviors', ['large'], () => {
     });
 
     describe('Modal Focus', () => {
-      it('focuses on the modal when opened', () => {
+      it(' is on the first element when modal when opened', () => {
         $('#root-component .disclose-small').click();
         $('[class*="slide-group"] #DemoContainer-1 .maximize').waitForDisplayed({ timeout: 1000 });
-        expect($('[aria-modal="true"][role="dialog"]').isFocused()).toEqual(true);
+        
+        const firstElementWithModalBeginAttribute =  $('[aria-modal="true"][role="dialog"] [data-terra-abstract-modal-begin="true"]');
+        expect(firstElementWithModalBeginAttribute.getText() === '').toEqual(true);
+        
+        const expectedParentElement = $('[aria-modal="true"][role="dialog"]');
+        expect(firstElementWithModalBeginAttribute.parentElement().getHTML() === expectedParentElement.getHTML()).toEqual(true);
+        
         Terra.validates.element('modal is focused', { selector });
         browser.keys('Escape');
       });

--- a/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
+++ b/packages/terra-modal-manager/tests/wdio/modal-manager-spec.js
@@ -313,7 +313,7 @@ Terra.describeViewports('ModalManager - Behaviors', ['large'], () => {
     });
 
     describe('Modal Focus', () => {
-      it(' is on the first element when modal when opened', () => {
+      it('is on the first element when modal when opened', () => {
         $('#root-component .disclose-small').click();
         $('[class*="slide-group"] #DemoContainer-1 .maximize').waitForDisplayed({ timeout: 1000 });
 

--- a/packages/terra-notification-dialog/tests/jest/__snapshots__/NotificationDialog.test.jsx.snap
+++ b/packages/terra-notification-dialog/tests/jest/__snapshots__/NotificationDialog.test.jsx.snap
@@ -1090,6 +1090,10 @@ exports[`correctly applies the theme context className 1`] = `
                   tabindex="0"
                 >
                   <span
+                    data-terra-abstract-modal-begin="true"
+                    tabindex="-1"
+                  />
+                  <span
                     class="visually-hidden-text"
                     data-terra-abstract-modal-begin="true"
                     tabindex="-1"
@@ -1232,6 +1236,10 @@ exports[`correctly applies the theme context className 1`] = `
                 role="alertdialog"
                 tabIndex="0"
               >
+                <span
+                  data-terra-abstract-modal-begin={true}
+                  tabIndex="-1"
+                />
                 <FormattedMessage
                   id="Terra.AbstractModal.BeginModalDialog"
                   values={Object {}}


### PR DESCRIPTION
### Summary
When entering a modal, the h1 title of the modal should be read by the screen reader. 

**What was changed:**
The required behavior was achieved by introducing an additional non-hidden empty span with tabIndex=-1, data-terra-abstract-modal-begin attribute and assign focus on dialog opening.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:
- [x] Jest
- [x] WDIO
- [x] Visual testing (please attach a screenshot or recording)

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

**This PR resolves:**

UXPLATFORM-8733

---

Thank you for contributing to Terra.
@cerner/terra
