### PR TITLE
[terra-tabs] Removed browser specific focus border appearing when using both mouse and keyboard subsequently.

### DIFF
--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added
   * Added support for programmatic activation of tabs.
+  * Removed additional focus border for tab.
 
 ## 7.4.0 - (August 10, 2023)
 

--- a/packages/terra-tabs/src/common-tabs/TerraStructuralTabs.module.scss
+++ b/packages/terra-tabs/src/common-tabs/TerraStructuralTabs.module.scss
@@ -112,6 +112,7 @@
       transition-timing-function: var(--terra-tabs-structural-transition-timing-function, ease);
 
       &.is-active {
+        outline: none;
         background-color: var(--terra-tabs-structural-active-background-color, #fff);
         background-image: var(--terra-tabs-structural-active-background-image, linear-gradient(to bottom, #006fc3, #006fc3));
         background-size: var(--terra-tabs-structural-active-background-size, 100% 2px);

--- a/packages/terra-tabs/src/common-tabs/TerraStructuralTabs.module.scss
+++ b/packages/terra-tabs/src/common-tabs/TerraStructuralTabs.module.scss
@@ -112,11 +112,11 @@
       transition-timing-function: var(--terra-tabs-structural-transition-timing-function, ease);
 
       &.is-active {
-        outline: none;
         background-color: var(--terra-tabs-structural-active-background-color, #fff);
         background-image: var(--terra-tabs-structural-active-background-image, linear-gradient(to bottom, #006fc3, #006fc3));
         background-size: var(--terra-tabs-structural-active-background-size, 100% 2px);
         box-shadow: var(--terra-tabs-structural-active-box-shadow, none);
+        outline: none;
         color: var(--terra-tabs-structural-active-color, #000);
         font-weight: var(--terra-tabs-structural-active-font-weight, normal);
         overflow: hidden; //forces :before background-image to honor border-radius clipping.

--- a/packages/terra-tabs/src/common-tabs/TerraStructuralTabs.module.scss
+++ b/packages/terra-tabs/src/common-tabs/TerraStructuralTabs.module.scss
@@ -116,9 +116,9 @@
         background-image: var(--terra-tabs-structural-active-background-image, linear-gradient(to bottom, #006fc3, #006fc3));
         background-size: var(--terra-tabs-structural-active-background-size, 100% 2px);
         box-shadow: var(--terra-tabs-structural-active-box-shadow, none);
-        outline: none;
         color: var(--terra-tabs-structural-active-color, #000);
         font-weight: var(--terra-tabs-structural-active-font-weight, normal);
+        outline: none;
         overflow: hidden; //forces :before background-image to honor border-radius clipping.
         position: relative;
         z-index: var(--terra-tabs-structural-active-z-index);


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
removed additional focus border.

**Why it was changed:**
"blue border" is completely removed as we already have a dotted focus indicator and an active tab indicator as well (bottom blue border)


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9370 <!-- Jira Number or issue Number. Please do not link to Jira. -->


**Pre Implementation :**

![image](https://github.com/cerner/terra-framework/assets/126573882/1f6a5aaf-1ed2-4a8f-8ad7-95fdf7c894e2)

**Post Implementation :**

![image](https://github.com/cerner/terra-framework/assets/126573882/e9eb9bff-4ef0-43db-8a9e-c60f2651c0de)

---

Thank you for contributing to Terra.
@cerner/terra
