### PR TITLE
Added screen reader support for nested modalManager disclosures

### DIFF
--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-
+  * Changed
+    * Added Accessibility support for nested ModalManager disclosures.
+    
 ## 3.40.0 - (April 27, 2023)
 
   * Added

--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
   * Changed
-    * Added Accessibility support for nested ModalManager disclosures.
+    * Added screen reader support to read the title of the modal when it is open for nested ModalManager disclosures.
     
 ## 3.40.0 - (April 27, 2023)
 

--- a/packages/terra-abstract-modal/CHANGELOG.md
+++ b/packages/terra-abstract-modal/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-  * Changed
+  * Added
     * Added screen reader support to read the title of the modal when it is open for nested ModalManager disclosures.
     
 ## 3.40.0 - (April 27, 2023)

--- a/packages/terra-abstract-modal/src/AbstractModal.jsx
+++ b/packages/terra-abstract-modal/src/AbstractModal.jsx
@@ -60,6 +60,11 @@ const propTypes = {
    * Z-Index layer to apply to the ModalContent and ModalOverlay. Valid values are the standard modal layer: '6000', and the max layer: '8000'.
    */
   zIndex: PropTypes.oneOf(zIndexes),
+  /**
+   * @private
+   * Callback function to set the reference of the element that will receive focus when the Slide content is visible.
+   */
+  setModalFocusElementRef: PropTypes.func,
 };
 
 const defaultProps = {

--- a/packages/terra-abstract-modal/src/_ModalContent.jsx
+++ b/packages/terra-abstract-modal/src/_ModalContent.jsx
@@ -58,6 +58,11 @@ const propTypes = {
    * Z-Index layer to apply to the ModalContent and ModalOverlay.
    */
   zIndex: PropTypes.oneOf(zIndexes),
+  /**
+   * @private
+   * Callback function to set the reference of the element that will receive focus when the Slide content is visible.
+   */
+  setModalFocusElementRef: PropTypes.func,
 };
 
 const defaultProps = {
@@ -84,6 +89,7 @@ const ModalContent = forwardRef((props, ref) => {
     isScrollable,
     rootSelector,
     zIndex,
+    setModalFocusElementRef,
     ...customProps
   } = props;
 
@@ -141,7 +147,7 @@ const ModalContent = forwardRef((props, ref) => {
           // This empty span with data-terra-abstract-modal-begin attribute
           //  receives focus when the dialog is opened.
         }
-        <span data-terra-abstract-modal-begin tabIndex="-1" />
+        <span ref={setModalFocusElementRef} data-terra-abstract-modal-begin tabIndex="-1" />
         <FormattedMessage id="Terra.AbstractModal.BeginModalDialog">
           {text => {
             // In the latest version of react-intl this param is an array, when previous versions it was a string.

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
   * Changed
-    * Added Accessibility support for nested ModalManager disclosures.
+    * Added screen reader support to read the title of the modal when it is open for nested ModalManager disclosures.
 
 ## 6.61.0 - (April 27, 2023)
 

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+  * Changed
+    * Added Accessibility support for nested ModalManager disclosures.
+
 ## 6.61.0 - (April 27, 2023)
 
   * Changed

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  * Changed
+  * Added
     * Added screen reader support to read the title of the modal when it is open for nested ModalManager disclosures.
 
 ## 6.61.0 - (April 27, 2023)

--- a/packages/terra-modal-manager/src/ModalManager.jsx
+++ b/packages/terra-modal-manager/src/ModalManager.jsx
@@ -53,6 +53,11 @@ class ModalManager extends React.Component {
     super(props);
 
     this.renderModal = this.renderModal.bind(this);
+    this.setModalFocusElementRef = this.setModalFocusElementRef.bind(this);
+  }
+
+  setModalFocusElementRef(node) {
+    this.modalElementRef = node;
   }
 
   renderModal(manager) {
@@ -94,6 +99,7 @@ class ModalManager extends React.Component {
           closeOnEsc
           closeOnOutsideClick={false}
           ariaLabel={headerDataForPresentedComponent?.title || 'Modal'}
+          setModalFocusElementRef={this.setModalFocusElementRef}
         >
           <ContentContainer
             fill
@@ -112,7 +118,7 @@ class ModalManager extends React.Component {
               </React.Fragment>
             )}
           >
-            <SlideGroup items={manager.disclosure.components} isAnimated={!isFullscreen} />
+            <SlideGroup items={manager.disclosure.components} isAnimated={!isFullscreen} focusRef={this.modalElementRef} />
           </ContentContainer>
         </AbstractModal>
       </div>

--- a/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
+++ b/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`ModalManager correctly applies the theme context className 1`] = `
             onRequestClose={[Function]}
             role="dialog"
             rootSelector="#root"
+            setModalFocusElementRef={[Function]}
             zIndex="6000"
           />
         </div>
@@ -173,6 +174,7 @@ exports[`ModalManager should disclose content in Modal 1`] = `
           onRequestClose={[Function]}
           role="dialog"
           rootSelector="#root"
+          setModalFocusElementRef={[Function]}
           zIndex="6000"
         >
           <Portal
@@ -255,6 +257,7 @@ exports[`ModalManager should disclose content in Modal 1`] = `
                 onRequestClose={[Function]}
                 role="dialog"
                 rootSelector="#root"
+                setModalFocusElementRef={[Function]}
                 zIndex="6000"
               >
                 <ModalOverlay
@@ -603,6 +606,7 @@ exports[`ModalManager should render the ModalManager with custom props 1`] = `
           onRequestClose={[Function]}
           role="dialog"
           rootSelector="#root"
+          setModalFocusElementRef={[Function]}
           zIndex="6000"
         />
       </div>
@@ -715,6 +719,7 @@ exports[`ModalManager should render the ModalManager with defaults 1`] = `
           onRequestClose={[Function]}
           role="dialog"
           rootSelector="#root"
+          setModalFocusElementRef={[Function]}
           zIndex="6000"
         />
       </div>


### PR DESCRIPTION
### Summary
When entering a modal and its nested disclosures, the h1 title of the modal should be read by the screen reader.

**What was changed:**
The required behavior was achieved by introducing an additional non-hidden empty span with tabIndex=-1, data-terra-abstract-modal-begin attribute and assign focus on dialog opening. Additionally, reference to the span was passed to read the heading for nested disclosures.

### Testing

This change was tested using:

- [X] WDIO
- [X] Jest
- [X] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [X] UX review
- [X] Accessibility review
- [ ] Functional review

**This PR resolves:**

UXPLATFORM-8733

Thank you for contributing to Terra.
@cerner/terra
