### PR TITLE
[terra-collapsible-menu-view] Add aria-haspopup attribute to menu buttons

### DIFF
--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added aria-haspopup attribute to menu buttons.
+
 ## 6.77.0 - (August 10, 2023)
 
 * Changed

--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added aria-haspopup attribute to menu buttons.
+  * Added aria-haspopup attribute to menu buttons so screen reader users are provided the context that they will open a dialog popup.
 
 ## 6.77.0 - (August 10, 2023)
 

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
@@ -139,6 +139,7 @@ class CollapsibleMenuViewItem extends React.Component {
           button={(
             <Button
               {...attributes}
+              aria-haspopup="dialog"
               icon={icon}
               text={text}
               isReversed={isReversed}

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
@@ -55,6 +55,20 @@ describe('CollapsibleMenuViewItem', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should set aria-haspopup attribute on menu button', () => {
+    const wrapper = mountWithIntl(<CollapsibleMenuViewItem
+      text="Menu Button 1"
+      key="MenuButton1"
+      className="MenuButton1"
+      shouldCloseOnClick={false}
+      subMenuItems={[
+        <CollapsibleMenuViewItem text="Default Item 1" key="defaultItem1" />,
+        <CollapsibleMenuViewItem text="Default Item 2" key="defaultItem2" />,
+      ]}
+    />);
+    expect(wrapper.find('Button').prop('aria-haspopup')).toEqual('dialog');
+  });
+
   it('should render a disabled button when isDisabled is set', () => {
     const wrapper = shallowWithIntl(<CollapsibleMenuViewItem text="Testing" isDisabled />);
     expect(wrapper).toMatchSnapshot();

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
@@ -629,6 +629,7 @@ exports[`CollapsibleMenuViewItem should render a menu when subMenuItems are give
 <CollapsibleMenu
   button={
     <Button
+      aria-haspopup="dialog"
       intl={
         Object {
           "defaultFormats": Object {},


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Currently, the main collapsible menu button and regular menu buttons with submenu items do not announce to screen readers that interacting with them will open a dialog popup with additional controls. This creates a poor experience for screen reader users since there is nothing distinguishing menu buttons that will open a collapsible menu from regular buttons.

**What was changed:**
Added the `aria-haspopup` attribute to menu buttons.

**Why it was changed:**
So screen reader users are provided the context that menu buttons will open a dialog popup.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

#### Visual Testing

https://github.com/cerner/terra-framework/assets/37230460/42779662-1317-4f03-b5d9-6885def5ffd8

https://github.com/cerner/terra-framework/assets/37230460/8acd4b05-112c-45a4-a2ca-ab37ad19c158

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
The value of the `aria-haspopup` attribute must match the value of the `role` attribute on the popup container. In this case, Terra Collapsible Menu View uses Terra Menu, which uses Terra Popup, to display the collapsible menus. Terra Popup sets the role to "dialog" on the popup container.

**This PR resolves:**

UXPLATFORM-9506 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
