### PR TITLE
[terra-worklist-data-grid] Remove ability to vary the row height

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Changed
+  * Updated examples and tests for `terra-worklist-data-grid` to remove row height
 
 ## 1.22.0 - (June 5, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/worklist-data-grid/example/gridData.json
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/worklist-data-grid/example/gridData.json
@@ -27,7 +27,6 @@
       ]
     },
     {
-      "height": "150px",
       "id": "2",
       "cells": [
         { "content": "Temperature Oral (degC)"},

--- a/packages/terra-framework-docs/src/terra-dev-site/test/worklist-data-grid/gridData.json
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/worklist-data-grid/gridData.json
@@ -27,7 +27,6 @@
       ]
     },
     {
-      "height": "150px",
       "id": "2",
       "cells": [
         { "content": "Temperature Oral (degC)"},

--- a/packages/terra-worklist-data-grid/CHANGELOG.md
+++ b/packages/terra-worklist-data-grid/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Changed
+  * Removed ability to set variable row heights
 
 * Initial stable release

--- a/packages/terra-worklist-data-grid/CHANGELOG.md
+++ b/packages/terra-worklist-data-grid/CHANGELOG.md
@@ -4,4 +4,5 @@
 * Changed
   * Removed ability to set variable row heights
 
-* Initial stable release
+## 0.1
+  * Initial stable release

--- a/packages/terra-worklist-data-grid/src/WorklistDataGrid.jsx
+++ b/packages/terra-worklist-data-grid/src/WorklistDataGrid.jsx
@@ -176,7 +176,7 @@ function WorklistDataGrid(props) {
   };
 
   const buildRow = (row) => {
-    const height = row.height || props.rowHeight;
+    const height = props.rowHeight;
     return (
       <tr key={row.id} className={cx('worklist-data-grid-row')} style={{ height }}>
         {row.cells.map((cell, cellColumnIndex) => (

--- a/packages/terra-worklist-data-grid/src/proptypes/rowShape.js
+++ b/packages/terra-worklist-data-grid/src/proptypes/rowShape.js
@@ -6,10 +6,7 @@ const rowShape = PropTypes.shape({
    * An identifier to uniquely identify the row within the grid.
    */
   id: PropTypes.string.isRequired,
-  /**
-   * String that specifies the row height. Any valid CSS height value is accepted.
-   */
-  height: PropTypes.string,
+
   /**
    * Data to be displayed in the cells of the row. Cells will be rendered in the row in the order given.
    */


### PR DESCRIPTION

### Summary

**What was changed:**
The ability to specify a height for each specific row was removed.

**Why it was changed:**
Based on the updated requirements, all rows of the worklist data grid should be the same height.


### Testing

This change was tested using:

- [x] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-9044

---

Thank you for contributing to Terra.
@cerner/terra
