### PR TITLE
[terra-worklist-data-grid] Make Row Selection Column Header Selectable

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * Updated toggle examples for `terra-collapsible-menu-view` to include selectable toggles and toggles within a collapsed menu.
+  * Updated row selection example for `terra-worklist-data-grid` to show ability to select the row selection column header.
 
 ## 1.31.0 - (August 4, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/worklist-data-grid/Examples.2/RowSelection.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/worklist-data-grid/Examples.2/RowSelection.jsx
@@ -99,6 +99,7 @@ const RowSelection = () => {
 
   const onColumnSelect = (columnId) => {
     if (columnId === WorklistDataGridUtils.ROW_SELECTION_COLUMN.id) {
+      // eslint-disable-next-line no-alert
       alert('Row Selection Header Clicked');
     }
   };

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/worklist-data-grid/Examples.2/RowSelection.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/worklist-data-grid/Examples.2/RowSelection.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import WorklistDataGrid from 'terra-worklist-data-grid';
+import WorklistDataGridUtils from 'terra-worklist-data-grid/src/utils/WorklistDataGridUtils';
 
 const gridDataJSON = {
   cols: [
@@ -96,6 +97,12 @@ const RowSelection = () => {
     setHasSelectableRows(event.target.checked);
   };
 
+  const onColumnSelect = (columnId) => {
+    if (columnId === WorklistDataGridUtils.ROW_SELECTION_COLUMN.id) {
+      alert('Row Selection Header Clicked');
+    }
+  };
+
   return (
     <React.Fragment>
       <div>
@@ -137,6 +144,7 @@ const RowSelection = () => {
         onDisableSelectableRows={() => {
           disableSelectableRows();
         }}
+        onColumnSelect={onColumnSelect}
       />
     </React.Fragment>
   );

--- a/packages/terra-worklist-data-grid/CHANGELOG.md
+++ b/packages/terra-worklist-data-grid/CHANGELOG.md
@@ -10,6 +10,7 @@
   * Added `overflowColumns` prop for columns that are scrollable.
   * Added support for pinned columns.
   * Added ability to dive into cells with focusable elements.
+  * Added ability to selct the row selection column header to allow sorting by consumers.
  
 * Fixed
   * Text alignment of the row header column.

--- a/packages/terra-worklist-data-grid/src/WorklistDataGrid.jsx
+++ b/packages/terra-worklist-data-grid/src/WorklistDataGrid.jsx
@@ -393,7 +393,7 @@ function WorklistDataGrid(props) {
 
   const handleColumnSelect = (columnId, cellCoordinates) => {
     handleCellSelectionChange(null, null, cellCoordinates);
-    if (onColumnSelect && !(hasSelectableRows && cellCoordinates.col === 0)) {
+    if (onColumnSelect) {
       onColumnSelect(columnId);
     }
   };

--- a/packages/terra-worklist-data-grid/src/utils/WorklistDataGridUtils.js
+++ b/packages/terra-worklist-data-grid/src/utils/WorklistDataGridUtils.js
@@ -4,7 +4,7 @@
 const ROW_SELECTION_COLUMN = {
   id: 'WorklistDataGrid-rowSelectionColumn',
   width: 40,
-  isSelectable: false,
+  isSelectable: true,
   isResizable: false,
 };
 

--- a/packages/terra-worklist-data-grid/tests/jest/WorklistDataGrid.test.jsx
+++ b/packages/terra-worklist-data-grid/tests/jest/WorklistDataGrid.test.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { mountWithIntl, shallowWithIntl } from 'terra-enzyme-intl';
 import WorklistDataGrid from '../../src/WorklistDataGrid';
+import WorklistDataGridUtils from '../../src/utils/WorklistDataGridUtils';
+import ColumnHeaderCell from '../../src/subcomponents/ColumnHeaderCell';
 import ColumnHeader from '../../src/subcomponents/ColumnHeader';
 import Row from '../../src/subcomponents/Row';
-
 import ERRORS from '../../src/utils/constants';
 
 // Source data for tests
@@ -102,6 +103,32 @@ describe('basic grid', () => {
     verifyRow(0, rows.get(0), dataFile.rows[0], dataFile.cols);
     verifyRow(1, rows.get(1), dataFile.rows[1], dataFile.cols);
     verifyRow(2, rows.get(2), dataFile.rows[2], dataFile.cols);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('verifies row selection column header selection', () => {
+    const mockColumnSelect = jest.fn();
+
+    const wrapper = mountWithIntl(
+      <WorklistDataGrid
+        id="test-terra-worklist-data-grid"
+        pinnedColumns={dataFile.cols.slice(0, 2)}
+        overflowColumns={dataFile.cols.slice(2)}
+        hasSelectableRows
+        rows={dataFile.rows}
+        onColumnSelect={mockColumnSelect}
+      />,
+    );
+
+    // Find column headers
+    const columnHeader = wrapper.find(ColumnHeaderCell);
+
+    // Simulate onMouseDown event on row selection column header
+    columnHeader.at(0).simulate('mouseDown');
+
+    // Validate mock function was called from simulated click event
+    expect(mockColumnSelect).toHaveBeenCalledWith(WorklistDataGridUtils.ROW_SELECTION_COLUMN.id);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/packages/terra-worklist-data-grid/tests/jest/__snapshots__/WorklistDataGrid.test.jsx.snap
+++ b/packages/terra-worklist-data-grid/tests/jest/__snapshots__/WorklistDataGrid.test.jsx.snap
@@ -1,5 +1,2321 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`basic grid verifies row selection column header selection 1`] = `
+<InjectIntl(WorklistDataGrid)
+  hasSelectableRows={true}
+  id="test-terra-worklist-data-grid"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": null,
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
+  onColumnSelect={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "WorklistDataGrid-rowSelectionColumn",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  overflowColumns={
+    Array [
+      Object {
+        "displayName": "March 17",
+        "id": "Column-2",
+        "isSelectable": false,
+      },
+    ]
+  }
+  pinnedColumns={
+    Array [
+      Object {
+        "displayName": " Vitals",
+        "id": "Column-0",
+      },
+      Object {
+        "displayName": "March 16",
+        "id": "Column-1",
+      },
+    ]
+  }
+  rows={
+    Array [
+      Object {
+        "cells": Array [
+          Object {
+            "content": "Heart Rate Monitored (bpm)",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "66",
+            "isMasked": true,
+          },
+        ],
+        "id": "1",
+      },
+      Object {
+        "cells": Array [
+          Object {
+            "content": "Temperature Oral (degC)",
+          },
+          Object {
+            "content": "36.7",
+          },
+          Object {
+            "content": "36.9",
+            "isMasked": true,
+          },
+        ],
+        "id": "2",
+      },
+      Object {
+        "cells": Array [
+          Object {
+            "content": "Cardiac Index (L/min/m2)",
+          },
+          Object {
+            "content": "2.25",
+          },
+          Object {
+            "content": "2.28",
+            "isMasked": true,
+          },
+        ],
+        "id": "3",
+      },
+    ]
+  }
+>
+  <WorklistDataGrid
+    columnHeaderHeight="2.5rem"
+    defaultColumnWidth={200}
+    hasSelectableRows={true}
+    id="test-terra-worklist-data-grid"
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": null,
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
+      }
+    }
+    onColumnSelect={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "WorklistDataGrid-rowSelectionColumn",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    overflowColumns={
+      Array [
+        Object {
+          "displayName": "March 17",
+          "id": "Column-2",
+          "isSelectable": false,
+        },
+      ]
+    }
+    pinnedColumns={
+      Array [
+        Object {
+          "displayName": " Vitals",
+          "id": "Column-0",
+        },
+        Object {
+          "displayName": "March 16",
+          "id": "Column-1",
+        },
+      ]
+    }
+    rowHeaderIndex={0}
+    rowHeight="2.5rem"
+    rows={
+      Array [
+        Object {
+          "cells": Array [
+            Object {
+              "content": "Heart Rate Monitored (bpm)",
+            },
+            Object {
+              "content": "",
+            },
+            Object {
+              "content": "66",
+              "isMasked": true,
+            },
+          ],
+          "id": "1",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "content": "Temperature Oral (degC)",
+            },
+            Object {
+              "content": "36.7",
+            },
+            Object {
+              "content": "36.9",
+              "isMasked": true,
+            },
+          ],
+          "id": "2",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "content": "Cardiac Index (L/min/m2)",
+            },
+            Object {
+              "content": "2.25",
+            },
+            Object {
+              "content": "2.28",
+              "isMasked": true,
+            },
+          ],
+          "id": "3",
+        },
+      ]
+    }
+  >
+    <div
+      className="worklist-data-grid-container"
+    >
+      <table
+        className="worklist-data-grid"
+        id="test-terra-worklist-data-grid"
+        onKeyDown={[Function]}
+        role="grid"
+      >
+        <ColumnHeader
+          columns={
+            Array [
+              Object {
+                "id": "WorklistDataGrid-rowSelectionColumn",
+                "isResizable": false,
+                "isSelectable": true,
+                "maximumWidth": 300,
+                "minimumWidth": 60,
+                "width": 40,
+              },
+              Object {
+                "displayName": " Vitals",
+                "id": "Column-0",
+                "maximumWidth": 300,
+                "minimumWidth": 60,
+                "width": 200,
+              },
+              Object {
+                "displayName": "March 16",
+                "id": "Column-1",
+                "maximumWidth": 300,
+                "minimumWidth": 60,
+                "width": 200,
+              },
+              Object {
+                "displayName": "March 17",
+                "id": "Column-2",
+                "isSelectable": false,
+                "maximumWidth": 300,
+                "minimumWidth": 60,
+                "width": 200,
+              },
+            ]
+          }
+          headerHeight="2.5rem"
+          onColumnSelect={[Function]}
+          onResizeMouseDown={[Function]}
+          tabStopColumnIndex={0}
+          tableHeight={-1}
+        >
+          <thead>
+            <tr
+              className="column-header-row"
+              height="2.5rem"
+            >
+              <InjectIntl(ColumnHeaderCell)
+                columnIndex={0}
+                headerHeight="2.5rem"
+                id="WorklistDataGrid-rowSelectionColumn"
+                isResizable={false}
+                isSelectable={true}
+                isTabStop={true}
+                key="WorklistDataGrid-rowSelectionColumn"
+                maximumWidth={300}
+                minimumWidth={60}
+                onColumnSelect={[Function]}
+                onResizeMouseDown={[Function]}
+                rowIndex={0}
+                tableHeight={-1}
+                width={40}
+              >
+                <ColumnHeaderCell
+                  columnIndex={0}
+                  hasError={false}
+                  headerHeight="2.5rem"
+                  id="WorklistDataGrid-rowSelectionColumn"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isResizable={false}
+                  isSelectable={true}
+                  isTabStop={true}
+                  maximumWidth={300}
+                  minimumWidth={60}
+                  onColumnSelect={[Function]}
+                  onResizeMouseDown={[Function]}
+                  rowIndex={0}
+                  tableHeight={-1}
+                  width={40}
+                >
+                  <th
+                    className="column-header selectable pinned"
+                    key="WorklistDataGrid-rowSelectionColumn"
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    role="columnheader"
+                    scope="col"
+                    style={
+                      Object {
+                        "height": "2.5rem",
+                        "left": 0,
+                        "width": "40px",
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      className="header-container"
+                    >
+                      <span />
+                    </div>
+                  </th>
+                </ColumnHeaderCell>
+              </InjectIntl(ColumnHeaderCell)>
+              <InjectIntl(ColumnHeaderCell)
+                columnIndex={1}
+                displayName=" Vitals"
+                headerHeight="2.5rem"
+                id="Column-0"
+                isTabStop={false}
+                key="Column-0"
+                maximumWidth={300}
+                minimumWidth={60}
+                onColumnSelect={[Function]}
+                onResizeMouseDown={[Function]}
+                rowIndex={0}
+                tableHeight={-1}
+                width={200}
+              >
+                <ColumnHeaderCell
+                  columnIndex={1}
+                  displayName=" Vitals"
+                  hasError={false}
+                  headerHeight="2.5rem"
+                  id="Column-0"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isResizable={true}
+                  isSelectable={true}
+                  isTabStop={false}
+                  maximumWidth={300}
+                  minimumWidth={60}
+                  onColumnSelect={[Function]}
+                  onResizeMouseDown={[Function]}
+                  rowIndex={0}
+                  tableHeight={-1}
+                  width={200}
+                >
+                  <th
+                    className="column-header selectable pinned"
+                    key="Column-0"
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    role="columnheader"
+                    scope="col"
+                    style={
+                      Object {
+                        "height": "2.5rem",
+                        "left": 40,
+                        "width": "200px",
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="header-container"
+                      role="button"
+                    >
+                      <span>
+                         Vitals
+                      </span>
+                    </div>
+                    <InjectIntl(ColumnResizeHandle)
+                      columnIndex={1}
+                      columnText=" Vitals"
+                      columnWidth={200}
+                      height={-1}
+                      maximumWidth={300}
+                      minimumWidth={60}
+                      onResizeMouseDown={[Function]}
+                    >
+                      <ColumnResizeHandle
+                        columnIndex={1}
+                        columnText=" Vitals"
+                        columnWidth={200}
+                        height={-1}
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en",
+                            "formatDate": [Function],
+                            "formatHTMLMessage": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatPlural": [Function],
+                            "formatRelative": [Function],
+                            "formatTime": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralFormat": [Function],
+                              "getRelativeFormat": [Function],
+                            },
+                            "locale": "en",
+                            "messages": null,
+                            "now": [Function],
+                            "onError": [Function],
+                            "textComponent": "span",
+                            "timeZone": null,
+                          }
+                        }
+                        maximumWidth={300}
+                        minimumWidth={60}
+                        onResizeMouseDown={[Function]}
+                      >
+                        <div
+                          aria-hidden={true}
+                          aria-label=" Vitals"
+                          aria-valuemax={300}
+                          aria-valuemin={60}
+                          aria-valuenow={200}
+                          aria-valuetext="Terra.worklist-data-grid.resizeHandleValueText"
+                          className="resize-handle"
+                          draggable={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseDown={[Function]}
+                          role="slider"
+                          style={
+                            Object {
+                              "height": "-1px",
+                            }
+                          }
+                          tabIndex={-1}
+                        />
+                      </ColumnResizeHandle>
+                    </InjectIntl(ColumnResizeHandle)>
+                  </th>
+                </ColumnHeaderCell>
+              </InjectIntl(ColumnHeaderCell)>
+              <InjectIntl(ColumnHeaderCell)
+                columnIndex={2}
+                displayName="March 16"
+                headerHeight="2.5rem"
+                id="Column-1"
+                isTabStop={false}
+                key="Column-1"
+                maximumWidth={300}
+                minimumWidth={60}
+                onColumnSelect={[Function]}
+                onResizeMouseDown={[Function]}
+                rowIndex={0}
+                tableHeight={-1}
+                width={200}
+              >
+                <ColumnHeaderCell
+                  columnIndex={2}
+                  displayName="March 16"
+                  hasError={false}
+                  headerHeight="2.5rem"
+                  id="Column-1"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isResizable={true}
+                  isSelectable={true}
+                  isTabStop={false}
+                  maximumWidth={300}
+                  minimumWidth={60}
+                  onColumnSelect={[Function]}
+                  onResizeMouseDown={[Function]}
+                  rowIndex={0}
+                  tableHeight={-1}
+                  width={200}
+                >
+                  <th
+                    className="column-header selectable pinned"
+                    key="Column-1"
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    role="columnheader"
+                    scope="col"
+                    style={
+                      Object {
+                        "height": "2.5rem",
+                        "left": 240,
+                        "width": "200px",
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="header-container"
+                      role="button"
+                    >
+                      <span>
+                        March 16
+                      </span>
+                    </div>
+                    <InjectIntl(ColumnResizeHandle)
+                      columnIndex={2}
+                      columnText="March 16"
+                      columnWidth={200}
+                      height={-1}
+                      maximumWidth={300}
+                      minimumWidth={60}
+                      onResizeMouseDown={[Function]}
+                    >
+                      <ColumnResizeHandle
+                        columnIndex={2}
+                        columnText="March 16"
+                        columnWidth={200}
+                        height={-1}
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en",
+                            "formatDate": [Function],
+                            "formatHTMLMessage": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatPlural": [Function],
+                            "formatRelative": [Function],
+                            "formatTime": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralFormat": [Function],
+                              "getRelativeFormat": [Function],
+                            },
+                            "locale": "en",
+                            "messages": null,
+                            "now": [Function],
+                            "onError": [Function],
+                            "textComponent": "span",
+                            "timeZone": null,
+                          }
+                        }
+                        maximumWidth={300}
+                        minimumWidth={60}
+                        onResizeMouseDown={[Function]}
+                      >
+                        <div
+                          aria-hidden={true}
+                          aria-label="March 16"
+                          aria-valuemax={300}
+                          aria-valuemin={60}
+                          aria-valuenow={200}
+                          aria-valuetext="Terra.worklist-data-grid.resizeHandleValueText"
+                          className="resize-handle"
+                          draggable={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseDown={[Function]}
+                          role="slider"
+                          style={
+                            Object {
+                              "height": "-1px",
+                            }
+                          }
+                          tabIndex={-1}
+                        />
+                      </ColumnResizeHandle>
+                    </InjectIntl(ColumnResizeHandle)>
+                    <div
+                      className="pinned-columns-divider"
+                      style={
+                        Object {
+                          "height": -1,
+                          "left": 199,
+                        }
+                      }
+                    />
+                  </th>
+                </ColumnHeaderCell>
+              </InjectIntl(ColumnHeaderCell)>
+              <InjectIntl(ColumnHeaderCell)
+                columnIndex={3}
+                displayName="March 17"
+                headerHeight="2.5rem"
+                id="Column-2"
+                isSelectable={false}
+                isTabStop={false}
+                key="Column-2"
+                maximumWidth={300}
+                minimumWidth={60}
+                onColumnSelect={[Function]}
+                onResizeMouseDown={[Function]}
+                rowIndex={0}
+                tableHeight={-1}
+                width={200}
+              >
+                <ColumnHeaderCell
+                  columnIndex={3}
+                  displayName="March 17"
+                  hasError={false}
+                  headerHeight="2.5rem"
+                  id="Column-2"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isResizable={true}
+                  isSelectable={false}
+                  isTabStop={false}
+                  maximumWidth={300}
+                  minimumWidth={60}
+                  onColumnSelect={[Function]}
+                  onResizeMouseDown={[Function]}
+                  rowIndex={0}
+                  tableHeight={-1}
+                  width={200}
+                >
+                  <th
+                    className="column-header"
+                    key="Column-2"
+                    role="columnheader"
+                    scope="col"
+                    style={
+                      Object {
+                        "height": "2.5rem",
+                        "left": null,
+                        "width": "200px",
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="header-container"
+                      role="button"
+                    >
+                      <span>
+                        March 17
+                      </span>
+                    </div>
+                    <InjectIntl(ColumnResizeHandle)
+                      columnIndex={3}
+                      columnText="March 17"
+                      columnWidth={200}
+                      height={-1}
+                      maximumWidth={300}
+                      minimumWidth={60}
+                      onResizeMouseDown={[Function]}
+                    >
+                      <ColumnResizeHandle
+                        columnIndex={3}
+                        columnText="March 17"
+                        columnWidth={200}
+                        height={-1}
+                        intl={
+                          Object {
+                            "defaultFormats": Object {},
+                            "defaultLocale": "en",
+                            "formatDate": [Function],
+                            "formatHTMLMessage": [Function],
+                            "formatMessage": [Function],
+                            "formatNumber": [Function],
+                            "formatPlural": [Function],
+                            "formatRelative": [Function],
+                            "formatTime": [Function],
+                            "formats": Object {},
+                            "formatters": Object {
+                              "getDateTimeFormat": [Function],
+                              "getMessageFormat": [Function],
+                              "getNumberFormat": [Function],
+                              "getPluralFormat": [Function],
+                              "getRelativeFormat": [Function],
+                            },
+                            "locale": "en",
+                            "messages": null,
+                            "now": [Function],
+                            "onError": [Function],
+                            "textComponent": "span",
+                            "timeZone": null,
+                          }
+                        }
+                        maximumWidth={300}
+                        minimumWidth={60}
+                        onResizeMouseDown={[Function]}
+                      >
+                        <div
+                          aria-hidden={true}
+                          aria-label="March 17"
+                          aria-valuemax={300}
+                          aria-valuemin={60}
+                          aria-valuenow={200}
+                          aria-valuetext="Terra.worklist-data-grid.resizeHandleValueText"
+                          className="resize-handle"
+                          draggable={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseDown={[Function]}
+                          role="slider"
+                          style={
+                            Object {
+                              "height": "-1px",
+                            }
+                          }
+                          tabIndex={-1}
+                        />
+                      </ColumnResizeHandle>
+                    </InjectIntl(ColumnResizeHandle)>
+                  </th>
+                </ColumnHeaderCell>
+              </InjectIntl(ColumnHeaderCell)>
+            </tr>
+          </thead>
+        </ColumnHeader>
+        <tbody>
+          <Row
+            cells={
+              Array [
+                Object {
+                  "content": "Heart Rate Monitored (bpm)",
+                },
+                Object {
+                  "content": "",
+                },
+                Object {
+                  "content": "66",
+                  "isMasked": true,
+                },
+              ]
+            }
+            displayedColumns={
+              Array [
+                Object {
+                  "id": "WorklistDataGrid-rowSelectionColumn",
+                  "isResizable": false,
+                  "isSelectable": true,
+                  "width": 40,
+                },
+                Object {
+                  "displayName": " Vitals",
+                  "id": "Column-0",
+                },
+                Object {
+                  "displayName": "March 16",
+                  "id": "Column-1",
+                },
+                Object {
+                  "displayName": "March 17",
+                  "id": "Column-2",
+                  "isSelectable": false,
+                },
+              ]
+            }
+            hasRowSelection={true}
+            height="2.5rem"
+            id="1"
+            isSelected={false}
+            key="1"
+            onCellSelect={[Function]}
+            onRowSelect={[Function]}
+            rowHeaderIndex={0}
+            rowIndex={1}
+          >
+            <tr
+              className="worklist-data-grid-row"
+              style={
+                Object {
+                  "height": "2.5rem",
+                }
+              }
+            >
+              <InjectIntl(RowSelectionCell)
+                columnId="WorklistDataGrid-rowSelectionColumn"
+                columnIndex={0}
+                isSelected={false}
+                isTabStop={false}
+                onCellSelect={[Function]}
+                rowId="1"
+                rowIndex={1}
+              >
+                <RowSelectionCell
+                  columnId="WorklistDataGrid-rowSelectionColumn"
+                  columnIndex={0}
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="1"
+                  rowIndex={1}
+                >
+                  <InjectIntl(Cell)
+                    columnId="WorklistDataGrid-rowSelectionColumn"
+                    columnIndex={0}
+                    isSelected={false}
+                    isTabStop={false}
+                    key="1_WorklistDataGrid-rowSelectionColumn"
+                    onCellSelect={[Function]}
+                    rowId="1"
+                    rowIndex={1}
+                  >
+                    <Cell
+                      columnId="WorklistDataGrid-rowSelectionColumn"
+                      columnIndex={0}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "formatDate": [Function],
+                          "formatHTMLMessage": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatPlural": [Function],
+                          "formatRelative": [Function],
+                          "formatTime": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralFormat": [Function],
+                            "getRelativeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": null,
+                          "now": [Function],
+                          "onError": [Function],
+                          "textComponent": "span",
+                          "timeZone": null,
+                        }
+                      }
+                      isMasked={false}
+                      isRowHeader={false}
+                      isSelectable={true}
+                      isSelected={false}
+                      isTabStop={false}
+                      onCellSelect={[Function]}
+                      rowId="1"
+                      rowIndex={1}
+                    >
+                      <td
+                        aria-selected={false}
+                        className="worklist-data-grid-cell pinned selectable"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "left": 0,
+                          }
+                        }
+                        tabIndex={-1}
+                      >
+                        <FocusTrap
+                          _createFocusTrap={[Function]}
+                          active={false}
+                          focusTrapOptions={
+                            Object {
+                              "clickOutsideDeactivates": true,
+                              "escapeDeactivates": false,
+                              "onDeactivate": [Function],
+                              "returnFocusOnDeactivate": true,
+                            }
+                          }
+                          paused={false}
+                        >
+                          <div
+                            className="cell-content"
+                            style={
+                              Object {
+                                "height": undefined,
+                              }
+                            }
+                          >
+                            <input
+                              aria-checked={false}
+                              aria-label="Terra.worklist-data-grid.row-index"
+                              checked={false}
+                              tabIndex={-1}
+                              type="checkbox"
+                            />
+                          </div>
+                        </FocusTrap>
+                      </td>
+                    </Cell>
+                  </InjectIntl(Cell)>
+                </RowSelectionCell>
+              </InjectIntl(RowSelectionCell)>
+              <InjectIntl(Cell)
+                columnId="Column-0"
+                columnIndex={1}
+                height="2.5rem"
+                isRowHeader={true}
+                isSelected={false}
+                isTabStop={false}
+                key="1_Column-0"
+                onCellSelect={[Function]}
+                rowId="1"
+                rowIndex={1}
+              >
+                <Cell
+                  columnId="Column-0"
+                  columnIndex={1}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={false}
+                  isRowHeader={true}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="1"
+                  rowIndex={1}
+                >
+                  <th
+                    aria-selected={false}
+                    className="worklist-data-grid-cell pinned selectable"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="rowheader"
+                    scope="row"
+                    style={
+                      Object {
+                        "left": 40,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        Heart Rate Monitored (bpm)
+                      </div>
+                    </FocusTrap>
+                  </th>
+                </Cell>
+              </InjectIntl(Cell)>
+              <InjectIntl(Cell)
+                columnId="Column-1"
+                columnIndex={2}
+                height="2.5rem"
+                isRowHeader={false}
+                isSelected={false}
+                isTabStop={false}
+                key="1_Column-1"
+                onCellSelect={[Function]}
+                rowId="1"
+                rowIndex={1}
+              >
+                <Cell
+                  columnId="Column-1"
+                  columnIndex={2}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={false}
+                  isRowHeader={false}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="1"
+                  rowIndex={1}
+                >
+                  <td
+                    aria-selected={false}
+                    className="worklist-data-grid-cell pinned selectable blank"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "left": 240,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        <span
+                          className="no-data-cell"
+                        >
+                          Terra.worklistDataGrid.blank
+                        </span>
+                      </div>
+                    </FocusTrap>
+                  </td>
+                </Cell>
+              </InjectIntl(Cell)>
+              <InjectIntl(Cell)
+                columnId="Column-2"
+                columnIndex={3}
+                height="2.5rem"
+                isMasked={true}
+                isRowHeader={false}
+                isSelected={false}
+                isTabStop={false}
+                key="1_Column-2"
+                onCellSelect={[Function]}
+                rowId="1"
+                rowIndex={1}
+              >
+                <Cell
+                  columnId="Column-2"
+                  columnIndex={3}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={true}
+                  isRowHeader={false}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="1"
+                  rowIndex={1}
+                >
+                  <td
+                    aria-selected={false}
+                    className="worklist-data-grid-cell masked"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "left": null,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        <span
+                          className="no-data-cell"
+                        >
+                          Terra.worklistDataGrid.maskedCell
+                        </span>
+                      </div>
+                    </FocusTrap>
+                  </td>
+                </Cell>
+              </InjectIntl(Cell)>
+            </tr>
+          </Row>
+          <Row
+            cells={
+              Array [
+                Object {
+                  "content": "Temperature Oral (degC)",
+                },
+                Object {
+                  "content": "36.7",
+                },
+                Object {
+                  "content": "36.9",
+                  "isMasked": true,
+                },
+              ]
+            }
+            displayedColumns={
+              Array [
+                Object {
+                  "id": "WorklistDataGrid-rowSelectionColumn",
+                  "isResizable": false,
+                  "isSelectable": true,
+                  "width": 40,
+                },
+                Object {
+                  "displayName": " Vitals",
+                  "id": "Column-0",
+                },
+                Object {
+                  "displayName": "March 16",
+                  "id": "Column-1",
+                },
+                Object {
+                  "displayName": "March 17",
+                  "id": "Column-2",
+                  "isSelectable": false,
+                },
+              ]
+            }
+            hasRowSelection={true}
+            height="2.5rem"
+            id="2"
+            isSelected={false}
+            key="2"
+            onCellSelect={[Function]}
+            onRowSelect={[Function]}
+            rowHeaderIndex={0}
+            rowIndex={2}
+          >
+            <tr
+              className="worklist-data-grid-row"
+              style={
+                Object {
+                  "height": "2.5rem",
+                }
+              }
+            >
+              <InjectIntl(RowSelectionCell)
+                columnId="WorklistDataGrid-rowSelectionColumn"
+                columnIndex={0}
+                isSelected={false}
+                isTabStop={false}
+                onCellSelect={[Function]}
+                rowId="2"
+                rowIndex={2}
+              >
+                <RowSelectionCell
+                  columnId="WorklistDataGrid-rowSelectionColumn"
+                  columnIndex={0}
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="2"
+                  rowIndex={2}
+                >
+                  <InjectIntl(Cell)
+                    columnId="WorklistDataGrid-rowSelectionColumn"
+                    columnIndex={0}
+                    isSelected={false}
+                    isTabStop={false}
+                    key="2_WorklistDataGrid-rowSelectionColumn"
+                    onCellSelect={[Function]}
+                    rowId="2"
+                    rowIndex={2}
+                  >
+                    <Cell
+                      columnId="WorklistDataGrid-rowSelectionColumn"
+                      columnIndex={0}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "formatDate": [Function],
+                          "formatHTMLMessage": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatPlural": [Function],
+                          "formatRelative": [Function],
+                          "formatTime": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralFormat": [Function],
+                            "getRelativeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": null,
+                          "now": [Function],
+                          "onError": [Function],
+                          "textComponent": "span",
+                          "timeZone": null,
+                        }
+                      }
+                      isMasked={false}
+                      isRowHeader={false}
+                      isSelectable={true}
+                      isSelected={false}
+                      isTabStop={false}
+                      onCellSelect={[Function]}
+                      rowId="2"
+                      rowIndex={2}
+                    >
+                      <td
+                        aria-selected={false}
+                        className="worklist-data-grid-cell pinned selectable"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "left": 0,
+                          }
+                        }
+                        tabIndex={-1}
+                      >
+                        <FocusTrap
+                          _createFocusTrap={[Function]}
+                          active={false}
+                          focusTrapOptions={
+                            Object {
+                              "clickOutsideDeactivates": true,
+                              "escapeDeactivates": false,
+                              "onDeactivate": [Function],
+                              "returnFocusOnDeactivate": true,
+                            }
+                          }
+                          paused={false}
+                        >
+                          <div
+                            className="cell-content"
+                            style={
+                              Object {
+                                "height": undefined,
+                              }
+                            }
+                          >
+                            <input
+                              aria-checked={false}
+                              aria-label="Terra.worklist-data-grid.row-index"
+                              checked={false}
+                              tabIndex={-1}
+                              type="checkbox"
+                            />
+                          </div>
+                        </FocusTrap>
+                      </td>
+                    </Cell>
+                  </InjectIntl(Cell)>
+                </RowSelectionCell>
+              </InjectIntl(RowSelectionCell)>
+              <InjectIntl(Cell)
+                columnId="Column-0"
+                columnIndex={1}
+                height="2.5rem"
+                isRowHeader={true}
+                isSelected={false}
+                isTabStop={false}
+                key="2_Column-0"
+                onCellSelect={[Function]}
+                rowId="2"
+                rowIndex={2}
+              >
+                <Cell
+                  columnId="Column-0"
+                  columnIndex={1}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={false}
+                  isRowHeader={true}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="2"
+                  rowIndex={2}
+                >
+                  <th
+                    aria-selected={false}
+                    className="worklist-data-grid-cell pinned selectable"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="rowheader"
+                    scope="row"
+                    style={
+                      Object {
+                        "left": 40,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        Temperature Oral (degC)
+                      </div>
+                    </FocusTrap>
+                  </th>
+                </Cell>
+              </InjectIntl(Cell)>
+              <InjectIntl(Cell)
+                columnId="Column-1"
+                columnIndex={2}
+                height="2.5rem"
+                isRowHeader={false}
+                isSelected={false}
+                isTabStop={false}
+                key="2_Column-1"
+                onCellSelect={[Function]}
+                rowId="2"
+                rowIndex={2}
+              >
+                <Cell
+                  columnId="Column-1"
+                  columnIndex={2}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={false}
+                  isRowHeader={false}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="2"
+                  rowIndex={2}
+                >
+                  <td
+                    aria-selected={false}
+                    className="worklist-data-grid-cell pinned selectable"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "left": 240,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        36.7
+                      </div>
+                    </FocusTrap>
+                  </td>
+                </Cell>
+              </InjectIntl(Cell)>
+              <InjectIntl(Cell)
+                columnId="Column-2"
+                columnIndex={3}
+                height="2.5rem"
+                isMasked={true}
+                isRowHeader={false}
+                isSelected={false}
+                isTabStop={false}
+                key="2_Column-2"
+                onCellSelect={[Function]}
+                rowId="2"
+                rowIndex={2}
+              >
+                <Cell
+                  columnId="Column-2"
+                  columnIndex={3}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={true}
+                  isRowHeader={false}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="2"
+                  rowIndex={2}
+                >
+                  <td
+                    aria-selected={false}
+                    className="worklist-data-grid-cell masked"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "left": null,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        <span
+                          className="no-data-cell"
+                        >
+                          Terra.worklistDataGrid.maskedCell
+                        </span>
+                      </div>
+                    </FocusTrap>
+                  </td>
+                </Cell>
+              </InjectIntl(Cell)>
+            </tr>
+          </Row>
+          <Row
+            cells={
+              Array [
+                Object {
+                  "content": "Cardiac Index (L/min/m2)",
+                },
+                Object {
+                  "content": "2.25",
+                },
+                Object {
+                  "content": "2.28",
+                  "isMasked": true,
+                },
+              ]
+            }
+            displayedColumns={
+              Array [
+                Object {
+                  "id": "WorklistDataGrid-rowSelectionColumn",
+                  "isResizable": false,
+                  "isSelectable": true,
+                  "width": 40,
+                },
+                Object {
+                  "displayName": " Vitals",
+                  "id": "Column-0",
+                },
+                Object {
+                  "displayName": "March 16",
+                  "id": "Column-1",
+                },
+                Object {
+                  "displayName": "March 17",
+                  "id": "Column-2",
+                  "isSelectable": false,
+                },
+              ]
+            }
+            hasRowSelection={true}
+            height="2.5rem"
+            id="3"
+            isSelected={false}
+            key="3"
+            onCellSelect={[Function]}
+            onRowSelect={[Function]}
+            rowHeaderIndex={0}
+            rowIndex={3}
+          >
+            <tr
+              className="worklist-data-grid-row"
+              style={
+                Object {
+                  "height": "2.5rem",
+                }
+              }
+            >
+              <InjectIntl(RowSelectionCell)
+                columnId="WorklistDataGrid-rowSelectionColumn"
+                columnIndex={0}
+                isSelected={false}
+                isTabStop={false}
+                onCellSelect={[Function]}
+                rowId="3"
+                rowIndex={3}
+              >
+                <RowSelectionCell
+                  columnId="WorklistDataGrid-rowSelectionColumn"
+                  columnIndex={0}
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="3"
+                  rowIndex={3}
+                >
+                  <InjectIntl(Cell)
+                    columnId="WorklistDataGrid-rowSelectionColumn"
+                    columnIndex={0}
+                    isSelected={false}
+                    isTabStop={false}
+                    key="3_WorklistDataGrid-rowSelectionColumn"
+                    onCellSelect={[Function]}
+                    rowId="3"
+                    rowIndex={3}
+                  >
+                    <Cell
+                      columnId="WorklistDataGrid-rowSelectionColumn"
+                      columnIndex={0}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "formatDate": [Function],
+                          "formatHTMLMessage": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatPlural": [Function],
+                          "formatRelative": [Function],
+                          "formatTime": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralFormat": [Function],
+                            "getRelativeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": null,
+                          "now": [Function],
+                          "onError": [Function],
+                          "textComponent": "span",
+                          "timeZone": null,
+                        }
+                      }
+                      isMasked={false}
+                      isRowHeader={false}
+                      isSelectable={true}
+                      isSelected={false}
+                      isTabStop={false}
+                      onCellSelect={[Function]}
+                      rowId="3"
+                      rowIndex={3}
+                    >
+                      <td
+                        aria-selected={false}
+                        className="worklist-data-grid-cell pinned selectable"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        style={
+                          Object {
+                            "left": 0,
+                          }
+                        }
+                        tabIndex={-1}
+                      >
+                        <FocusTrap
+                          _createFocusTrap={[Function]}
+                          active={false}
+                          focusTrapOptions={
+                            Object {
+                              "clickOutsideDeactivates": true,
+                              "escapeDeactivates": false,
+                              "onDeactivate": [Function],
+                              "returnFocusOnDeactivate": true,
+                            }
+                          }
+                          paused={false}
+                        >
+                          <div
+                            className="cell-content"
+                            style={
+                              Object {
+                                "height": undefined,
+                              }
+                            }
+                          >
+                            <input
+                              aria-checked={false}
+                              aria-label="Terra.worklist-data-grid.row-index"
+                              checked={false}
+                              tabIndex={-1}
+                              type="checkbox"
+                            />
+                          </div>
+                        </FocusTrap>
+                      </td>
+                    </Cell>
+                  </InjectIntl(Cell)>
+                </RowSelectionCell>
+              </InjectIntl(RowSelectionCell)>
+              <InjectIntl(Cell)
+                columnId="Column-0"
+                columnIndex={1}
+                height="2.5rem"
+                isRowHeader={true}
+                isSelected={false}
+                isTabStop={false}
+                key="3_Column-0"
+                onCellSelect={[Function]}
+                rowId="3"
+                rowIndex={3}
+              >
+                <Cell
+                  columnId="Column-0"
+                  columnIndex={1}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={false}
+                  isRowHeader={true}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="3"
+                  rowIndex={3}
+                >
+                  <th
+                    aria-selected={false}
+                    className="worklist-data-grid-cell pinned selectable"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="rowheader"
+                    scope="row"
+                    style={
+                      Object {
+                        "left": 40,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        Cardiac Index (L/min/m2)
+                      </div>
+                    </FocusTrap>
+                  </th>
+                </Cell>
+              </InjectIntl(Cell)>
+              <InjectIntl(Cell)
+                columnId="Column-1"
+                columnIndex={2}
+                height="2.5rem"
+                isRowHeader={false}
+                isSelected={false}
+                isTabStop={false}
+                key="3_Column-1"
+                onCellSelect={[Function]}
+                rowId="3"
+                rowIndex={3}
+              >
+                <Cell
+                  columnId="Column-1"
+                  columnIndex={2}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={false}
+                  isRowHeader={false}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="3"
+                  rowIndex={3}
+                >
+                  <td
+                    aria-selected={false}
+                    className="worklist-data-grid-cell pinned selectable"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "left": 240,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        2.25
+                      </div>
+                    </FocusTrap>
+                  </td>
+                </Cell>
+              </InjectIntl(Cell)>
+              <InjectIntl(Cell)
+                columnId="Column-2"
+                columnIndex={3}
+                height="2.5rem"
+                isMasked={true}
+                isRowHeader={false}
+                isSelected={false}
+                isTabStop={false}
+                key="3_Column-2"
+                onCellSelect={[Function]}
+                rowId="3"
+                rowIndex={3}
+              >
+                <Cell
+                  columnId="Column-2"
+                  columnIndex={3}
+                  height="2.5rem"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "formatDate": [Function],
+                      "formatHTMLMessage": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatPlural": [Function],
+                      "formatRelative": [Function],
+                      "formatTime": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralFormat": [Function],
+                        "getRelativeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": null,
+                      "now": [Function],
+                      "onError": [Function],
+                      "textComponent": "span",
+                      "timeZone": null,
+                    }
+                  }
+                  isMasked={true}
+                  isRowHeader={false}
+                  isSelectable={true}
+                  isSelected={false}
+                  isTabStop={false}
+                  onCellSelect={[Function]}
+                  rowId="3"
+                  rowIndex={3}
+                >
+                  <td
+                    aria-selected={false}
+                    className="worklist-data-grid-cell masked"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "left": null,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <FocusTrap
+                      _createFocusTrap={[Function]}
+                      active={false}
+                      focusTrapOptions={
+                        Object {
+                          "clickOutsideDeactivates": true,
+                          "escapeDeactivates": false,
+                          "onDeactivate": [Function],
+                          "returnFocusOnDeactivate": true,
+                        }
+                      }
+                      paused={false}
+                    >
+                      <div
+                        className="cell-content"
+                        style={
+                          Object {
+                            "height": "2.5rem",
+                          }
+                        }
+                      >
+                        <span
+                          className="no-data-cell"
+                        >
+                          Terra.worklistDataGrid.maskedCell
+                        </span>
+                      </div>
+                    </FocusTrap>
+                  </td>
+                </Cell>
+              </InjectIntl(Cell)>
+            </tr>
+          </Row>
+        </tbody>
+      </table>
+      <VisuallyHiddenText
+        aria-live="polite"
+        text="Terra.worklist-data-grid.row-selection-mode-enabled"
+      >
+        <span
+          aria-live="polite"
+          className="visually-hidden-text"
+        >
+          Terra.worklist-data-grid.row-selection-mode-enabled
+        </span>
+      </VisuallyHiddenText>
+      <VisuallyHiddenText
+        aria-atomic="true"
+        aria-live="polite"
+        text={null}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="visually-hidden-text"
+        />
+      </VisuallyHiddenText>
+    </div>
+  </WorklistDataGrid>
+</InjectIntl(WorklistDataGrid)>
+`;
+
 exports[`basic grid verifies that the grid created is consistent with the rows and overflowColumns props 1`] = `
 <div
   className="worklist-data-grid-container"


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
The WorklistDataGrid was updated to make the row selection column header selectable so that consumers can be notified when it is selected.

**Why it was changed:**
The MPages Worklist Framework needs the ability to sort the row selection column based on the selection state.  In order to facilitate this requirement, the WorklistDataGrid component needs the ability to notify consumers when the row selection column header is selected.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

The row selection example for the WorklistDataGrid was updated to facilitate testing of the row selection column header.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-9460 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
