### PR TITLE
uuid locked to v8.2.0

### DIFF
--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.38.0 - (June 5, 2023)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 1.37.0 - (May 25, 2023)
 

--- a/packages/terra-date-input/package.json
+++ b/packages/terra-date-input/package.json
@@ -37,7 +37,7 @@
     "terra-theme-context": "^1.8.0",
     "terra-time-input": "^4.50.0",
     "terra-visually-hidden-text": "^2.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "devDependencies": {
     "terra-form-checkbox": "^4.16.0",

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 4.82.0 - (June 5, 2023)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 4.81.0 - (May 11, 2023)
 

--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -43,7 +43,7 @@
     "terra-responsive-element": "^5.0.0",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Changed
   * Allow navigation to disabled items
   * Updated submenu exit context to first item
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 6.67.0 - (May 11, 2023)
 

--- a/packages/terra-menu/package.json
+++ b/packages/terra-menu/package.json
@@ -36,7 +36,7 @@
     "terra-popup": "^6.67.0",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.36.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "devDependencies": {
     "terra-button": "^3.3.0",

--- a/packages/terra-navigation-prompt/CHANGELOG.md
+++ b/packages/terra-navigation-prompt/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.70.0 - (June 5, 2023)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 1.69.0 - (May 11, 2023)
 

--- a/packages/terra-navigation-prompt/package.json
+++ b/packages/terra-navigation-prompt/package.json
@@ -31,7 +31,7 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-notification-dialog": "^4.30.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-pills/CHANGELOG.md
+++ b/packages/terra-pills/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.6.0 - (June 5, 2023)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 1.5.0 - (May 11, 2023)
 

--- a/packages/terra-pills/package.json
+++ b/packages/terra-pills/package.json
@@ -38,7 +38,7 @@
     "terra-popup": "^6.67.0",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.32.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-slide-panel/CHANGELOG.md
+++ b/packages/terra-slide-panel/CHANGELOG.md
@@ -11,7 +11,7 @@
   * Fixed a11y bug where multiple slide panels shared same ID for visually hidden text. (This fix requires updates to Jest snapshots and requires UUID to be mocked on consuming applications)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 3.39.0 - (April 27, 2023)
 

--- a/packages/terra-slide-panel/package.json
+++ b/packages/terra-slide-panel/package.json
@@ -32,7 +32,7 @@
     "prop-types": "^15.5.8",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.36.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 6.69.0 - (June 5, 2023)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 6.68.0 - (May 11, 2023)
 

--- a/packages/terra-tabs/package.json
+++ b/packages/terra-tabs/package.json
@@ -37,7 +37,7 @@
     "terra-responsive-element": "^5.0.0",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.36.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 4.50.0 - (June 5, 2023)
 
 * Changed
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 4.49.0 - (May 25, 2023)
 

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -34,7 +34,7 @@
     "terra-form-input": "^4.4.0",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.35.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
Per test issues caused to some projects that use terra-toolkit by stringify updated in uuid v8.3.0, the uuid version has been locked to 8.2.0

### Testing

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review