### PR TITLE
[terra-worklist-data-grid] Fix height of pinned column border

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Updated focusable cell example for `terra-worklist-data-grid` to allow text area to be editable.
   * Updated examples and tests for `terra-worklist-data-grid` to account for cell selection state being controlled by consumers.
   * Updated programmatic activation test and examples for `terra-tabs`.
+  * Updated pinned column test for `terra-worklist-data-grid` to test the divider when the table height changes.
 
 ## 1.32.0 - (August 10, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/test/worklist-data-grid/PinnedColumns.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/worklist-data-grid/PinnedColumns.test.jsx
@@ -56,7 +56,7 @@ const PinnedColumns = () => {
   const { cols } = gridDataJSON;
   const [rows, setRows] = useState([]);
 
-  // Change row data for data grid
+  // Change row data for data grid to validate that pinned column border resizes correctly.
   useEffect(() => {
     setRows(gridDataJSON.rows);
   }, []);

--- a/packages/terra-framework-docs/src/terra-dev-site/test/worklist-data-grid/PinnedColumns.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/worklist-data-grid/PinnedColumns.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import WorklistDataGrid from 'terra-worklist-data-grid';
 
 const gridDataJSON = {
@@ -53,7 +53,13 @@ const gridDataJSON = {
 
 const PinnedColumns = () => {
   const rowHeaderIndex = 0;
-  const { cols, rows } = gridDataJSON;
+  const { cols } = gridDataJSON;
+  const [rows, setRows] = useState([]);
+
+  // Change row data for data grid
+  useEffect(() => {
+    setRows(gridDataJSON.rows);
+  }, []);
 
   return (
     <WorklistDataGrid

--- a/packages/terra-worklist-data-grid/CHANGELOG.md
+++ b/packages/terra-worklist-data-grid/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed
   * Reduced number of unnecessary rerenders in the `terra-worklist-data-grid` component.
   * Fixed cells not honoring the value of props passed by consumers.
+  * Fixed pinned column separator not adjusting size when the table height changes.
 
 ## 0.4.0 - (August 10, 2023)
 

--- a/packages/terra-worklist-data-grid/package.json
+++ b/packages/terra-worklist-data-grid/package.json
@@ -32,6 +32,7 @@
     "focus-trap-react": "^6.0.0",
     "keycode-js": "^3.1.0",
     "prop-types": "^15.5.8",
+    "resize-observer-polyfill": "^1.4.1",
     "terra-icon": "^3.54.0",
     "terra-theme-context": "^1.8.0",
     "terra-visually-hidden-text": "^2.36.0"

--- a/packages/terra-worklist-data-grid/src/WorklistDataGrid.jsx
+++ b/packages/terra-worklist-data-grid/src/WorklistDataGrid.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classNames from 'classnames/bind';
 import * as KeyCode from 'keycode-js';
+import ResizeObserver from 'resize-observer-polyfill';
 
 import ThemeContext from 'terra-theme-context';
 import VisuallyHiddenText from 'terra-visually-hidden-text';
@@ -243,10 +244,19 @@ function WorklistDataGrid(props) {
   // callback Hooks
 
   const gridRef = useCallback((node) => {
+    if (!node) {
+      return;
+    }
+
     grid.current = node;
 
-    // Update table height state variable
-    setTableHeight(grid.current.offsetHeight - 1);
+    const resizeObserver = new ResizeObserver(() => {
+      // Update table height state variable
+      setTableHeight(grid.current.offsetHeight - 1);
+    });
+
+    // Register resize observer to detect size changes
+    resizeObserver.observe(node);
   }, []);
 
   // -------------------------------------

--- a/packages/terra-worklist-data-grid/tests/jest/__snapshots__/WorklistDataGrid.test.jsx.snap
+++ b/packages/terra-worklist-data-grid/tests/jest/__snapshots__/WorklistDataGrid.test.jsx.snap
@@ -252,7 +252,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
           headerHeight="2.5rem"
           onColumnSelect={[Function]}
           onResizeMouseDown={[Function]}
-          tableHeight={-1}
+          tableHeight={0}
         >
           <thead>
             <tr
@@ -270,7 +270,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -313,7 +313,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -344,7 +344,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       columnIndex={0}
                       columnText=" Vitals"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -353,7 +353,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                         columnIndex={0}
                         columnText=" Vitals"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -400,7 +400,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -421,7 +421,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -464,7 +464,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -495,7 +495,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       columnIndex={1}
                       columnText="March 16"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -504,7 +504,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                         columnIndex={1}
                         columnText="March 16"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -551,7 +551,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -562,7 +562,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       className="pinned-columns-divider"
                       style={
                         Object {
-                          "height": -1,
+                          "height": 0,
                           "left": 199,
                         }
                       }
@@ -582,7 +582,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -625,7 +625,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -654,7 +654,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       columnIndex={2}
                       columnText="March 17"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -663,7 +663,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                         columnIndex={2}
                         columnText="March 17"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -710,7 +710,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -1974,7 +1974,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
           headerHeight="2.5rem"
           onColumnSelect={[Function]}
           onResizeMouseDown={[Function]}
-          tableHeight={-1}
+          tableHeight={0}
         >
           <thead>
             <tr
@@ -1992,7 +1992,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -2035,7 +2035,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -2066,7 +2066,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       columnIndex={0}
                       columnText=" Vitals"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -2075,7 +2075,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                         columnIndex={0}
                         columnText=" Vitals"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -2122,7 +2122,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -2143,7 +2143,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -2186,7 +2186,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -2217,7 +2217,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       columnIndex={1}
                       columnText="March 16"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -2226,7 +2226,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                         columnIndex={1}
                         columnText="March 16"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -2273,7 +2273,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -2284,7 +2284,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       className="pinned-columns-divider"
                       style={
                         Object {
-                          "height": -1,
+                          "height": 0,
                           "left": 199,
                         }
                       }
@@ -2304,7 +2304,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -2347,7 +2347,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -2376,7 +2376,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                       columnIndex={2}
                       columnText="March 17"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -2385,7 +2385,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                         columnIndex={2}
                         columnText="March 17"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -2432,7 +2432,7 @@ exports[`basic grid verifies onCellSelect callback is not triggered when space i
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -3734,7 +3734,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
           headerHeight="2.5rem"
           onColumnSelect={[Function]}
           onResizeMouseDown={[Function]}
-          tableHeight={-1}
+          tableHeight={0}
         >
           <thead>
             <tr
@@ -3753,7 +3753,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={40}
               >
                 <ColumnHeaderCell
@@ -3795,7 +3795,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={40}
                 >
                   <th
@@ -3833,7 +3833,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -3876,7 +3876,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -3907,7 +3907,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                       columnIndex={1}
                       columnText=" Vitals"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -3916,7 +3916,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                         columnIndex={1}
                         columnText=" Vitals"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -3963,7 +3963,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -3984,7 +3984,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -4027,7 +4027,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -4058,7 +4058,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                       columnIndex={2}
                       columnText="March 16"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -4067,7 +4067,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                         columnIndex={2}
                         columnText="March 16"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -4114,7 +4114,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -4125,7 +4125,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                       className="pinned-columns-divider"
                       style={
                         Object {
-                          "height": -1,
+                          "height": 0,
                           "left": 199,
                         }
                       }
@@ -4145,7 +4145,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -4188,7 +4188,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -4217,7 +4217,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                       columnIndex={3}
                       columnText="March 17"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -4226,7 +4226,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                         columnIndex={3}
                         columnText="March 17"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -4273,7 +4273,7 @@ exports[`basic grid verifies row selection column header selection 1`] = `
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -6022,7 +6022,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
           headerHeight="2.5rem"
           onColumnSelect={[Function]}
           onResizeMouseDown={[Function]}
-          tableHeight={-1}
+          tableHeight={0}
         >
           <thead>
             <tr
@@ -6041,7 +6041,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={40}
               >
                 <ColumnHeaderCell
@@ -6083,7 +6083,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={40}
                 >
                   <th
@@ -6121,7 +6121,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -6164,7 +6164,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -6195,7 +6195,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                       columnIndex={1}
                       columnText=" Vitals"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -6204,7 +6204,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                         columnIndex={1}
                         columnText=" Vitals"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -6251,7 +6251,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -6272,7 +6272,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -6315,7 +6315,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -6346,7 +6346,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                       columnIndex={2}
                       columnText="March 16"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -6355,7 +6355,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                         columnIndex={2}
                         columnText="March 16"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -6402,7 +6402,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -6413,7 +6413,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                       className="pinned-columns-divider"
                       style={
                         Object {
-                          "height": -1,
+                          "height": 0,
                           "left": 199,
                         }
                       }
@@ -6433,7 +6433,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -6476,7 +6476,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -6505,7 +6505,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                       columnIndex={3}
                       columnText="March 17"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -6514,7 +6514,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                         columnIndex={3}
                         columnText="March 17"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -6561,7 +6561,7 @@ exports[`basic grid verifies row selection when space is pressed on a masked cel
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -8310,7 +8310,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
           headerHeight="2.5rem"
           onColumnSelect={[Function]}
           onResizeMouseDown={[Function]}
-          tableHeight={-1}
+          tableHeight={0}
         >
           <thead>
             <tr
@@ -8329,7 +8329,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={40}
               >
                 <ColumnHeaderCell
@@ -8371,7 +8371,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={40}
                 >
                   <th
@@ -8409,7 +8409,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -8452,7 +8452,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -8483,7 +8483,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                       columnIndex={1}
                       columnText=" Vitals"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -8492,7 +8492,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                         columnIndex={1}
                         columnText=" Vitals"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -8539,7 +8539,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -8560,7 +8560,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -8603,7 +8603,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -8634,7 +8634,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                       columnIndex={2}
                       columnText="March 16"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -8643,7 +8643,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                         columnIndex={2}
                         columnText="March 16"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -8690,7 +8690,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}
@@ -8701,7 +8701,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                       className="pinned-columns-divider"
                       style={
                         Object {
-                          "height": -1,
+                          "height": 0,
                           "left": 199,
                         }
                       }
@@ -8721,7 +8721,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                 onColumnSelect={[Function]}
                 onResizeMouseDown={[Function]}
                 rowIndex={0}
-                tableHeight={-1}
+                tableHeight={0}
                 width={200}
               >
                 <ColumnHeaderCell
@@ -8764,7 +8764,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                   onColumnSelect={[Function]}
                   onResizeMouseDown={[Function]}
                   rowIndex={0}
-                  tableHeight={-1}
+                  tableHeight={0}
                   width={200}
                 >
                   <th
@@ -8793,7 +8793,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                       columnIndex={3}
                       columnText="March 17"
                       columnWidth={200}
-                      height={-1}
+                      height={0}
                       maximumWidth={300}
                       minimumWidth={60}
                       onResizeMouseDown={[Function]}
@@ -8802,7 +8802,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                         columnIndex={3}
                         columnText="March 17"
                         columnWidth={200}
-                        height={-1}
+                        height={0}
                         intl={
                           Object {
                             "defaultFormats": Object {},
@@ -8849,7 +8849,7 @@ exports[`basic grid verifies row selection when space is pressed on a non-select
                           role="slider"
                           style={
                             Object {
-                              "height": "-1px",
+                              "height": "0px",
                             }
                           }
                           tabIndex={-1}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Modified WorklistDataGrid logic such that the border height for the pinned column separator adjust to table height changes.

**Why it was changed:**
The change was made to ensure the separator is visible and looks correct to users.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

<img width="1006" alt="Screen Shot 2023-08-21 at 5 54 13 PM" src="https://github.com/cerner/terra-framework/assets/59840481/667caabd-a7c7-4bbf-ac3e-08b91a209452">

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-9526 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra