### PR TITLE
[terra-date-picker] Screen reader updates for invalid dates and calendar date selection

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Changed
   * Visual focus changed to dashed lines for individual fields.
   * Screen reader announcement for visual label.
-  * Updated screen response to announce when invalid characters
+  * Updated screen response to announce when invalid dates
     are entered.
   * Updated screen response to announce when calendar popup dates
     are selected.

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -5,18 +5,18 @@
 * Fixed
   * Fixed DatePicker scroll on smaller viewports.
 
-* Updated
+* Changed
+  * Visual focus changed to dashed lines for individual fields.
   * Screen reader announcement for visual label.
+  * Updated screen response to announce when invalid characters
+    are entered.
+  * Updated screen response to announce when calendar popup dates
+    are selected.
 
 ## 4.89.0 - (September 5, 2023)
 
 * Changed
-  * Visual focus changed to dashed lines for individual fields.
   * Fixed the date format being read 3 times when using SR
-  * Updated screen response to announce when invalid characters 
-    are entered.
-  * Updated screen response to announce when calendar popup dates 
-    are selected.
 
 ## 4.88.0 - (August 31, 2023)
 

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Changed
   * Visual focus changed to dashed lines for individual fields.
   * Fixed the date format being read 3 times when using SR
+  * Updated screen response to announce when invalid characters 
+    are entered.
+  * Updated screen response to announce when calendar popup dates 
+    are selected.
 
 ## 4.88.0 - (August 31, 2023)
 

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -8,8 +8,7 @@
 * Changed
   * Visual focus changed to dashed lines for individual fields.
   * Screen reader announcement for visual label.
-  * Updated screen response to announce when invalid dates
-    are entered.
+  * Updated screen response to announce when invalid date is entered.
   * Updated screen response to announce when calendar popup dates
     are selected.
 

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -136,6 +136,11 @@ const propTypes = {
    * An ISO 8601 string representation of the minimum date that can be selected. The value must be in the `YYYY-MM-DD` format. Must be on or after `01/01/1900`
    */
   minDate: PropTypes.string,
+  /**
+   * A function that gets called for each date in the picker to evaluate which date should be disabled.
+   * A return value of true will be enabled and false will be disabled.
+   */
+  filterDate: PropTypes.func,
 };
 
 const defaultProps = {
@@ -159,6 +164,7 @@ const defaultProps = {
   includeDates: undefined,
   maxDate: '2100-12-31',
   minDate: '1900-01-01',
+  filterDate: undefined,
 };
 
 const DatePickerInput = (props) => {
@@ -186,6 +192,7 @@ const DatePickerInput = (props) => {
     includeDates,
     maxDate,
     minDate,
+    filterDate,
     ...customProps
   } = props;
 
@@ -816,11 +823,12 @@ const DatePickerInput = (props) => {
   }
   let calendarDate = inputDate ? `${inputDate} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : '';
 
-  // Check if date is excluded or out or range or not included
+  // Check if date is excluded or out of range or not included or filtered
   let invalidEntry = '';
   if (DateUtil.isDateExcluded(DateUtil.createSafeDate(dateValue, initialTimeZone), props.excludeDates)
       || DateUtil.isDateOutOfRange(DateUtil.createSafeDate(dateValue, initialTimeZone), DateUtil.createSafeDate(DateUtil.getMinDate(props.minDate), initialTimeZone), DateUtil.createSafeDate(DateUtil.getMaxDate(props.maxDate), initialTimeZone))
-      || DateUtil.isDateNotIncluded(DateUtil.createSafeDate(dateValue, initialTimeZone), props.includeDates)) {
+      || DateUtil.isDateNotIncluded(DateUtil.createSafeDate(dateValue, initialTimeZone), props.includeDates)
+      || (props.filterDate && !props.filterDate(DateUtil.createSafeDate(dateValue, initialTimeZone)))) {
     invalidEntry = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
     calendarDate = '';
   }

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -165,7 +165,7 @@ const DatePickerInput = (props) => {
   const [dayInitialFocused, setDayInitialFocused] = useState(false);
   const [monthInitialFocused, setMonthInitialFocused] = useState(false);
   const [yearInitialFocused, setYearInitialFocused] = useState(false);
-  // TODO:  Added below states for invalid input message for SR
+  // Added below state for invalid input message for SR
   const [invalidInput, SetInvalidInput] = useState(false);
   const editOnkeyDown = useRef(false);
   const theme = React.useContext(ThemeContext);
@@ -219,12 +219,6 @@ const DatePickerInput = (props) => {
     }
   }, [shouldShowPicker, onClick]);
 
-  const setFocus = (node) => {
-    if (node) {
-      node.focus();
-    }
-  };
-
   /**
    * Moves focus to the correct input depending on date ordering. Focus changing is
    * disabled if a complete date has been entered in order to make single input
@@ -236,16 +230,9 @@ const DatePickerInput = (props) => {
     if (dateFormatOrder === DateUtil.dateOrder.MDY) {
       if (inputValue.length === 2) {
         if (type === DateUtil.inputType.MONTH) {
-          // TODO: Commented below to prevent focus shft to allow VO+Chrome read second digit
-          const dayfocus = dayInputRef;
-          setTimeout(() => {
-            setFocus(dayfocus);
-          }, 500);
+          dayInputRef.focus();
         } else {
-          const yearfocus = yearInputRef;
-          setTimeout(() => {
-            setFocus(yearfocus);
-          }, 500);
+          yearInputRef.focus();
         }
       }
     } else if (dateFormatOrder === DateUtil.dateOrder.DMY) {
@@ -340,7 +327,9 @@ const DatePickerInput = (props) => {
       }
     }
     setDate(event, inputValue, type);
-    SetInvalidInput(false);
+    if (invalidInput) {
+      SetInvalidInput(false);
+    }
   };
 
   const handleDayChange = (event) => {
@@ -354,7 +343,6 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.day || inputValue.length > 2 || Number(inputValue) > 31 || inputValue === '00') {
-      // TODO: Added below to set invalid day
       handleInvalidInputChange(true);
       return;
     }
@@ -550,6 +538,7 @@ const DatePickerInput = (props) => {
 
     // set date to today
     if (event.key === 't' || event.key === 'T') {
+      // Added this state change for invalid input entry
       SetInvalidInput(false);
       inputDate = DateUtil.getCurrentDate();
       formattedDate = DateUtil.strictFormatISODate(inputDate, momentDateFormat);
@@ -801,7 +790,7 @@ const DatePickerInput = (props) => {
     { 'is-invalid': isInvalid },
   ]);
 
-  // TODO: Indicates selected date from calendar popup
+  // Indicates selected date from calendar popup for SR
   const calendarDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} is selected` : label;
 
   return (
@@ -826,7 +815,7 @@ const DatePickerInput = (props) => {
             refCallback={setVisuallyHiddenComponent}
             aria-atomic="true"
             aria-relevant="all"
-            aria-live={(invalidInput) ? 'assertive' : 'polite'}
+            aria-live="assertive"
           />
           <DateInputLayout
             dateFormatOrder={dateFormatOrder}

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -271,7 +271,9 @@ const DatePickerInput = (props) => {
   };
 
   const handleInvalidInputChange = () => {
-    visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
+    if (visuallyHiddenComponent) {
+      visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
+    }
   };
 
   const setVisuallyHiddenComponent = (node) => {

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -358,7 +358,6 @@ const DatePickerInput = (props) => {
       }
     }
 
-    SetInvalidDay(false);
     handleDateChange(event, inputValue, DateUtil.inputType.DAY);
   };
 
@@ -416,7 +415,6 @@ const DatePickerInput = (props) => {
       return;
     }
 
-    SetInvalidYear(false);
     handleDateChange(event, inputValue, DateUtil.inputType.YEAR);
   };
 
@@ -688,7 +686,6 @@ const DatePickerInput = (props) => {
     { 'initial-focus': dayInitialFocused },
   ]);
 
-  // TODO: Added aria-invalid to indicate wrong input
   const dateDayInput = (
     <Input
       {...additionalInputProps}
@@ -712,7 +709,6 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.dayLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.DMY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={dayInputId}
-      aria-invalid={invalidDay}
     />
   );
 
@@ -744,7 +740,6 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.monthLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.MDY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={monthInputId}
-      aria-invalid={invalidMonth}
     />
   );
 
@@ -776,7 +771,6 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.yearLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.YMD ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={yearInputId}
-      aria-invalid={invalidYear}
     />
   );
 

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -305,8 +305,9 @@ const DatePickerInput = (props) => {
     }
   };
 
-  const handleInvalidInputChange = () => {
-    if (visuallyHiddenComponent) {
+  const handleInvalidInputChange = (inputValue) => {
+    if (visuallyHiddenComponent && inputValue !== '+' && inputValue !== '=' && inputValue !== '-'
+        && inputValue !== '_' && inputValue !== 't' && inputValue !== 'T') {
       visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
     }
   };
@@ -363,7 +364,7 @@ const DatePickerInput = (props) => {
   const handleDayChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
@@ -371,7 +372,7 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.day || inputValue.length > 2 || Number(inputValue) > 31 || inputValue === '00') {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
@@ -391,7 +392,7 @@ const DatePickerInput = (props) => {
   const handleMonthChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
@@ -399,7 +400,7 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.month || inputValue.length > 2 || Number(inputValue) > 12 || inputValue === '00') {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
@@ -418,7 +419,7 @@ const DatePickerInput = (props) => {
   const handleYearChange = (event) => {
     const inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
@@ -426,19 +427,19 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 4.
     if (inputValue === date.year || inputValue.length > 4) {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
     // Ignore the 3rd entry if the first two digits are not 19, 20 or 21
     if (inputValue.length === 3 && (Number(inputValue) < 190 || Number(inputValue) > 210)) {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 
     // Ignore the 4th entry if the year value is not between MIN_YEAR and MAX_YEAR
     if (inputValue.length === 4 && (Number(inputValue) < Number(DateUtil.MIN_YEAR) || Number(inputValue) > Number(DateUtil.MAX_YEAR))) {
-      handleInvalidInputChange();
+      handleInvalidInputChange(inputValue);
       return;
     }
 

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -792,6 +792,7 @@ const DatePickerInput = (props) => {
 
   // Indicates selected date from calendar popup for SR
   const calendarDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : label;
+  const inputDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })}` : '';
 
   return (
     <div className={cx(theme.className)}>
@@ -842,7 +843,7 @@ const DatePickerInput = (props) => {
       </div>
       {!useExternalFormatMask && (
         <div id={formatDescriptionId} className={cx('format-text')}>
-          <VisuallyHiddenText text={`${intl.formatMessage({ id: 'Terra.datePicker.dateFormatLabel' })} ${format}`} />
+          <VisuallyHiddenText text={`${intl.formatMessage({ id: 'Terra.datePicker.dateFormatLabel' })} ${format} ${inputDate}`} />
           <div aria-hidden="true">
             {`(${format})`}
           </div>

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -219,6 +219,12 @@ const DatePickerInput = (props) => {
     }
   }, [shouldShowPicker, onClick]);
 
+  const setFocus = (node) => {
+    if (node) {
+      node.focus();
+    }
+  };
+
   /**
    * Moves focus to the correct input depending on date ordering. Focus changing is
    * disabled if a complete date has been entered in order to make single input
@@ -231,9 +237,15 @@ const DatePickerInput = (props) => {
       if (inputValue.length === 2) {
         if (type === DateUtil.inputType.MONTH) {
           // TODO: Commented below to prevent focus shft to allow VO+Chrome read second digit
-          // dayInputRef.focus();
+          const dayfocus = dayInputRef;
+          setTimeout(() => {
+            setFocus(dayfocus);
+          }, 500);
         } else {
-          // yearInputRef.focus();
+          const yearfocus = yearInputRef;
+          setTimeout(() => {
+            setFocus(yearfocus);
+          }, 500);
         }
       }
     } else if (dateFormatOrder === DateUtil.dateOrder.DMY) {

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -788,8 +788,11 @@ const DatePickerInput = (props) => {
   ]);
 
   // Indicates selected date from calendar popup for SR
-  const calendarDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : label;
-  const inputDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })}` : '';
+  let inputDate;
+  if (DateUtil.isValidDate(value, momentDateFormat)) {
+    inputDate = `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })}`;
+  }
+  const calendarDate = inputDate ? `${inputDate} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : label;
 
   return (
     <div className={cx(theme.className)}>
@@ -826,7 +829,7 @@ const DatePickerInput = (props) => {
         <Button
           data-terra-open-calendar-button
           className={buttonClasses}
-          text={`${calendarDate} ${intl.formatMessage({ id: 'Terra.datePicker.openCalendar' })}`}
+          text={intl.formatMessage({ id: 'Terra.datePicker.openCalendar' })}
           onClick={handleOnButtonClick}
           onKeyDown={handleOnButtonKeyDown}
           icon={<IconCalendar />}
@@ -836,11 +839,12 @@ const DatePickerInput = (props) => {
           onBlur={onBlur}
           onFocus={onButtonFocus}
           refCallback={buttonRefCallback}
+          aria-label={`${calendarDate} ${intl.formatMessage({ id: 'Terra.datePicker.openCalendar' })}`}
         />
       </div>
       {!useExternalFormatMask && (
         <div id={formatDescriptionId} className={cx('format-text')}>
-          <VisuallyHiddenText text={`${intl.formatMessage({ id: 'Terra.datePicker.dateFormatLabel' })} ${format} ${inputDate}`} />
+          <VisuallyHiddenText text={`${intl.formatMessage({ id: 'Terra.datePicker.dateFormatLabel' })} ${format} ${inputDate || ''}`} />
           <div aria-hidden="true">
             {`(${format})`}
           </div>

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -165,6 +165,10 @@ const DatePickerInput = (props) => {
   const [dayInitialFocused, setDayInitialFocused] = useState(false);
   const [monthInitialFocused, setMonthInitialFocused] = useState(false);
   const [yearInitialFocused, setYearInitialFocused] = useState(false);
+  // TODO:  Added below states for invalid input message for SR
+  const [invalidDay, SetInvalidDay] = useState(false);
+  const [invalidMonth, SetInvalidMonth] = useState(false);
+  const [invalidYear, SetInvalidYear] = useState(false);
   const editOnkeyDown = useRef(false);
   const theme = React.useContext(ThemeContext);
   // variables to store ref's for day, month and year input
@@ -228,9 +232,10 @@ const DatePickerInput = (props) => {
     if (dateFormatOrder === DateUtil.dateOrder.MDY) {
       if (inputValue.length === 2) {
         if (type === DateUtil.inputType.MONTH) {
-          dayInputRef.focus();
+          // TODO: Commented below to prevent focus shft to allow VO+Chrome read second digit
+          // dayInputRef.focus();
         } else {
-          yearInputRef.focus();
+          // yearInputRef.focus();
         }
       }
     } else if (dateFormatOrder === DateUtil.dateOrder.DMY) {
@@ -319,6 +324,7 @@ const DatePickerInput = (props) => {
   const handleDayChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
+      SetInvalidDay(true);
       return;
     }
 
@@ -326,6 +332,8 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.day || inputValue.length > 2 || Number(inputValue) > 31 || inputValue === '00') {
+      // TODO: Added below to set invalid day
+      SetInvalidDay(true);
       return;
     }
 
@@ -339,12 +347,14 @@ const DatePickerInput = (props) => {
       }
     }
 
+    SetInvalidDay(false);
     handleDateChange(event, inputValue, DateUtil.inputType.DAY);
   };
 
   const handleMonthChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
+      SetInvalidMonth(true);
       return;
     }
 
@@ -352,6 +362,7 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.month || inputValue.length > 2 || Number(inputValue) > 12 || inputValue === '00') {
+      SetInvalidMonth(true);
       return;
     }
 
@@ -365,12 +376,14 @@ const DatePickerInput = (props) => {
       }
     }
 
+    SetInvalidMonth(false);
     handleDateChange(event, inputValue, DateUtil.inputType.MONTH);
   };
 
   const handleYearChange = (event) => {
     const inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
+      SetInvalidYear(true);
       return;
     }
 
@@ -378,19 +391,23 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 4.
     if (inputValue === date.year || inputValue.length > 4) {
+      SetInvalidYear(true);
       return;
     }
 
     // Ignore the 3rd entry if the first two digits are not 19, 20 or 21
     if (inputValue.length === 3 && (Number(inputValue) < 190 || Number(inputValue) > 210)) {
+      SetInvalidYear(true);
       return;
     }
 
     // Ignore the 4th entry if the year value is not between MIN_YEAR and MAX_YEAR
     if (inputValue.length === 4 && (Number(inputValue) < Number(DateUtil.MIN_YEAR) || Number(inputValue) > Number(DateUtil.MAX_YEAR))) {
+      SetInvalidYear(true);
       return;
     }
 
+    SetInvalidYear(false);
     handleDateChange(event, inputValue, DateUtil.inputType.YEAR);
   };
 
@@ -515,6 +532,9 @@ const DatePickerInput = (props) => {
 
     // set date to today
     if (event.key === 't' || event.key === 'T') {
+      SetInvalidDay(false);
+      SetInvalidMonth(false);
+      SetInvalidYear(false);
       inputDate = DateUtil.getCurrentDate();
       formattedDate = DateUtil.strictFormatISODate(inputDate, momentDateFormat);
       if (onChange) {
@@ -660,6 +680,7 @@ const DatePickerInput = (props) => {
     { 'initial-focus': dayInitialFocused },
   ]);
 
+  // TODO: Added aria-invalid to indicate wrong input
   const dateDayInput = (
     <Input
       {...additionalInputProps}
@@ -683,6 +704,7 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.dayLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.DMY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={dayInputId}
+      aria-invalid={invalidDay}
     />
   );
 
@@ -714,6 +736,7 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.monthLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.MDY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={monthInputId}
+      aria-invalid={invalidMonth}
     />
   );
 
@@ -745,6 +768,7 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.yearLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.YMD ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={yearInputId}
+      aria-invalid={invalidYear}
     />
   );
 
@@ -764,6 +788,9 @@ const DatePickerInput = (props) => {
     'button',
     { 'is-invalid': isInvalid },
   ]);
+
+  // TODO: Indicates selected date from calendar popup
+  const calendarDate = value ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} is selected` : label;
 
   return (
     <div className={cx(theme.className)}>
@@ -794,7 +821,7 @@ const DatePickerInput = (props) => {
         <Button
           data-terra-open-calendar-button
           className={buttonClasses}
-          text={intl.formatMessage({ id: 'Terra.datePicker.openCalendar' })}
+          text={`${calendarDate} ${intl.formatMessage({ id: 'Terra.datePicker.openCalendar' })}`}
           onClick={handleOnButtonClick}
           onKeyDown={handleOnButtonKeyDown}
           icon={<IconCalendar />}

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -791,7 +791,7 @@ const DatePickerInput = (props) => {
   ]);
 
   // Indicates selected date from calendar popup for SR
-  const calendarDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} is selected` : label;
+  const calendarDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : label;
 
   return (
     <div className={cx(theme.className)}>

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -884,7 +884,7 @@ const DatePickerInput = (props) => {
       </div>
       {!useExternalFormatMask && (
         <div id={formatDescriptionId} className={cx('format-text')}>
-          <VisuallyHiddenText text={`${invalidEntry} ${intl.formatMessage({ id: 'Terra.datePicker.dateFormatLabel' })} ${format} ${inputDate || ''} `} />
+          <VisuallyHiddenText aria-live={DateUtil.isMac() ? 'polite' : 'off'} text={`${invalidEntry} ${intl.formatMessage({ id: 'Terra.datePicker.dateFormatLabel' })} ${format} ${inputDate || ''} `} />
           <div aria-hidden="true">
             {`(${format})`}
           </div>

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -165,8 +165,6 @@ const DatePickerInput = (props) => {
   const [dayInitialFocused, setDayInitialFocused] = useState(false);
   const [monthInitialFocused, setMonthInitialFocused] = useState(false);
   const [yearInitialFocused, setYearInitialFocused] = useState(false);
-  // Added below state for invalid input message for SR
-  const [invalidInput, SetInvalidInput] = useState(false);
   const editOnkeyDown = useRef(false);
   const theme = React.useContext(ThemeContext);
   // variables to store ref's for day, month and year input
@@ -273,7 +271,6 @@ const DatePickerInput = (props) => {
   };
 
   const handleInvalidInputChange = () => {
-    SetInvalidInput(true);
     visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
   };
 
@@ -324,9 +321,6 @@ const DatePickerInput = (props) => {
       }
     }
     setDate(event, inputValue, type);
-    if (invalidInput) {
-      SetInvalidInput(false);
-    }
   };
 
   const handleDayChange = (event) => {
@@ -535,8 +529,6 @@ const DatePickerInput = (props) => {
 
     // set date to today
     if (event.key === 't' || event.key === 'T') {
-      // Added this state change for invalid input entry
-      SetInvalidInput(false);
       inputDate = DateUtil.getCurrentDate();
       formattedDate = DateUtil.strictFormatISODate(inputDate, momentDateFormat);
       if (onChange) {

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -272,12 +272,9 @@ const DatePickerInput = (props) => {
     }
   };
 
-  const handleInvalidInputChange = (val) => {
-    visuallyHiddenComponent.innerText = '';
-    SetInvalidInput(val);
-    if (val) {
-      visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
-    }
+  const handleInvalidInputChange = () => {
+    SetInvalidInput(true);
+    visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
   };
 
   const setVisuallyHiddenComponent = (node) => {
@@ -335,7 +332,7 @@ const DatePickerInput = (props) => {
   const handleDayChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
@@ -343,7 +340,7 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.day || inputValue.length > 2 || Number(inputValue) > 31 || inputValue === '00') {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
@@ -363,7 +360,7 @@ const DatePickerInput = (props) => {
   const handleMonthChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
@@ -371,7 +368,7 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.month || inputValue.length > 2 || Number(inputValue) > 12 || inputValue === '00') {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
@@ -390,7 +387,7 @@ const DatePickerInput = (props) => {
   const handleYearChange = (event) => {
     const inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
@@ -398,19 +395,19 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 4.
     if (inputValue === date.year || inputValue.length > 4) {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
     // Ignore the 3rd entry if the first two digits are not 19, 20 or 21
     if (inputValue.length === 3 && (Number(inputValue) < 190 || Number(inputValue) > 210)) {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 
     // Ignore the 4th entry if the year value is not between MIN_YEAR and MAX_YEAR
     if (inputValue.length === 4 && (Number(inputValue) < Number(DateUtil.MIN_YEAR) || Number(inputValue) > Number(DateUtil.MAX_YEAR))) {
-      handleInvalidInputChange(true);
+      handleInvalidInputChange();
       return;
     }
 

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -219,6 +219,12 @@ const DatePickerInput = (props) => {
     }
   }, [shouldShowPicker, onClick]);
 
+  const setFocus = (node) => {
+    if (node) {
+      node.focus();
+    }
+  };
+
   /**
    * Moves focus to the correct input depending on date ordering. Focus changing is
    * disabled if a complete date has been entered in order to make single input
@@ -231,9 +237,15 @@ const DatePickerInput = (props) => {
       if (inputValue.length === 2) {
         if (type === DateUtil.inputType.MONTH) {
           // TODO: Commented below to prevent focus shft to allow VO+Chrome read second digit
-          // dayInputRef.focus();
+          const dayfocus = dayInputRef;
+          setTimeout(() => {
+            setFocus(dayfocus);
+          }, 500);
         } else {
-          // yearInputRef.focus();
+          const yearfocus = yearInputRef;
+          setTimeout(() => {
+            setFocus(yearfocus);
+          }, 500);
         }
       }
     } else if (dateFormatOrder === DateUtil.dateOrder.DMY) {
@@ -790,7 +802,7 @@ const DatePickerInput = (props) => {
   ]);
 
   // TODO: Indicates selected date from calendar popup
-  const calendarDate = value ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} is selected` : label;
+  const calendarDate = DateUtil.isValidDate(value, momentDateFormat) ? `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })} is selected` : label;
 
   return (
     <div className={cx(theme.className)}>

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -792,7 +792,7 @@ const DatePickerInput = (props) => {
   if (DateUtil.isValidDate(value, momentDateFormat)) {
     inputDate = `${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })}`;
   }
-  const calendarDate = inputDate ? `${inputDate} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : label;
+  const calendarDate = inputDate ? `${inputDate} ${intl.formatMessage({ id: 'Terra.datePicker.selected' })}` : '';
 
   return (
     <div className={cx(theme.className)}>

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -219,12 +219,6 @@ const DatePickerInput = (props) => {
     }
   }, [shouldShowPicker, onClick]);
 
-  const setFocus = (node) => {
-    if (node) {
-      node.focus();
-    }
-  };
-
   /**
    * Moves focus to the correct input depending on date ordering. Focus changing is
    * disabled if a complete date has been entered in order to make single input
@@ -236,16 +230,9 @@ const DatePickerInput = (props) => {
     if (dateFormatOrder === DateUtil.dateOrder.MDY) {
       if (inputValue.length === 2) {
         if (type === DateUtil.inputType.MONTH) {
-          // TODO: Commented below to prevent focus shft to allow VO+Chrome read second digit
-          const dayfocus = dayInputRef;
-          setTimeout(() => {
-            setFocus(dayfocus);
-          }, 500);
+          dayInputRef.focus();
         } else {
-          const yearfocus = yearInputRef;
-          setTimeout(() => {
-            setFocus(yearfocus);
-          }, 500);
+          yearInputRef.focus();
         }
       }
     } else if (dateFormatOrder === DateUtil.dateOrder.DMY) {

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -276,7 +276,7 @@ const DatePickerInput = (props) => {
     visuallyHiddenComponent.innerText = '';
     SetInvalidInput(val);
     if (val) {
-      visuallyHiddenComponent.innerText = 'Please enter a valid Date';
+      visuallyHiddenComponent.innerText = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
     }
   };
 

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -166,16 +166,14 @@ const DatePickerInput = (props) => {
   const [monthInitialFocused, setMonthInitialFocused] = useState(false);
   const [yearInitialFocused, setYearInitialFocused] = useState(false);
   // TODO:  Added below states for invalid input message for SR
-  const [invalidDay, SetInvalidDay] = useState(false);
-  const [invalidMonth, SetInvalidMonth] = useState(false);
-  const [invalidYear, SetInvalidYear] = useState(false);
+  const [invalidInput, SetInvalidInput] = useState(false);
   const editOnkeyDown = useRef(false);
   const theme = React.useContext(ThemeContext);
   // variables to store ref's for day, month and year input
   let dayInputRef;
   let monthInputRef;
   let yearInputRef;
-
+  let visuallyHiddenComponent = null;
   const { onCalendarButtonClick, shouldShowPicker } = customProps;
   delete customProps.onCalendarButtonClick;
   delete customProps.shouldShowPicker;
@@ -275,6 +273,18 @@ const DatePickerInput = (props) => {
     }
   };
 
+  const handleInvalidInputChange = (val) => {
+    visuallyHiddenComponent.innerText = '';
+    SetInvalidInput(val);
+    if (val) {
+      visuallyHiddenComponent.innerText = 'Please enter a valid Date';
+    }
+  };
+
+  const setVisuallyHiddenComponent = (node) => {
+    visuallyHiddenComponent = node;
+  };
+
   /**
    * Sets the day, month and year based on input values, formats them
    * based on the date format variant, and passes the formatted date to onChange.
@@ -317,14 +327,14 @@ const DatePickerInput = (props) => {
         onChange(event, dateString);
       }
     }
-
     setDate(event, inputValue, type);
+    SetInvalidInput(false);
   };
 
   const handleDayChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      SetInvalidDay(true);
+      handleInvalidInputChange(true);
       return;
     }
 
@@ -333,7 +343,7 @@ const DatePickerInput = (props) => {
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.day || inputValue.length > 2 || Number(inputValue) > 31 || inputValue === '00') {
       // TODO: Added below to set invalid day
-      SetInvalidDay(true);
+      handleInvalidInputChange(true);
       return;
     }
 
@@ -347,14 +357,13 @@ const DatePickerInput = (props) => {
       }
     }
 
-    SetInvalidDay(false);
     handleDateChange(event, inputValue, DateUtil.inputType.DAY);
   };
 
   const handleMonthChange = (event) => {
     let inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      SetInvalidMonth(true);
+      handleInvalidInputChange(true);
       return;
     }
 
@@ -362,7 +371,7 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 2.
     if (inputValue === date.month || inputValue.length > 2 || Number(inputValue) > 12 || inputValue === '00') {
-      SetInvalidMonth(true);
+      handleInvalidInputChange(true);
       return;
     }
 
@@ -375,15 +384,13 @@ const DatePickerInput = (props) => {
         inputValue = `0${inputValue}`;
       }
     }
-
-    SetInvalidMonth(false);
     handleDateChange(event, inputValue, DateUtil.inputType.MONTH);
   };
 
   const handleYearChange = (event) => {
     const inputValue = event.target.value;
     if (!DateUtil.validDateInput(inputValue)) {
-      SetInvalidYear(true);
+      handleInvalidInputChange(true);
       return;
     }
 
@@ -391,23 +398,22 @@ const DatePickerInput = (props) => {
     // When 'Predictive text' is enabled on Android the maxLength attribute on the input is ignored so we have to
     // check the length of inputValue to make sure that it is less then 4.
     if (inputValue === date.year || inputValue.length > 4) {
-      SetInvalidYear(true);
+      handleInvalidInputChange(true);
       return;
     }
 
     // Ignore the 3rd entry if the first two digits are not 19, 20 or 21
     if (inputValue.length === 3 && (Number(inputValue) < 190 || Number(inputValue) > 210)) {
-      SetInvalidYear(true);
+      handleInvalidInputChange(true);
       return;
     }
 
     // Ignore the 4th entry if the year value is not between MIN_YEAR and MAX_YEAR
     if (inputValue.length === 4 && (Number(inputValue) < Number(DateUtil.MIN_YEAR) || Number(inputValue) > Number(DateUtil.MAX_YEAR))) {
-      SetInvalidYear(true);
+      handleInvalidInputChange(true);
       return;
     }
 
-    SetInvalidYear(false);
     handleDateChange(event, inputValue, DateUtil.inputType.YEAR);
   };
 
@@ -532,9 +538,7 @@ const DatePickerInput = (props) => {
 
     // set date to today
     if (event.key === 't' || event.key === 'T') {
-      SetInvalidDay(false);
-      SetInvalidMonth(false);
-      SetInvalidYear(false);
+      SetInvalidInput(false);
       inputDate = DateUtil.getCurrentDate();
       formattedDate = DateUtil.strictFormatISODate(inputDate, momentDateFormat);
       if (onChange) {
@@ -680,7 +684,6 @@ const DatePickerInput = (props) => {
     { 'initial-focus': dayInitialFocused },
   ]);
 
-  // TODO: Added aria-invalid to indicate wrong input
   const dateDayInput = (
     <Input
       {...additionalInputProps}
@@ -704,7 +707,6 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.dayLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.DMY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={dayInputId}
-      aria-invalid={invalidDay}
     />
   );
 
@@ -736,7 +738,6 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.monthLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.MDY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={monthInputId}
-      aria-invalid={invalidMonth}
     />
   );
 
@@ -768,7 +769,6 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.yearLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.YMD ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={yearInputId}
-      aria-invalid={invalidYear}
     />
   );
 
@@ -810,6 +810,12 @@ const DatePickerInput = (props) => {
           />
           <VisuallyHiddenText text={value ? `${label}, ${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })}` : label} />
           <VisuallyHiddenText id={nameLabelId} text={name} />
+          <VisuallyHiddenText
+            refCallback={setVisuallyHiddenComponent}
+            aria-atomic="true"
+            aria-relevant="all"
+            aria-live={(invalidInput) ? 'assertive' : 'polite'}
+          />
           <DateInputLayout
             dateFormatOrder={dateFormatOrder}
             separator={dateSpacer}

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -230,9 +230,10 @@ const DatePickerInput = (props) => {
     if (dateFormatOrder === DateUtil.dateOrder.MDY) {
       if (inputValue.length === 2) {
         if (type === DateUtil.inputType.MONTH) {
-          dayInputRef.focus();
+          // TODO: Commented below to prevent focus shft to allow VO+Chrome read second digit
+          // dayInputRef.focus();
         } else {
-          yearInputRef.focus();
+          // yearInputRef.focus();
         }
       }
     } else if (dateFormatOrder === DateUtil.dateOrder.DMY) {
@@ -357,6 +358,7 @@ const DatePickerInput = (props) => {
       }
     }
 
+    SetInvalidDay(false);
     handleDateChange(event, inputValue, DateUtil.inputType.DAY);
   };
 
@@ -414,6 +416,7 @@ const DatePickerInput = (props) => {
       return;
     }
 
+    SetInvalidYear(false);
     handleDateChange(event, inputValue, DateUtil.inputType.YEAR);
   };
 
@@ -685,6 +688,7 @@ const DatePickerInput = (props) => {
     { 'initial-focus': dayInitialFocused },
   ]);
 
+  // TODO: Added aria-invalid to indicate wrong input
   const dateDayInput = (
     <Input
       {...additionalInputProps}
@@ -708,6 +712,7 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.dayLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.DMY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={dayInputId}
+      aria-invalid={invalidDay}
     />
   );
 
@@ -739,6 +744,7 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.monthLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.MDY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={monthInputId}
+      aria-invalid={invalidMonth}
     />
   );
 
@@ -770,6 +776,7 @@ const DatePickerInput = (props) => {
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.yearLabel' })}
       aria-describedby={dateFormatOrder === DateUtil.dateOrder.YMD ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
       id={yearInputId}
+      aria-invalid={invalidYear}
     />
   );
 

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -830,7 +830,7 @@ const DatePickerInput = (props) => {
       || DateUtil.isDateOutOfRange(DateUtil.createSafeDate(dateValue, initialTimeZone), DateUtil.createSafeDate(DateUtil.getMinDate(props.minDate), initialTimeZone), DateUtil.createSafeDate(DateUtil.getMaxDate(props.maxDate), initialTimeZone))
       || DateUtil.isDateNotIncluded(DateUtil.createSafeDate(dateValue, initialTimeZone), props.includeDates)
       || (props.filterDate && !props.filterDate(DateUtil.createSafeDate(dateValue, initialTimeZone)))) {
-    invalidEntry = intl.formatMessage({ id: 'Terra.datePicker.invalidDate' });
+    invalidEntry = `${intl.formatMessage({ id: 'Terra.datePicker.invalidDate' })}.`;
     calendarDate = '';
   }
 

--- a/packages/terra-date-picker/src/DatePicker.jsx
+++ b/packages/terra-date-picker/src/DatePicker.jsx
@@ -498,6 +498,7 @@ class DatePicker extends React.Component {
                 includeDates={DateUtil.filterInvalidDates(includeDates)}
                 maxDate={DateUtil.createSafeDate(DateUtil.getMaxDate(maxDate), initialTimeZone)}
                 minDate={DateUtil.createSafeDate(DateUtil.getMinDate(minDate), initialTimeZone)}
+                filterDate={this.handleFilterDate}
               />
             )}
             customInputRef="firstInputRefCallback"

--- a/packages/terra-date-picker/src/DatePicker.jsx
+++ b/packages/terra-date-picker/src/DatePicker.jsx
@@ -494,6 +494,10 @@ class DatePicker extends React.Component {
                 ariaLabel={ariaLabel}
                 useExternalFormatMask={useExternalFormatMask}
                 initialTimeZone={initialTimeZone}
+                excludeDates={DateUtil.filterInvalidDates(excludeDates)}
+                includeDates={DateUtil.filterInvalidDates(includeDates)}
+                maxDate={DateUtil.createSafeDate(DateUtil.getMaxDate(maxDate), initialTimeZone)}
+                minDate={DateUtil.createSafeDate(DateUtil.getMinDate(minDate), initialTimeZone)}
               />
             )}
             customInputRef="firstInputRefCallback"

--- a/packages/terra-date-picker/src/DateUtil.js
+++ b/packages/terra-date-picker/src/DateUtil.js
@@ -582,6 +582,13 @@ class DateUtil {
     }
     return momentDate.format('YYYY-MM-DD');
   }
+
+  /**
+   * Util to determine if the user agent indicates that it is macOS
+   * @return {boolean}
+   */
+
+  static isMac = () => navigator.userAgent.indexOf('Mac') !== -1 && navigator.userAgent.indexOf('Win') === -1;
 }
 
 DateUtil.inputType = {

--- a/packages/terra-date-picker/src/DateUtil.js
+++ b/packages/terra-date-picker/src/DateUtil.js
@@ -126,6 +126,30 @@ class DateUtil {
   }
 
   /**
+   * Determines if a date matched the year, month, and day of any dates in the list.
+   * @param {object} sourceDate - The moment date to check for match.
+   * @param {array} includedDates - An array of moment dates to check for.
+   * @return {boolean} - True if the sourceDate is found in the list. False, otherwise.
+   */
+  static isDateNotIncluded(sourceDate, includedDates) {
+    if (!sourceDate || !sourceDate.isValid() || !includedDates) {
+      return false;
+    }
+
+    const includeMomentDates = DateUtil.filterInvalidDates(includedDates);
+
+    if (includeMomentDates) {
+      for (let index = 0; index < includeMomentDates.length; index += 1) {
+        if (sourceDate.isSame(includeMomentDates[index], 'day')) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Converts a date string in the given format to the ISO format with only the date part.
    * @param {string} date - The date string to convert.
    * @param {string} format - The format of the date string.

--- a/packages/terra-date-picker/tests/jest/DatePicker.test.jsx
+++ b/packages/terra-date-picker/tests/jest/DatePicker.test.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 /* eslint-disable import/no-extraneous-dependencies */
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { IntlProvider } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
 import moment from 'moment-timezone';
 import DatePicker from '../../lib/DatePicker';
@@ -168,22 +165,4 @@ it('should render a date picker with onRequestClose', () => {
   const datePicker = shallowWithIntl(<DatePicker name="date-input" onRequestClose={() => {}} />);
   const wrapper = datePicker.dive();
   expect(wrapper).toMatchSnapshot();
-});
-
-it('should render a date picker with empty or invalid date in field', () => {
-  DateUtil.createSafeDate.mockRestore();
-  DateUtil.filterInvalidDates.mockRestore();
-  render(<IntlProvider><DatePicker name="date-input" /></IntlProvider>);
-
-  expect(screen.getByTitle('Terra.datePicker.openCalendar')).toHaveAttribute('aria-label', ' Terra.datePicker.openCalendar');
-});
-
-it('should render a date picker with valid date in field', () => {
-  DateUtil.createSafeDate = jest.fn();
-  DateUtil.filterInvalidDates = jest.fn();
-  DateUtil.createSafeDate.mockImplementation(() => moment.utc('2017-01-01'));
-  DateUtil.filterInvalidDates.mockImplementation(() => [moment.utc('2017-01-01')]);
-  render(<IntlProvider><DatePicker name="date-input" /></IntlProvider>);
-
-  expect(screen.getByTitle('Terra.datePicker.openCalendar')).toHaveAttribute('aria-label', 'Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar');
 });

--- a/packages/terra-date-picker/tests/jest/DatePicker.test.jsx
+++ b/packages/terra-date-picker/tests/jest/DatePicker.test.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 /* eslint-disable import/no-extraneous-dependencies */
 import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 import { shallowWithIntl, mountWithIntl } from 'terra-enzyme-intl';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IntlProvider } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
 import moment from 'moment-timezone';
 import DatePicker from '../../lib/DatePicker';
@@ -165,4 +168,22 @@ it('should render a date picker with onRequestClose', () => {
   const datePicker = shallowWithIntl(<DatePicker name="date-input" onRequestClose={() => {}} />);
   const wrapper = datePicker.dive();
   expect(wrapper).toMatchSnapshot();
+});
+
+it('should render a date picker with empty or invalid date in field', () => {
+  DateUtil.createSafeDate.mockRestore();
+  DateUtil.filterInvalidDates.mockRestore();
+  render(<IntlProvider><DatePicker name="date-input" /></IntlProvider>);
+
+  expect(screen.getByTitle('Terra.datePicker.openCalendar')).toHaveAttribute('aria-label', ' Terra.datePicker.openCalendar');
+});
+
+it('should render a date picker with valid date in field', () => {
+  DateUtil.createSafeDate = jest.fn();
+  DateUtil.filterInvalidDates = jest.fn();
+  DateUtil.createSafeDate.mockImplementation(() => moment.utc('2017-01-01'));
+  DateUtil.filterInvalidDates.mockImplementation(() => [moment.utc('2017-01-01')]);
+  render(<IntlProvider><DatePicker name="date-input" /></IntlProvider>);
+
+  expect(screen.getByTitle('Terra.datePicker.openCalendar')).toHaveAttribute('aria-label', 'Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar');
 });

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -407,9 +407,11 @@ exports[`correctly applies the theme context className 1`] = `
           id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         >
           <VisuallyHiddenText
+            aria-live="off"
             text=" Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  "
           >
             <span
+              aria-live="off"
               className="visually-hidden-text"
             >
                Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
@@ -887,9 +889,11 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
       id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
     >
       <VisuallyHiddenText
+        aria-live="off"
         text=" Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  "
       >
         <span
+          aria-live="off"
           className="visually-hidden-text"
         >
            Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
@@ -1017,6 +1021,7 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
     id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
   >
     <span
+      aria-live="off"
       class="visually-hidden-text"
     >
        Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
@@ -1142,6 +1147,7 @@ exports[`should render a date input with isInvalid prop 1`] = `
     id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
   >
     <span
+      aria-live="off"
       class="visually-hidden-text"
     >
        Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
@@ -1267,6 +1273,7 @@ exports[`should render a default date input 1`] = `
     id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
   >
     <span
+      aria-live="off"
       class="visually-hidden-text"
     >
        Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
@@ -1767,9 +1774,11 @@ exports[`should render a default date input with all props 1`] = `
       id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
     >
       <VisuallyHiddenText
+        aria-live="off"
         text=" Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 "
       >
         <span
+          aria-live="off"
           className="visually-hidden-text"
         >
            Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -324,6 +324,7 @@ exports[`correctly applies the theme context className 1`] = `
             </DateInputLayout>
           </div>
           <Button
+            aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
             className="button"
             data-terra-open-calendar-button={true}
             icon={
@@ -339,7 +340,7 @@ exports[`correctly applies the theme context className 1`] = `
             isReversed={false}
             onClick={[Function]}
             onKeyDown={[Function]}
-            text="Terra.datePicker.date Terra.datePicker.openCalendar"
+            text="Terra.datePicker.openCalendar"
             type="button"
             variant="neutral"
           >
@@ -355,7 +356,7 @@ exports[`correctly applies the theme context className 1`] = `
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
-              title="Terra.datePicker.date Terra.datePicker.openCalendar"
+              title="Terra.datePicker.openCalendar"
               type="button"
             >
               <span
@@ -435,7 +436,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
-            title="Terra.datePicker.date Terra.datePicker.openCalendar"
+            title="Terra.datePicker.openCalendar"
             type="button"
           >
             <span
@@ -757,6 +758,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
         </DateInputLayout>
       </div>
       <Button
+        aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
         className="button"
         data-terra-open-calendar-button={true}
         icon={
@@ -781,7 +783,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
                   aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
-                  title="Terra.datePicker.date Terra.datePicker.openCalendar"
+                  title="Terra.datePicker.openCalendar"
                   type="button"
                 >
                   <span
@@ -816,7 +818,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             ],
           }
         }
-        text="Terra.datePicker.date Terra.datePicker.openCalendar"
+        text="Terra.datePicker.openCalendar"
         type="button"
         variant="neutral"
       >
@@ -832,7 +834,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
-          title="Terra.datePicker.date Terra.datePicker.openCalendar"
+          title="Terra.datePicker.openCalendar"
           type="button"
         >
           <span
@@ -980,7 +982,7 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
       aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
-      title="Terra.datePicker.date Terra.datePicker.openCalendar"
+      title="Terra.datePicker.openCalendar"
       type="button"
     >
       <span
@@ -1105,7 +1107,7 @@ exports[`should render a date input with isInvalid prop 1`] = `
       aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
       class="button neutral compact button is-invalid"
       data-terra-open-calendar-button="true"
-      title="Terra.datePicker.date Terra.datePicker.openCalendar"
+      title="Terra.datePicker.openCalendar"
       type="button"
     >
       <span
@@ -1230,7 +1232,7 @@ exports[`should render a default date input 1`] = `
       aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
-      title="Terra.datePicker.date Terra.datePicker.openCalendar"
+      title="Terra.datePicker.openCalendar"
       type="button"
     >
       <span
@@ -1286,7 +1288,7 @@ exports[`should render a default date input with all props 1`] = `
             aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
-            title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+            title="Terra.datePicker.openCalendar"
             type="button"
           >
             <span
@@ -1632,6 +1634,7 @@ exports[`should render a default date input with all props 1`] = `
         </DateInputLayout>
       </div>
       <Button
+        aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
         className="button"
         data-terra-open-calendar-button={true}
         icon={
@@ -1658,7 +1661,7 @@ exports[`should render a default date input with all props 1`] = `
                   aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
-                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                  title="Terra.datePicker.openCalendar"
                   type="button"
                 >
                   <span
@@ -1693,7 +1696,7 @@ exports[`should render a default date input with all props 1`] = `
             ],
           }
         }
-        text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+        text="Terra.datePicker.openCalendar"
         type="button"
         variant="neutral"
       >
@@ -1709,7 +1712,7 @@ exports[`should render a default date input with all props 1`] = `
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
-          title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+          title="Terra.datePicker.openCalendar"
           type="button"
         >
           <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -324,7 +324,7 @@ exports[`correctly applies the theme context className 1`] = `
             </DateInputLayout>
           </div>
           <Button
-            aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+            aria-label=" Terra.datePicker.openCalendar"
             className="button"
             data-terra-open-calendar-button={true}
             icon={
@@ -346,7 +346,7 @@ exports[`correctly applies the theme context className 1`] = `
           >
             <button
               aria-disabled={false}
-              aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+              aria-label=" Terra.datePicker.openCalendar"
               className="button neutral compact orion-fusion-theme button"
               data-terra-open-calendar-button={true}
               disabled={false}
@@ -433,7 +433,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
         Array [
           <button
             aria-disabled="false"
-            aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+            aria-label=" Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
             title="Terra.datePicker.openCalendar"
@@ -758,7 +758,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
         </DateInputLayout>
       </div>
       <Button
-        aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+        aria-label=" Terra.datePicker.openCalendar"
         className="button"
         data-terra-open-calendar-button={true}
         icon={
@@ -780,7 +780,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
               Array [
                 <button
                   aria-disabled="false"
-                  aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+                  aria-label=" Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
                   title="Terra.datePicker.openCalendar"
@@ -824,7 +824,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
       >
         <button
           aria-disabled={false}
-          aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+          aria-label=" Terra.datePicker.openCalendar"
           className="button neutral compact button"
           data-terra-open-calendar-button={true}
           disabled={false}
@@ -979,7 +979,7 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+      aria-label=" Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
       title="Terra.datePicker.openCalendar"
@@ -1104,7 +1104,7 @@ exports[`should render a date input with isInvalid prop 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+      aria-label=" Terra.datePicker.openCalendar"
       class="button neutral compact button is-invalid"
       data-terra-open-calendar-button="true"
       title="Terra.datePicker.openCalendar"
@@ -1229,7 +1229,7 @@ exports[`should render a default date input 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
+      aria-label=" Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
       title="Terra.datePicker.openCalendar"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -404,12 +404,12 @@ exports[`correctly applies the theme context className 1`] = `
           id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         >
           <VisuallyHiddenText
-            text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat"
+            text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat "
           >
             <span
               className="visually-hidden-text"
             >
-              Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+              Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
             </span>
           </VisuallyHiddenText>
           <div
@@ -881,12 +881,12 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
       id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
     >
       <VisuallyHiddenText
-        text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat"
+        text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat "
       >
         <span
           className="visually-hidden-text"
         >
-          Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+          Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
         </span>
       </VisuallyHiddenText>
       <div
@@ -1013,7 +1013,7 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
     <span
       class="visually-hidden-text"
     >
-      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
     </span>
     <div
       aria-hidden="true"
@@ -1138,7 +1138,7 @@ exports[`should render a date input with isInvalid prop 1`] = `
     <span
       class="visually-hidden-text"
     >
-      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
     </span>
     <div
       aria-hidden="true"
@@ -1263,7 +1263,7 @@ exports[`should render a default date input 1`] = `
     <span
       class="visually-hidden-text"
     >
-      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
     </span>
     <div
       aria-hidden="true"
@@ -1758,12 +1758,12 @@ exports[`should render a default date input with all props 1`] = `
       id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
     >
       <VisuallyHiddenText
-        text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat"
+        text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017"
       >
         <span
           className="visually-hidden-text"
         >
-          Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+          Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017
         </span>
       </VisuallyHiddenText>
       <div

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -99,6 +99,19 @@ exports[`correctly applies the theme context className 1`] = `
                 id="name-label-00000000-0000-0000-0000-000000000000"
               />
             </VisuallyHiddenText>
+            <VisuallyHiddenText
+              aria-atomic="true"
+              aria-live="assertive"
+              aria-relevant="all"
+              refCallback={[Function]}
+            >
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                aria-relevant="all"
+                className="visually-hidden-text"
+              />
+            </VisuallyHiddenText>
             <DateInputLayout
               dateFormatOrder="MDY"
               day={
@@ -519,6 +532,19 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             id="name-label-00000000-0000-0000-0000-000000000000"
           />
         </VisuallyHiddenText>
+        <VisuallyHiddenText
+          aria-atomic="true"
+          aria-live="assertive"
+          aria-relevant="all"
+          refCallback={[Function]}
+        >
+          <span
+            aria-atomic="true"
+            aria-live="assertive"
+            aria-relevant="all"
+            className="visually-hidden-text"
+          />
+        </VisuallyHiddenText>
         <DateInputLayout
           dateFormatOrder="MDY"
           day={
@@ -896,6 +922,12 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
         class="visually-hidden-text"
         id="name-label-00000000-0000-0000-0000-000000000000"
       />
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        aria-relevant="all"
+        class="visually-hidden-text"
+      />
       <input
         aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         aria-label="Terra.datePicker.monthLabel"
@@ -1015,6 +1047,12 @@ exports[`should render a date input with isInvalid prop 1`] = `
         class="visually-hidden-text"
         id="name-label-00000000-0000-0000-0000-000000000000"
       />
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        aria-relevant="all"
+        class="visually-hidden-text"
+      />
       <input
         aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         aria-label="Terra.datePicker.monthLabel"
@@ -1133,6 +1171,12 @@ exports[`should render a default date input 1`] = `
       <span
         class="visually-hidden-text"
         id="name-label-00000000-0000-0000-0000-000000000000"
+      />
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        aria-relevant="all"
+        class="visually-hidden-text"
       />
       <input
         aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
@@ -1353,6 +1397,19 @@ exports[`should render a default date input with all props 1`] = `
           >
             date-input
           </span>
+        </VisuallyHiddenText>
+        <VisuallyHiddenText
+          aria-atomic="true"
+          aria-live="assertive"
+          aria-relevant="all"
+          refCallback={[Function]}
+        >
+          <span
+            aria-atomic="true"
+            aria-live="assertive"
+            aria-relevant="all"
+            className="visually-hidden-text"
+          />
         </VisuallyHiddenText>
         <DateInputLayout
           dateFormatOrder="MDY"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -1239,10 +1239,10 @@ exports[`should render a default date input with all props 1`] = `
         Array [
           <button
             aria-disabled="false"
-            aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+            aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
-            title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+            title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
             type="button"
           >
             <span
@@ -1598,10 +1598,10 @@ exports[`should render a default date input with all props 1`] = `
               Array [
                 <button
                   aria-disabled="false"
-                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
-                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                   type="button"
                 >
                   <span
@@ -1636,13 +1636,13 @@ exports[`should render a default date input with all props 1`] = `
             ],
           }
         }
-        text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+        text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
         type="button"
         variant="neutral"
       >
         <button
           aria-disabled={false}
-          aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+          aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
           className="button neutral compact button"
           data-terra-open-calendar-button={true}
           disabled={false}
@@ -1652,7 +1652,7 @@ exports[`should render a default date input with all props 1`] = `
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
-          title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+          title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
           type="button"
         >
           <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -66,6 +66,8 @@ exports[`correctly applies the theme context className 1`] = `
       }
       isIncomplete={false}
       isInvalid={false}
+      maxDate="2100-12-31"
+      minDate="1900-01-01"
       required={false}
       useExternalFormatMask={false}
     >
@@ -405,12 +407,12 @@ exports[`correctly applies the theme context className 1`] = `
           id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         >
           <VisuallyHiddenText
-            text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat "
+            text=" Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  "
           >
             <span
               className="visually-hidden-text"
             >
-              Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
+               Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
             </span>
           </VisuallyHiddenText>
           <div
@@ -500,6 +502,8 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
   }
   isIncomplete={false}
   isInvalid={false}
+  maxDate="2100-12-31"
+  minDate="1900-01-01"
   required={false}
   useExternalFormatMask={false}
 >
@@ -883,12 +887,12 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
       id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
     >
       <VisuallyHiddenText
-        text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat "
+        text=" Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  "
       >
         <span
           className="visually-hidden-text"
         >
-          Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
+           Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
         </span>
       </VisuallyHiddenText>
       <div
@@ -1015,7 +1019,7 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
     <span
       class="visually-hidden-text"
     >
-      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
+       Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
     </span>
     <div
       aria-hidden="true"
@@ -1140,7 +1144,7 @@ exports[`should render a date input with isInvalid prop 1`] = `
     <span
       class="visually-hidden-text"
     >
-      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
+       Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
     </span>
     <div
       aria-hidden="true"
@@ -1265,7 +1269,7 @@ exports[`should render a default date input 1`] = `
     <span
       class="visually-hidden-text"
     >
-      Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat 
+       Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat  
     </span>
     <div
       aria-hidden="true"
@@ -1353,6 +1357,8 @@ exports[`should render a default date input with all props 1`] = `
   }
   isIncomplete={false}
   isInvalid={false}
+  maxDate="2100-12-31"
+  minDate="1900-01-01"
   name="date-input"
   onBlur={[Function]}
   onButtonFocus={[Function]}
@@ -1761,12 +1767,12 @@ exports[`should render a default date input with all props 1`] = `
       id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
     >
       <VisuallyHiddenText
-        text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017"
+        text=" Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 "
       >
         <span
           className="visually-hidden-text"
         >
-          Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017
+           Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 
         </span>
       </VisuallyHiddenText>
       <div

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -326,13 +326,13 @@ exports[`correctly applies the theme context className 1`] = `
             isReversed={false}
             onClick={[Function]}
             onKeyDown={[Function]}
-            text="Terra.datePicker.openCalendar"
+            text="Terra.datePicker.date Terra.datePicker.openCalendar"
             type="button"
             variant="neutral"
           >
             <button
               aria-disabled={false}
-              aria-label="Terra.datePicker.openCalendar"
+              aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
               className="button neutral compact orion-fusion-theme button"
               data-terra-open-calendar-button={true}
               disabled={false}
@@ -342,7 +342,7 @@ exports[`correctly applies the theme context className 1`] = `
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
-              title="Terra.datePicker.openCalendar"
+              title="Terra.datePicker.date Terra.datePicker.openCalendar"
               type="button"
             >
               <span
@@ -419,10 +419,10 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
         Array [
           <button
             aria-disabled="false"
-            aria-label="Terra.datePicker.openCalendar"
+            aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
-            title="Terra.datePicker.openCalendar"
+            title="Terra.datePicker.date Terra.datePicker.openCalendar"
             type="button"
           >
             <span
@@ -752,10 +752,10 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
               Array [
                 <button
                   aria-disabled="false"
-                  aria-label="Terra.datePicker.openCalendar"
+                  aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
-                  title="Terra.datePicker.openCalendar"
+                  title="Terra.datePicker.date Terra.datePicker.openCalendar"
                   type="button"
                 >
                   <span
@@ -790,13 +790,13 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             ],
           }
         }
-        text="Terra.datePicker.openCalendar"
+        text="Terra.datePicker.date Terra.datePicker.openCalendar"
         type="button"
         variant="neutral"
       >
         <button
           aria-disabled={false}
-          aria-label="Terra.datePicker.openCalendar"
+          aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
           className="button neutral compact button"
           data-terra-open-calendar-button={true}
           disabled={false}
@@ -806,7 +806,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
-          title="Terra.datePicker.openCalendar"
+          title="Terra.datePicker.date Terra.datePicker.openCalendar"
           type="button"
         >
           <span
@@ -945,10 +945,10 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.openCalendar"
+      aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
-      title="Terra.datePicker.openCalendar"
+      title="Terra.datePicker.date Terra.datePicker.openCalendar"
       type="button"
     >
       <span
@@ -1064,10 +1064,10 @@ exports[`should render a date input with isInvalid prop 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.openCalendar"
+      aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
       class="button neutral compact button is-invalid"
       data-terra-open-calendar-button="true"
-      title="Terra.datePicker.openCalendar"
+      title="Terra.datePicker.date Terra.datePicker.openCalendar"
       type="button"
     >
       <span
@@ -1183,10 +1183,10 @@ exports[`should render a default date input 1`] = `
     </div>
     <button
       aria-disabled="false"
-      aria-label="Terra.datePicker.openCalendar"
+      aria-label="Terra.datePicker.date Terra.datePicker.openCalendar"
       class="button neutral compact button"
       data-terra-open-calendar-button="true"
-      title="Terra.datePicker.openCalendar"
+      title="Terra.datePicker.date Terra.datePicker.openCalendar"
       type="button"
     >
       <span
@@ -1239,10 +1239,10 @@ exports[`should render a default date input with all props 1`] = `
         Array [
           <button
             aria-disabled="false"
-            aria-label="Terra.datePicker.openCalendar"
+            aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
             class="button neutral compact button"
             data-terra-open-calendar-button="true"
-            title="Terra.datePicker.openCalendar"
+            title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
             type="button"
           >
             <span
@@ -1598,10 +1598,10 @@ exports[`should render a default date input with all props 1`] = `
               Array [
                 <button
                   aria-disabled="false"
-                  aria-label="Terra.datePicker.openCalendar"
+                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                   class="button neutral compact button"
                   data-terra-open-calendar-button="true"
-                  title="Terra.datePicker.openCalendar"
+                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                   type="button"
                 >
                   <span
@@ -1636,13 +1636,13 @@ exports[`should render a default date input with all props 1`] = `
             ],
           }
         }
-        text="Terra.datePicker.openCalendar"
+        text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
         type="button"
         variant="neutral"
       >
         <button
           aria-disabled={false}
-          aria-label="Terra.datePicker.openCalendar"
+          aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
           className="button neutral compact button"
           data-terra-open-calendar-button={true}
           disabled={false}
@@ -1652,7 +1652,7 @@ exports[`should render a default date input with all props 1`] = `
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onMouseDown={[Function]}
-          title="Terra.datePicker.openCalendar"
+          title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
           type="button"
         >
           <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -94,6 +94,7 @@ exports[`correctly applies the theme context className 1`] = `
                     "2017-01-01T00:00:00.000Z",
                   ]
                 }
+                filterDate={[Function]}
                 includeDates={
                   Array [
                     "2017-01-01T00:00:00.000Z",
@@ -156,6 +157,7 @@ exports[`correctly applies the theme context className 1`] = `
                       "2017-01-01T00:00:00.000Z",
                     ]
                   }
+                  filterDate={[Function]}
                   includeDates={
                     Array [
                       "2017-01-01T00:00:00.000Z",
@@ -252,6 +254,7 @@ exports[`correctly applies the theme context className 1`] = `
                       "2017-01-01T00:00:00.000Z",
                     ]
                   }
+                  filterDate={[Function]}
                   firstInputRefCallback={[Function]}
                   includeDates={
                     Array [
@@ -284,6 +287,7 @@ exports[`correctly applies the theme context className 1`] = `
                         "2017-01-01T00:00:00.000Z",
                       ]
                     }
+                    filterDate={[Function]}
                     firstInputRefCallback={[Function]}
                     includeDates={
                       Array [
@@ -724,6 +728,7 @@ exports[`should render a controlled date picker 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -799,6 +804,7 @@ exports[`should render a date picker with disabled dates 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -873,6 +879,7 @@ exports[`should render a date picker with filtered dates 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -947,6 +954,7 @@ exports[`should render a date picker with included dates 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1021,6 +1029,7 @@ exports[`should render a date picker with min and max dates 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1095,6 +1104,7 @@ exports[`should render a date picker with onBlur 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1169,6 +1179,7 @@ exports[`should render a date picker with onCalendarButtonClick 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1243,6 +1254,7 @@ exports[`should render a date picker with onChange 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1317,6 +1329,7 @@ exports[`should render a date picker with onChangeRaw 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1391,6 +1404,7 @@ exports[`should render a date picker with onFocus 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1465,6 +1479,7 @@ exports[`should render a date picker with onRequestClose 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1540,6 +1555,7 @@ exports[`should render a date picker with onSelect 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1614,6 +1630,7 @@ exports[`should render a default date input and date picker 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1688,6 +1705,7 @@ exports[`should render a default date input with custom input attributes 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1767,6 +1785,7 @@ exports[`should render a disabled date picker 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",
@@ -1841,6 +1860,7 @@ exports[`should render a required date input and date picker 1`] = `
               "2017-01-01T00:00:00.000Z",
             ]
           }
+          filterDate={[Function]}
           includeDates={
             Array [
               "2017-01-01T00:00:00.000Z",

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -552,13 +552,13 @@ exports[`correctly applies the theme context className 1`] = `
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           refCallback={[Function]}
-                          text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                          text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                           type="button"
                           variant="neutral"
                         >
                           <button
                             aria-disabled={false}
-                            aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                            aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                             className="button neutral compact orion-fusion-theme button"
                             data-terra-open-calendar-button={true}
                             disabled={false}
@@ -568,7 +568,7 @@ exports[`correctly applies the theme context className 1`] = `
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             onMouseDown={[Function]}
-                            title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                            title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                             type="button"
                           >
                             <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -547,6 +547,7 @@ exports[`correctly applies the theme context className 1`] = `
                           </DateInputLayout>
                         </div>
                         <Button
+                          aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                           className="button"
                           data-terra-open-calendar-button={true}
                           icon={
@@ -565,7 +566,7 @@ exports[`correctly applies the theme context className 1`] = `
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           refCallback={[Function]}
-                          text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                          text="Terra.datePicker.openCalendar"
                           type="button"
                           variant="neutral"
                         >
@@ -581,7 +582,7 @@ exports[`correctly applies the theme context className 1`] = `
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             onMouseDown={[Function]}
-                            title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                            title="Terra.datePicker.openCalendar"
                             type="button"
                           >
                             <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -322,6 +322,19 @@ exports[`correctly applies the theme context className 1`] = `
                               date-input
                             </span>
                           </VisuallyHiddenText>
+                          <VisuallyHiddenText
+                            aria-atomic="true"
+                            aria-live="assertive"
+                            aria-relevant="all"
+                            refCallback={[Function]}
+                          >
+                            <span
+                              aria-atomic="true"
+                              aria-live="assertive"
+                              aria-relevant="all"
+                              className="visually-hidden-text"
+                            />
+                          </VisuallyHiddenText>
                           <DateInputLayout
                             dateFormatOrder="MDY"
                             day={

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -552,13 +552,13 @@ exports[`correctly applies the theme context className 1`] = `
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           refCallback={[Function]}
-                          text="Terra.datePicker.openCalendar"
+                          text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                           type="button"
                           variant="neutral"
                         >
                           <button
                             aria-disabled={false}
-                            aria-label="Terra.datePicker.openCalendar"
+                            aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                             className="button neutral compact orion-fusion-theme button"
                             data-terra-open-calendar-button={true}
                             disabled={false}
@@ -568,7 +568,7 @@ exports[`correctly applies the theme context className 1`] = `
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             onMouseDown={[Function]}
-                            title="Terra.datePicker.openCalendar"
+                            title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                             type="button"
                           >
                             <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -630,12 +630,12 @@ exports[`correctly applies the theme context className 1`] = `
                         id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                       >
                         <VisuallyHiddenText
-                          text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat"
+                          text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017"
                         >
                           <span
                             className="visually-hidden-text"
                           >
-                            Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat
+                            Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017
                           </span>
                         </VisuallyHiddenText>
                         <div

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -683,9 +683,11 @@ exports[`correctly applies the theme context className 1`] = `
                         id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                       >
                         <VisuallyHiddenText
+                          aria-live="off"
                           text="Terra.datePicker.invalidDate Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 "
                         >
                           <span
+                            aria-live="off"
                             className="visually-hidden-text"
                           >
                             Terra.datePicker.invalidDate Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -89,8 +89,20 @@ exports[`correctly applies the theme context className 1`] = `
             customInput={
               <InjectIntl(DatePickerInput)
                 buttonRefCallback={[Function]}
+                excludeDates={
+                  Array [
+                    "2017-01-01T00:00:00.000Z",
+                  ]
+                }
+                includeDates={
+                  Array [
+                    "2017-01-01T00:00:00.000Z",
+                  ]
+                }
                 isIncomplete={false}
                 isInvalid={false}
+                maxDate={"2017-01-01T00:00:00.000Z"}
+                minDate={"2017-01-01T00:00:00.000Z"}
                 onButtonFocus={[Function]}
                 onCalendarButtonClick={[Function]}
                 required={false}
@@ -139,8 +151,20 @@ exports[`correctly applies the theme context className 1`] = `
               customInput={
                 <InjectIntl(DatePickerInput)
                   buttonRefCallback={[Function]}
+                  excludeDates={
+                    Array [
+                      "2017-01-01T00:00:00.000Z",
+                    ]
+                  }
+                  includeDates={
+                    Array [
+                      "2017-01-01T00:00:00.000Z",
+                    ]
+                  }
                   isIncomplete={false}
                   isInvalid={false}
+                  maxDate={"2017-01-01T00:00:00.000Z"}
+                  minDate={"2017-01-01T00:00:00.000Z"}
                   onButtonFocus={[Function]}
                   onCalendarButtonClick={[Function]}
                   required={false}
@@ -223,9 +247,21 @@ exports[`correctly applies the theme context className 1`] = `
                   buttonRefCallback={[Function]}
                   className=""
                   disabled={false}
+                  excludeDates={
+                    Array [
+                      "2017-01-01T00:00:00.000Z",
+                    ]
+                  }
                   firstInputRefCallback={[Function]}
+                  includeDates={
+                    Array [
+                      "2017-01-01T00:00:00.000Z",
+                    ]
+                  }
                   isIncomplete={false}
                   isInvalid={false}
+                  maxDate={"2017-01-01T00:00:00.000Z"}
+                  minDate={"2017-01-01T00:00:00.000Z"}
                   name="date-input"
                   onBlur={[Function]}
                   onButtonFocus={[Function]}
@@ -243,7 +279,17 @@ exports[`correctly applies the theme context className 1`] = `
                     buttonRefCallback={[Function]}
                     className=""
                     disabled={false}
+                    excludeDates={
+                      Array [
+                        "2017-01-01T00:00:00.000Z",
+                      ]
+                    }
                     firstInputRefCallback={[Function]}
+                    includeDates={
+                      Array [
+                        "2017-01-01T00:00:00.000Z",
+                      ]
+                    }
                     intl={
                       Object {
                         "defaultFormats": Object {},
@@ -273,6 +319,8 @@ exports[`correctly applies the theme context className 1`] = `
                     }
                     isIncomplete={false}
                     isInvalid={false}
+                    maxDate={"2017-01-01T00:00:00.000Z"}
+                    minDate={"2017-01-01T00:00:00.000Z"}
                     name="date-input"
                     onBlur={[Function]}
                     onButtonFocus={[Function]}
@@ -547,7 +595,7 @@ exports[`correctly applies the theme context className 1`] = `
                           </DateInputLayout>
                         </div>
                         <Button
-                          aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                          aria-label=" Terra.datePicker.openCalendar"
                           className="button"
                           data-terra-open-calendar-button={true}
                           icon={
@@ -572,7 +620,7 @@ exports[`correctly applies the theme context className 1`] = `
                         >
                           <button
                             aria-disabled={false}
-                            aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                            aria-label=" Terra.datePicker.openCalendar"
                             className="button neutral compact orion-fusion-theme button"
                             data-terra-open-calendar-button={true}
                             disabled={false}
@@ -631,12 +679,12 @@ exports[`correctly applies the theme context className 1`] = `
                         id="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                       >
                         <VisuallyHiddenText
-                          text="Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017"
+                          text="Terra.datePicker.invalidDate Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 "
                         >
                           <span
                             className="visually-hidden-text"
                           >
-                            Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017
+                            Terra.datePicker.invalidDate Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 
                           </span>
                         </VisuallyHiddenText>
                         <div
@@ -671,8 +719,20 @@ exports[`should render a controlled date picker 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -734,8 +794,20 @@ exports[`should render a date picker with disabled dates 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -796,8 +868,20 @@ exports[`should render a date picker with filtered dates 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -858,8 +942,20 @@ exports[`should render a date picker with included dates 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -920,8 +1016,20 @@ exports[`should render a date picker with min and max dates 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -982,8 +1090,20 @@ exports[`should render a date picker with onBlur 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1044,8 +1164,20 @@ exports[`should render a date picker with onCalendarButtonClick 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1106,8 +1238,20 @@ exports[`should render a date picker with onChange 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1168,8 +1312,20 @@ exports[`should render a date picker with onChangeRaw 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1230,8 +1386,20 @@ exports[`should render a date picker with onFocus 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1292,8 +1460,20 @@ exports[`should render a date picker with onRequestClose 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1355,8 +1535,20 @@ exports[`should render a date picker with onSelect 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1417,8 +1609,20 @@ exports[`should render a default date input and date picker 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1479,6 +1683,16 @@ exports[`should render a default date input with custom input attributes 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           inputAttributes={
             Object {
               "id": "terra-date-input",
@@ -1486,6 +1700,8 @@ exports[`should render a default date input with custom input attributes 1`] = `
           }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1546,8 +1762,20 @@ exports[`should render a disabled date picker 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={false}
@@ -1608,8 +1836,20 @@ exports[`should render a required date input and date picker 1`] = `
       customInput={
         <InjectIntl(DatePickerInput)
           buttonRefCallback={[Function]}
+          excludeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
+          includeDates={
+            Array [
+              "2017-01-01T00:00:00.000Z",
+            ]
+          }
           isIncomplete={false}
           isInvalid={false}
+          maxDate={"2017-01-01T00:00:00.000Z"}
+          minDate={"2017-01-01T00:00:00.000Z"}
           onButtonFocus={[Function]}
           onCalendarButtonClick={[Function]}
           required={true}

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -684,13 +684,13 @@ exports[`correctly applies the theme context className 1`] = `
                       >
                         <VisuallyHiddenText
                           aria-live="off"
-                          text="Terra.datePicker.invalidDate Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 "
+                          text="Terra.datePicker.invalidDate. Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 "
                         >
                           <span
                             aria-live="off"
                             className="visually-hidden-text"
                           >
-                            Terra.datePicker.invalidDate Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 
+                            Terra.datePicker.invalidDate. Terra.datePicker.dateFormatLabel Terra.datePicker.dateFormat Sunday, January 1, 2017 
                           </span>
                         </VisuallyHiddenText>
                         <div

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -355,6 +355,16 @@ exports[`should render a DatePickerField with props 1`] = `
                     <InjectIntl(DatePickerInput)
                       ariaLabel="Label Test"
                       buttonRefCallback={[Function]}
+                      excludeDates={
+                        Array [
+                          "2017-01-01T00:00:00.000Z",
+                        ]
+                      }
+                      includeDates={
+                        Array [
+                          "2017-01-01T00:00:00.000Z",
+                        ]
+                      }
                       inputAttributes={
                         Object {
                           "aria-describedby": "test-date-picker-error test-date-picker-help",
@@ -363,6 +373,8 @@ exports[`should render a DatePickerField with props 1`] = `
                       }
                       isIncomplete={false}
                       isInvalid={true}
+                      maxDate={"2017-01-01T00:00:00.000Z"}
+                      minDate={"2017-01-01T00:00:00.000Z"}
                       onButtonFocus={[Function]}
                       onCalendarButtonClick={[Function]}
                       required={true}
@@ -415,6 +427,16 @@ exports[`should render a DatePickerField with props 1`] = `
                       <InjectIntl(DatePickerInput)
                         ariaLabel="Label Test"
                         buttonRefCallback={[Function]}
+                        excludeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
+                        includeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         inputAttributes={
                           Object {
                             "aria-describedby": "test-date-picker-error test-date-picker-help",
@@ -423,6 +445,8 @@ exports[`should render a DatePickerField with props 1`] = `
                         }
                         isIncomplete={false}
                         isInvalid={true}
+                        maxDate={"2017-01-01T00:00:00.000Z"}
+                        minDate={"2017-01-01T00:00:00.000Z"}
                         onButtonFocus={[Function]}
                         onCalendarButtonClick={[Function]}
                         required={true}
@@ -509,8 +533,18 @@ exports[`should render a DatePickerField with props 1`] = `
                         buttonRefCallback={[Function]}
                         className=""
                         disabled={true}
+                        excludeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         firstInputRefCallback={[Function]}
                         id="test-date-picker"
+                        includeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         inputAttributes={
                           Object {
                             "aria-describedby": "test-date-picker-error test-date-picker-help",
@@ -519,6 +553,8 @@ exports[`should render a DatePickerField with props 1`] = `
                         }
                         isIncomplete={false}
                         isInvalid={true}
+                        maxDate={"2017-01-01T00:00:00.000Z"}
+                        minDate={"2017-01-01T00:00:00.000Z"}
                         name="test-date-picker"
                         onBlur={[Function]}
                         onButtonFocus={[Function]}
@@ -537,8 +573,18 @@ exports[`should render a DatePickerField with props 1`] = `
                           buttonRefCallback={[Function]}
                           className=""
                           disabled={true}
+                          excludeDates={
+                            Array [
+                              "2017-01-01T00:00:00.000Z",
+                            ]
+                          }
                           firstInputRefCallback={[Function]}
                           id="test-date-picker"
+                          includeDates={
+                            Array [
+                              "2017-01-01T00:00:00.000Z",
+                            ]
+                          }
                           inputAttributes={
                             Object {
                               "aria-describedby": "test-date-picker-error test-date-picker-help",
@@ -574,6 +620,8 @@ exports[`should render a DatePickerField with props 1`] = `
                           }
                           isIncomplete={false}
                           isInvalid={true}
+                          maxDate={"2017-01-01T00:00:00.000Z"}
+                          minDate={"2017-01-01T00:00:00.000Z"}
                           name="test-date-picker"
                           onBlur={[Function]}
                           onButtonFocus={[Function]}
@@ -849,7 +897,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                 </DateInputLayout>
                               </div>
                               <Button
-                                aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                aria-label=" Terra.datePicker.openCalendar"
                                 className="button is-invalid"
                                 data-terra-open-calendar-button={true}
                                 icon={
@@ -874,7 +922,7 @@ exports[`should render a DatePickerField with props 1`] = `
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                  aria-label=" Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button is-invalid"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}
@@ -1196,6 +1244,16 @@ exports[`should render a default DatePickerField component 1`] = `
                     <InjectIntl(DatePickerInput)
                       ariaLabel="Label"
                       buttonRefCallback={[Function]}
+                      excludeDates={
+                        Array [
+                          "2017-01-01T00:00:00.000Z",
+                        ]
+                      }
+                      includeDates={
+                        Array [
+                          "2017-01-01T00:00:00.000Z",
+                        ]
+                      }
                       inputAttributes={
                         Object {
                           "aria-describedby": "test-date-picker-help",
@@ -1203,6 +1261,8 @@ exports[`should render a default DatePickerField component 1`] = `
                       }
                       isIncomplete={false}
                       isInvalid={false}
+                      maxDate={"2017-01-01T00:00:00.000Z"}
+                      minDate={"2017-01-01T00:00:00.000Z"}
                       onButtonFocus={[Function]}
                       onCalendarButtonClick={[Function]}
                       required={false}
@@ -1253,6 +1313,16 @@ exports[`should render a default DatePickerField component 1`] = `
                       <InjectIntl(DatePickerInput)
                         ariaLabel="Label"
                         buttonRefCallback={[Function]}
+                        excludeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
+                        includeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         inputAttributes={
                           Object {
                             "aria-describedby": "test-date-picker-help",
@@ -1260,6 +1330,8 @@ exports[`should render a default DatePickerField component 1`] = `
                         }
                         isIncomplete={false}
                         isInvalid={false}
+                        maxDate={"2017-01-01T00:00:00.000Z"}
+                        minDate={"2017-01-01T00:00:00.000Z"}
                         onButtonFocus={[Function]}
                         onCalendarButtonClick={[Function]}
                         required={false}
@@ -1344,8 +1416,18 @@ exports[`should render a default DatePickerField component 1`] = `
                         buttonRefCallback={[Function]}
                         className=""
                         disabled={false}
+                        excludeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         firstInputRefCallback={[Function]}
                         id="test-date-picker"
+                        includeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         inputAttributes={
                           Object {
                             "aria-describedby": "test-date-picker-help",
@@ -1353,6 +1435,8 @@ exports[`should render a default DatePickerField component 1`] = `
                         }
                         isIncomplete={false}
                         isInvalid={false}
+                        maxDate={"2017-01-01T00:00:00.000Z"}
+                        minDate={"2017-01-01T00:00:00.000Z"}
                         name="test-date-picker"
                         onBlur={[Function]}
                         onButtonFocus={[Function]}
@@ -1371,8 +1455,18 @@ exports[`should render a default DatePickerField component 1`] = `
                           buttonRefCallback={[Function]}
                           className=""
                           disabled={false}
+                          excludeDates={
+                            Array [
+                              "2017-01-01T00:00:00.000Z",
+                            ]
+                          }
                           firstInputRefCallback={[Function]}
                           id="test-date-picker"
+                          includeDates={
+                            Array [
+                              "2017-01-01T00:00:00.000Z",
+                            ]
+                          }
                           inputAttributes={
                             Object {
                               "aria-describedby": "test-date-picker-help",
@@ -1407,6 +1501,8 @@ exports[`should render a default DatePickerField component 1`] = `
                           }
                           isIncomplete={false}
                           isInvalid={false}
+                          maxDate={"2017-01-01T00:00:00.000Z"}
+                          minDate={"2017-01-01T00:00:00.000Z"}
                           name="test-date-picker"
                           onBlur={[Function]}
                           onButtonFocus={[Function]}
@@ -1682,7 +1778,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                 </DateInputLayout>
                               </div>
                               <Button
-                                aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                aria-label=" Terra.datePicker.openCalendar"
                                 className="button"
                                 data-terra-open-calendar-button={true}
                                 icon={
@@ -1707,7 +1803,7 @@ exports[`should render a default DatePickerField component 1`] = `
                               >
                                 <button
                                   aria-disabled={false}
-                                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                  aria-label=" Terra.datePicker.openCalendar"
                                   className="button neutral compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={false}
@@ -2133,6 +2229,16 @@ exports[`should render a valid DatePickerField with props 1`] = `
                     <InjectIntl(DatePickerInput)
                       ariaLabel="Label Test"
                       buttonRefCallback={[Function]}
+                      excludeDates={
+                        Array [
+                          "2017-01-01T00:00:00.000Z",
+                        ]
+                      }
+                      includeDates={
+                        Array [
+                          "2017-01-01T00:00:00.000Z",
+                        ]
+                      }
                       inputAttributes={
                         Object {
                           "aria-describedby": "test-date-picker-help",
@@ -2141,6 +2247,8 @@ exports[`should render a valid DatePickerField with props 1`] = `
                       }
                       isIncomplete={false}
                       isInvalid={false}
+                      maxDate={"2017-01-01T00:00:00.000Z"}
+                      minDate={"2017-01-01T00:00:00.000Z"}
                       onButtonFocus={[Function]}
                       onCalendarButtonClick={[Function]}
                       required={true}
@@ -2191,6 +2299,16 @@ exports[`should render a valid DatePickerField with props 1`] = `
                       <InjectIntl(DatePickerInput)
                         ariaLabel="Label Test"
                         buttonRefCallback={[Function]}
+                        excludeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
+                        includeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         inputAttributes={
                           Object {
                             "aria-describedby": "test-date-picker-help",
@@ -2199,6 +2317,8 @@ exports[`should render a valid DatePickerField with props 1`] = `
                         }
                         isIncomplete={false}
                         isInvalid={false}
+                        maxDate={"2017-01-01T00:00:00.000Z"}
+                        minDate={"2017-01-01T00:00:00.000Z"}
                         onButtonFocus={[Function]}
                         onCalendarButtonClick={[Function]}
                         required={true}
@@ -2283,8 +2403,18 @@ exports[`should render a valid DatePickerField with props 1`] = `
                         buttonRefCallback={[Function]}
                         className=""
                         disabled={true}
+                        excludeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         firstInputRefCallback={[Function]}
                         id="test-date-picker"
+                        includeDates={
+                          Array [
+                            "2017-01-01T00:00:00.000Z",
+                          ]
+                        }
                         inputAttributes={
                           Object {
                             "aria-describedby": "test-date-picker-help",
@@ -2293,6 +2423,8 @@ exports[`should render a valid DatePickerField with props 1`] = `
                         }
                         isIncomplete={false}
                         isInvalid={false}
+                        maxDate={"2017-01-01T00:00:00.000Z"}
+                        minDate={"2017-01-01T00:00:00.000Z"}
                         name="test-date-picker"
                         onBlur={[Function]}
                         onButtonFocus={[Function]}
@@ -2311,8 +2443,18 @@ exports[`should render a valid DatePickerField with props 1`] = `
                           buttonRefCallback={[Function]}
                           className=""
                           disabled={true}
+                          excludeDates={
+                            Array [
+                              "2017-01-01T00:00:00.000Z",
+                            ]
+                          }
                           firstInputRefCallback={[Function]}
                           id="test-date-picker"
+                          includeDates={
+                            Array [
+                              "2017-01-01T00:00:00.000Z",
+                            ]
+                          }
                           inputAttributes={
                             Object {
                               "aria-describedby": "test-date-picker-help",
@@ -2348,6 +2490,8 @@ exports[`should render a valid DatePickerField with props 1`] = `
                           }
                           isIncomplete={false}
                           isInvalid={false}
+                          maxDate={"2017-01-01T00:00:00.000Z"}
+                          minDate={"2017-01-01T00:00:00.000Z"}
                           name="test-date-picker"
                           onBlur={[Function]}
                           onButtonFocus={[Function]}
@@ -2623,7 +2767,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                 </DateInputLayout>
                               </div>
                               <Button
-                                aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                aria-label=" Terra.datePicker.openCalendar"
                                 className="button"
                                 data-terra-open-calendar-button={true}
                                 icon={
@@ -2648,7 +2792,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                  aria-label=" Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -624,6 +624,19 @@ exports[`should render a DatePickerField with props 1`] = `
                                     test-date-picker
                                   </span>
                                 </VisuallyHiddenText>
+                                <VisuallyHiddenText
+                                  aria-atomic="true"
+                                  aria-live="assertive"
+                                  aria-relevant="all"
+                                  refCallback={[Function]}
+                                >
+                                  <span
+                                    aria-atomic="true"
+                                    aria-live="assertive"
+                                    aria-relevant="all"
+                                    className="visually-hidden-text"
+                                  />
+                                </VisuallyHiddenText>
                                 <DateInputLayout
                                   dateFormatOrder="MDY"
                                   day={
@@ -1442,6 +1455,19 @@ exports[`should render a default DatePickerField component 1`] = `
                                   >
                                     test-date-picker
                                   </span>
+                                </VisuallyHiddenText>
+                                <VisuallyHiddenText
+                                  aria-atomic="true"
+                                  aria-live="assertive"
+                                  aria-relevant="all"
+                                  refCallback={[Function]}
+                                >
+                                  <span
+                                    aria-atomic="true"
+                                    aria-live="assertive"
+                                    aria-relevant="all"
+                                    className="visually-hidden-text"
+                                  />
                                 </VisuallyHiddenText>
                                 <DateInputLayout
                                   dateFormatOrder="MDY"
@@ -2369,6 +2395,19 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   >
                                     test-date-picker
                                   </span>
+                                </VisuallyHiddenText>
+                                <VisuallyHiddenText
+                                  aria-atomic="true"
+                                  aria-live="assertive"
+                                  aria-relevant="all"
+                                  refCallback={[Function]}
+                                >
+                                  <span
+                                    aria-atomic="true"
+                                    aria-live="assertive"
+                                    aria-relevant="all"
+                                    className="visually-hidden-text"
+                                  />
                                 </VisuallyHiddenText>
                                 <DateInputLayout
                                   dateFormatOrder="MDY"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -360,6 +360,7 @@ exports[`should render a DatePickerField with props 1`] = `
                           "2017-01-01T00:00:00.000Z",
                         ]
                       }
+                      filterDate={[Function]}
                       includeDates={
                         Array [
                           "2017-01-01T00:00:00.000Z",
@@ -432,6 +433,7 @@ exports[`should render a DatePickerField with props 1`] = `
                             "2017-01-01T00:00:00.000Z",
                           ]
                         }
+                        filterDate={[Function]}
                         includeDates={
                           Array [
                             "2017-01-01T00:00:00.000Z",
@@ -538,6 +540,7 @@ exports[`should render a DatePickerField with props 1`] = `
                             "2017-01-01T00:00:00.000Z",
                           ]
                         }
+                        filterDate={[Function]}
                         firstInputRefCallback={[Function]}
                         id="test-date-picker"
                         includeDates={
@@ -578,6 +581,7 @@ exports[`should render a DatePickerField with props 1`] = `
                               "2017-01-01T00:00:00.000Z",
                             ]
                           }
+                          filterDate={[Function]}
                           firstInputRefCallback={[Function]}
                           id="test-date-picker"
                           includeDates={
@@ -1249,6 +1253,7 @@ exports[`should render a default DatePickerField component 1`] = `
                           "2017-01-01T00:00:00.000Z",
                         ]
                       }
+                      filterDate={[Function]}
                       includeDates={
                         Array [
                           "2017-01-01T00:00:00.000Z",
@@ -1318,6 +1323,7 @@ exports[`should render a default DatePickerField component 1`] = `
                             "2017-01-01T00:00:00.000Z",
                           ]
                         }
+                        filterDate={[Function]}
                         includeDates={
                           Array [
                             "2017-01-01T00:00:00.000Z",
@@ -1421,6 +1427,7 @@ exports[`should render a default DatePickerField component 1`] = `
                             "2017-01-01T00:00:00.000Z",
                           ]
                         }
+                        filterDate={[Function]}
                         firstInputRefCallback={[Function]}
                         id="test-date-picker"
                         includeDates={
@@ -1460,6 +1467,7 @@ exports[`should render a default DatePickerField component 1`] = `
                               "2017-01-01T00:00:00.000Z",
                             ]
                           }
+                          filterDate={[Function]}
                           firstInputRefCallback={[Function]}
                           id="test-date-picker"
                           includeDates={
@@ -2234,6 +2242,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                           "2017-01-01T00:00:00.000Z",
                         ]
                       }
+                      filterDate={[Function]}
                       includeDates={
                         Array [
                           "2017-01-01T00:00:00.000Z",
@@ -2304,6 +2313,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                             "2017-01-01T00:00:00.000Z",
                           ]
                         }
+                        filterDate={[Function]}
                         includeDates={
                           Array [
                             "2017-01-01T00:00:00.000Z",
@@ -2408,6 +2418,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                             "2017-01-01T00:00:00.000Z",
                           ]
                         }
+                        filterDate={[Function]}
                         firstInputRefCallback={[Function]}
                         id="test-date-picker"
                         includeDates={
@@ -2448,6 +2459,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                               "2017-01-01T00:00:00.000Z",
                             ]
                           }
+                          filterDate={[Function]}
                           firstInputRefCallback={[Function]}
                           id="test-date-picker"
                           includeDates={

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -854,13 +854,13 @@ exports[`should render a DatePickerField with props 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button is-invalid"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}
@@ -871,7 +871,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
                                   tabIndex="-1"
-                                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span
@@ -1673,13 +1673,13 @@ exports[`should render a default DatePickerField component 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
                                 <button
                                   aria-disabled={false}
-                                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                   className="button neutral compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={false}
@@ -1689,7 +1689,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                   onKeyDown={[Function]}
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
-                                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span
@@ -2600,13 +2600,13 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                  aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}
@@ -2617,7 +2617,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
                                   tabIndex="-1"
-                                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
+                                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -849,6 +849,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                 </DateInputLayout>
                               </div>
                               <Button
+                                aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                 className="button is-invalid"
                                 data-terra-open-calendar-button={true}
                                 icon={
@@ -867,7 +868,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                text="Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
@@ -884,7 +885,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
                                   tabIndex="-1"
-                                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                  title="Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span
@@ -1681,6 +1682,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                 </DateInputLayout>
                               </div>
                               <Button
+                                aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                 className="button"
                                 data-terra-open-calendar-button={true}
                                 icon={
@@ -1699,7 +1701,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                text="Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
@@ -1715,7 +1717,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                   onKeyDown={[Function]}
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
-                                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                  title="Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span
@@ -2621,6 +2623,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                 </DateInputLayout>
                               </div>
                               <Button
+                                aria-label="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
                                 className="button"
                                 data-terra-open-calendar-button={true}
                                 icon={
@@ -2639,7 +2642,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                text="Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
@@ -2656,7 +2659,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
                                   tabIndex="-1"
-                                  title="Sunday, January 1, 2017 Terra.datePicker.selected Terra.datePicker.openCalendar"
+                                  title="Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -854,13 +854,13 @@ exports[`should render a DatePickerField with props 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Terra.datePicker.openCalendar"
+                                text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Terra.datePicker.openCalendar"
+                                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button is-invalid"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}
@@ -871,7 +871,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
                                   tabIndex="-1"
-                                  title="Terra.datePicker.openCalendar"
+                                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span
@@ -1673,13 +1673,13 @@ exports[`should render a default DatePickerField component 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Terra.datePicker.openCalendar"
+                                text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
                                 <button
                                   aria-disabled={false}
-                                  aria-label="Terra.datePicker.openCalendar"
+                                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                   className="button neutral compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={false}
@@ -1689,7 +1689,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                   onKeyDown={[Function]}
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
-                                  title="Terra.datePicker.openCalendar"
+                                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span
@@ -2600,13 +2600,13 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
                                 refCallback={[Function]}
-                                text="Terra.datePicker.openCalendar"
+                                text="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                 type="button"
                                 variant="neutral"
                               >
                                 <button
                                   aria-disabled={true}
-                                  aria-label="Terra.datePicker.openCalendar"
+                                  aria-label="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                   className="button neutral is-disabled compact button"
                                   data-terra-open-calendar-button={true}
                                   disabled={true}
@@ -2617,7 +2617,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   onKeyUp={[Function]}
                                   onMouseDown={[Function]}
                                   tabIndex="-1"
-                                  title="Terra.datePicker.openCalendar"
+                                  title="Sunday, January 1, 2017 is selected Terra.datePicker.openCalendar"
                                   type="button"
                                 >
                                   <span

--- a/packages/terra-date-picker/tests/wdio/date-picker-spec.js
+++ b/packages/terra-date-picker/tests/wdio/date-picker-spec.js
@@ -1200,3 +1200,20 @@ Terra.describeViewports('Date Picker', ['tiny', 'small'], () => {
     });
   });
 });
+
+Terra.describeViewports('Date Picker', ['tiny', 'small', 'medium'], () => {
+  describe('Default', () => {
+    it('sets default label to calendar button when no date is entered', () => {
+      browser.url('/raw/tests/cerner-terra-framework-docs/date-picker/date-picker-default');
+
+      expect($('[class*="button"]').getAttribute('aria-label')).toEqual(' Open Calendar');
+    });
+
+    it('sets the valid date to calendar button label ', () => {
+      $('input[name="terra-date-month-date-input"]').setValue('01');
+      $('input[name="terra-date-day-date-input"]').setValue('01');
+      $('input[name="terra-date-year-date-input"]').setValue('2017');
+      expect($('[class*="button"]').getAttribute('aria-label')).toEqual('Sunday, January 1, 2017 selected. Open Calendar');
+    });
+  });
+});

--- a/packages/terra-date-picker/translations/de.json
+++ b/packages/terra-date-picker/translations/de.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Nächster Monat",
   "Terra.datePicker.previousMonth": "Letzter Monat",
   "Terra.datePicker.calendarInstructions": "Verwenden Sie die Pfeiltasten, um die Auswahl zu ändern. Drücken Sie die Eingabetaste, um ein Datum zu wählen. Drücken Sie die Esc-Taste, um die Datumsauswahl zu schließen.",
-  "Terra.datePicker.dateFormatLabel": "Datumsformat:"
+  "Terra.datePicker.dateFormatLabel": "Datumsformat:",
+  "Terra.datePicker.selected": "Ausgewählt"
 }

--- a/packages/terra-date-picker/translations/de.json
+++ b/packages/terra-date-picker/translations/de.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Letzter Monat",
   "Terra.datePicker.calendarInstructions": "Verwenden Sie die Pfeiltasten, um die Auswahl zu ändern. Drücken Sie die Eingabetaste, um ein Datum zu wählen. Drücken Sie die Esc-Taste, um die Datumsauswahl zu schließen.",
   "Terra.datePicker.dateFormatLabel": "Datumsformat:",
-  "Terra.datePicker.selected": "Ausgewählt"
+  "Terra.datePicker.selected": "Ausgewählt."
 }

--- a/packages/terra-date-picker/translations/de.json
+++ b/packages/terra-date-picker/translations/de.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Letzter Monat",
   "Terra.datePicker.calendarInstructions": "Verwenden Sie die Pfeiltasten, um die Auswahl zu ändern. Drücken Sie die Eingabetaste, um ein Datum zu wählen. Drücken Sie die Esc-Taste, um die Datumsauswahl zu schließen.",
   "Terra.datePicker.dateFormatLabel": "Datumsformat:",
-  "Terra.datePicker.selected": "Ausgewählt."
+  "Terra.datePicker.selected": "Ausgewählt.",
+  "Terra.datePicker.invalidDate": "Geben Sie ein gültiges Datum ein."
 }

--- a/packages/terra-date-picker/translations/en-AU.json
+++ b/packages/terra-date-picker/translations/en-AU.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Next month",
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
-  "Terra.datePicker.dateFormatLabel": "Date Format:"
+  "Terra.datePicker.dateFormatLabel": "Date Format:",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date"
 }

--- a/packages/terra-date-picker/translations/en-AU.json
+++ b/packages/terra-date-picker/translations/en-AU.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-AU.json
+++ b/packages/terra-date-picker/translations/en-AU.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
   "Terra.datePicker.invalidDate": "Please enter a valid Date",
-  "Terra.datePicker.selected": "selected"
+  "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-AU.json
+++ b/packages/terra-date-picker/translations/en-AU.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date"
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.selected": "selected"
 }

--- a/packages/terra-date-picker/translations/en-AU.json
+++ b/packages/terra-date-picker/translations/en-AU.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-CA.json
+++ b/packages/terra-date-picker/translations/en-CA.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Next month",
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
-  "Terra.datePicker.dateFormatLabel": "Date Format:"
+  "Terra.datePicker.dateFormatLabel": "Date Format:",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date"
 }

--- a/packages/terra-date-picker/translations/en-CA.json
+++ b/packages/terra-date-picker/translations/en-CA.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-CA.json
+++ b/packages/terra-date-picker/translations/en-CA.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
   "Terra.datePicker.invalidDate": "Please enter a valid Date",
-  "Terra.datePicker.selected": "selected"
+  "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-CA.json
+++ b/packages/terra-date-picker/translations/en-CA.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date"
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.selected": "selected"
 }

--- a/packages/terra-date-picker/translations/en-CA.json
+++ b/packages/terra-date-picker/translations/en-CA.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-GB.json
+++ b/packages/terra-date-picker/translations/en-GB.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Next month",
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
-  "Terra.datePicker.dateFormatLabel": "Date Format:"
+  "Terra.datePicker.dateFormatLabel": "Date Format:",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date"
 }

--- a/packages/terra-date-picker/translations/en-GB.json
+++ b/packages/terra-date-picker/translations/en-GB.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-GB.json
+++ b/packages/terra-date-picker/translations/en-GB.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
   "Terra.datePicker.invalidDate": "Please enter a valid Date",
-  "Terra.datePicker.selected": "selected"
+  "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-GB.json
+++ b/packages/terra-date-picker/translations/en-GB.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date"
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.selected": "selected"
 }

--- a/packages/terra-date-picker/translations/en-GB.json
+++ b/packages/terra-date-picker/translations/en-GB.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-US.json
+++ b/packages/terra-date-picker/translations/en-US.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Next month",
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
-  "Terra.datePicker.dateFormatLabel": "Date Format:"
+  "Terra.datePicker.dateFormatLabel": "Date Format:",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date"
 }

--- a/packages/terra-date-picker/translations/en-US.json
+++ b/packages/terra-date-picker/translations/en-US.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-US.json
+++ b/packages/terra-date-picker/translations/en-US.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
   "Terra.datePicker.invalidDate": "Please enter a valid Date",
-  "Terra.datePicker.selected": "selected"
+  "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en-US.json
+++ b/packages/terra-date-picker/translations/en-US.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date"
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.selected": "selected"
 }

--- a/packages/terra-date-picker/translations/en-US.json
+++ b/packages/terra-date-picker/translations/en-US.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en.json
+++ b/packages/terra-date-picker/translations/en.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Next month",
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
-  "Terra.datePicker.dateFormatLabel": "Date Format:"
+  "Terra.datePicker.dateFormatLabel": "Date Format:",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date"
 }

--- a/packages/terra-date-picker/translations/en.json
+++ b/packages/terra-date-picker/translations/en.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en.json
+++ b/packages/terra-date-picker/translations/en.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
   "Terra.datePicker.invalidDate": "Please enter a valid Date",
-  "Terra.datePicker.selected": "selected"
+  "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/en.json
+++ b/packages/terra-date-picker/translations/en.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date"
+  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.selected": "selected"
 }

--- a/packages/terra-date-picker/translations/en.json
+++ b/packages/terra-date-picker/translations/en.json
@@ -12,6 +12,6 @@
   "Terra.datePicker.previousMonth": "Previous month",
   "Terra.datePicker.calendarInstructions": "To change the selection, use the arrow keys. Press Enter to select a date. Press Escape to close the date picker pop-up.",
   "Terra.datePicker.dateFormatLabel": "Date Format:",
-  "Terra.datePicker.invalidDate": "Please enter a valid Date",
+  "Terra.datePicker.invalidDate": "Please enter a valid Date.",
   "Terra.datePicker.selected": "selected."
 }

--- a/packages/terra-date-picker/translations/es-ES.json
+++ b/packages/terra-date-picker/translations/es-ES.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
   "Terra.datePicker.selected": "seleccionado.",
-  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida."
 }

--- a/packages/terra-date-picker/translations/es-ES.json
+++ b/packages/terra-date-picker/translations/es-ES.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
   "Terra.datePicker.selected": "seleccionado.",
-  "Terra.datePicker.invalidDate": "Escriba una fecha válida."
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
 }

--- a/packages/terra-date-picker/translations/es-ES.json
+++ b/packages/terra-date-picker/translations/es-ES.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
-  "Terra.datePicker.selected": "seleccionado"
+  "Terra.datePicker.selected": "seleccionado."
 }

--- a/packages/terra-date-picker/translations/es-ES.json
+++ b/packages/terra-date-picker/translations/es-ES.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mes siguiente",
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
-  "Terra.datePicker.dateFormatLabel": "Formato de fecha:"
+  "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
+  "Terra.datePicker.selected": "seleccionado"
 }

--- a/packages/terra-date-picker/translations/es-ES.json
+++ b/packages/terra-date-picker/translations/es-ES.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
-  "Terra.datePicker.selected": "seleccionado."
+  "Terra.datePicker.selected": "seleccionado.",
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
 }

--- a/packages/terra-date-picker/translations/es-US.json
+++ b/packages/terra-date-picker/translations/es-US.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
   "Terra.datePicker.selected": "seleccionado.",
-  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida."
 }

--- a/packages/terra-date-picker/translations/es-US.json
+++ b/packages/terra-date-picker/translations/es-US.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
   "Terra.datePicker.selected": "seleccionado.",
-  "Terra.datePicker.invalidDate": "Escriba una fecha válida."
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
 }

--- a/packages/terra-date-picker/translations/es-US.json
+++ b/packages/terra-date-picker/translations/es-US.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
-  "Terra.datePicker.selected": "seleccionado"
+  "Terra.datePicker.selected": "seleccionado."
 }

--- a/packages/terra-date-picker/translations/es-US.json
+++ b/packages/terra-date-picker/translations/es-US.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mes siguiente",
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
-  "Terra.datePicker.dateFormatLabel": "Formato de fecha:"
+  "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
+  "Terra.datePicker.selected": "seleccionado"
 }

--- a/packages/terra-date-picker/translations/es-US.json
+++ b/packages/terra-date-picker/translations/es-US.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
-  "Terra.datePicker.selected": "seleccionado."
+  "Terra.datePicker.selected": "seleccionado.",
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
 }

--- a/packages/terra-date-picker/translations/es.json
+++ b/packages/terra-date-picker/translations/es.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
   "Terra.datePicker.selected": "seleccionado.",
-  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida."
 }

--- a/packages/terra-date-picker/translations/es.json
+++ b/packages/terra-date-picker/translations/es.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
   "Terra.datePicker.selected": "seleccionado.",
-  "Terra.datePicker.invalidDate": "Escriba una fecha válida."
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
 }

--- a/packages/terra-date-picker/translations/es.json
+++ b/packages/terra-date-picker/translations/es.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
-  "Terra.datePicker.selected": "seleccionado"
+  "Terra.datePicker.selected": "seleccionado."
 }

--- a/packages/terra-date-picker/translations/es.json
+++ b/packages/terra-date-picker/translations/es.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mes siguiente",
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
-  "Terra.datePicker.dateFormatLabel": "Formato de fecha:"
+  "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
+  "Terra.datePicker.selected": "seleccionado"
 }

--- a/packages/terra-date-picker/translations/es.json
+++ b/packages/terra-date-picker/translations/es.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mes anterior",
   "Terra.datePicker.calendarInstructions": "Para cambiar la selección, use las teclas de flecha. Presione Entrar para seleccionar una fecha. Presione Esc para cerrar el selector de fecha.",
   "Terra.datePicker.dateFormatLabel": "Formato de fecha:",
-  "Terra.datePicker.selected": "seleccionado."
+  "Terra.datePicker.selected": "seleccionado.",
+  "Terra.datePicker.invalidDate": "Escriba una fecha válida"
 }

--- a/packages/terra-date-picker/translations/fr-FR.json
+++ b/packages/terra-date-picker/translations/fr-FR.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mois précédent",
   "Terra.datePicker.calendarInstructions": "Pour modifier la sélection, utilisez les touches fléchées. Appuyez sur la touche Entrée pour sélectionner une date. Appuyez sur la touche Échap pour fermer la fenêtre contextuelle du sélecteur de dates.",
   "Terra.datePicker.dateFormatLabel": "Format de date:",
-  "Terra.datePicker.selected": "sélectionné"
+  "Terra.datePicker.selected": "sélectionné."
 }

--- a/packages/terra-date-picker/translations/fr-FR.json
+++ b/packages/terra-date-picker/translations/fr-FR.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mois suivant",
   "Terra.datePicker.previousMonth": "Mois précédent",
   "Terra.datePicker.calendarInstructions": "Pour modifier la sélection, utilisez les touches fléchées. Appuyez sur la touche Entrée pour sélectionner une date. Appuyez sur la touche Échap pour fermer la fenêtre contextuelle du sélecteur de dates.",
-  "Terra.datePicker.dateFormatLabel": "Format de date:"
+  "Terra.datePicker.dateFormatLabel": "Format de date:",
+  "Terra.datePicker.selected": "sélectionné"
 }

--- a/packages/terra-date-picker/translations/fr-FR.json
+++ b/packages/terra-date-picker/translations/fr-FR.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mois précédent",
   "Terra.datePicker.calendarInstructions": "Pour modifier la sélection, utilisez les touches fléchées. Appuyez sur la touche Entrée pour sélectionner une date. Appuyez sur la touche Échap pour fermer la fenêtre contextuelle du sélecteur de dates.",
   "Terra.datePicker.dateFormatLabel": "Format de date:",
-  "Terra.datePicker.selected": "sélectionné."
+  "Terra.datePicker.selected": "sélectionné.",
+  "Terra.datePicker.invalidDate": "Saisissez une date valide."
 }

--- a/packages/terra-date-picker/translations/fr.json
+++ b/packages/terra-date-picker/translations/fr.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mois précédent",
   "Terra.datePicker.calendarInstructions": "Pour modifier la sélection, utilisez les touches fléchées. Appuyez sur la touche Entrée pour sélectionner une date. Appuyez sur la touche Échap pour fermer la fenêtre contextuelle du sélecteur de dates.",
   "Terra.datePicker.dateFormatLabel": "Format de date:",
-  "Terra.datePicker.selected": "sélectionné"
+  "Terra.datePicker.selected": "sélectionné."
 }

--- a/packages/terra-date-picker/translations/fr.json
+++ b/packages/terra-date-picker/translations/fr.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mois suivant",
   "Terra.datePicker.previousMonth": "Mois précédent",
   "Terra.datePicker.calendarInstructions": "Pour modifier la sélection, utilisez les touches fléchées. Appuyez sur la touche Entrée pour sélectionner une date. Appuyez sur la touche Échap pour fermer la fenêtre contextuelle du sélecteur de dates.",
-  "Terra.datePicker.dateFormatLabel": "Format de date:"
+  "Terra.datePicker.dateFormatLabel": "Format de date:",
+  "Terra.datePicker.selected": "sélectionné"
 }

--- a/packages/terra-date-picker/translations/fr.json
+++ b/packages/terra-date-picker/translations/fr.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mois précédent",
   "Terra.datePicker.calendarInstructions": "Pour modifier la sélection, utilisez les touches fléchées. Appuyez sur la touche Entrée pour sélectionner une date. Appuyez sur la touche Échap pour fermer la fenêtre contextuelle du sélecteur de dates.",
   "Terra.datePicker.dateFormatLabel": "Format de date:",
-  "Terra.datePicker.selected": "sélectionné."
+  "Terra.datePicker.selected": "sélectionné.",
+  "Terra.datePicker.invalidDate": "Saisissez une date valide."
 }

--- a/packages/terra-date-picker/translations/nl-BE.json
+++ b/packages/terra-date-picker/translations/nl-BE.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
   "Terra.datePicker.selected": "geselecteerd.",
-  "Terra.datePicker.invalidDate": "Voer een geldige datum in"
+  "Terra.datePicker.invalidDate": "Voer een geldige datum in."
 }

--- a/packages/terra-date-picker/translations/nl-BE.json
+++ b/packages/terra-date-picker/translations/nl-BE.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Vorige maand",
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
-  "Terra.datePicker.selected": "geselecteerd"
+  "Terra.datePicker.selected": "geselecteerd."
 }

--- a/packages/terra-date-picker/translations/nl-BE.json
+++ b/packages/terra-date-picker/translations/nl-BE.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Vorige maand",
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
-  "Terra.datePicker.selected": "geselecteerd."
+  "Terra.datePicker.selected": "geselecteerd.",
+  "Terra.datePicker.invalidDate": "Voer een geldige datum in"
 }

--- a/packages/terra-date-picker/translations/nl-BE.json
+++ b/packages/terra-date-picker/translations/nl-BE.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Volgende maand",
   "Terra.datePicker.previousMonth": "Vorige maand",
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
-  "Terra.datePicker.dateFormatLabel": "Datumnotatie:"
+  "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
+  "Terra.datePicker.selected": "geselecteerd"
 }

--- a/packages/terra-date-picker/translations/nl-BE.json
+++ b/packages/terra-date-picker/translations/nl-BE.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
   "Terra.datePicker.selected": "geselecteerd.",
-  "Terra.datePicker.invalidDate": "Voer een geldige datum in."
+  "Terra.datePicker.invalidDate": "Voer een geldige datum in"
 }

--- a/packages/terra-date-picker/translations/nl.json
+++ b/packages/terra-date-picker/translations/nl.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
   "Terra.datePicker.selected": "geselecteerd.",
-  "Terra.datePicker.invalidDate": "Voer een geldige datum in"
+  "Terra.datePicker.invalidDate": "Voer een geldige datum in."
 }

--- a/packages/terra-date-picker/translations/nl.json
+++ b/packages/terra-date-picker/translations/nl.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Vorige maand",
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
-  "Terra.datePicker.selected": "geselecteerd"
+  "Terra.datePicker.selected": "geselecteerd."
 }

--- a/packages/terra-date-picker/translations/nl.json
+++ b/packages/terra-date-picker/translations/nl.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Vorige maand",
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
-  "Terra.datePicker.selected": "geselecteerd."
+  "Terra.datePicker.selected": "geselecteerd.",
+  "Terra.datePicker.invalidDate": "Voer een geldige datum in"
 }

--- a/packages/terra-date-picker/translations/nl.json
+++ b/packages/terra-date-picker/translations/nl.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Volgende maand",
   "Terra.datePicker.previousMonth": "Vorige maand",
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
-  "Terra.datePicker.dateFormatLabel": "Datumnotatie:"
+  "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
+  "Terra.datePicker.selected": "geselecteerd"
 }

--- a/packages/terra-date-picker/translations/nl.json
+++ b/packages/terra-date-picker/translations/nl.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Gebruik de pijltoetsen om de selectie te wijzigen. Druk op Enter om een datum te selecteren. Druk op Esc om de datumkiezer te sluiten.",
   "Terra.datePicker.dateFormatLabel": "Datumnotatie:",
   "Terra.datePicker.selected": "geselecteerd.",
-  "Terra.datePicker.invalidDate": "Voer een geldige datum in."
+  "Terra.datePicker.invalidDate": "Voer een geldige datum in"
 }

--- a/packages/terra-date-picker/translations/pt-BR.json
+++ b/packages/terra-date-picker/translations/pt-BR.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
   "Terra.datePicker.selected": "selecionado.",
-  "Terra.datePicker.invalidDate": "Insira uma Data válida."
+  "Terra.datePicker.invalidDate": "Insira uma Data válida"
 }

--- a/packages/terra-date-picker/translations/pt-BR.json
+++ b/packages/terra-date-picker/translations/pt-BR.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
   "Terra.datePicker.selected": "selecionado.",
-  "Terra.datePicker.invalidDate": "Insira uma Data válida"
+  "Terra.datePicker.invalidDate": "Insira uma Data válida."
 }

--- a/packages/terra-date-picker/translations/pt-BR.json
+++ b/packages/terra-date-picker/translations/pt-BR.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mês anterior",
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
-  "Terra.datePicker.selected": "selecionado."
+  "Terra.datePicker.selected": "selecionado.",
+  "Terra.datePicker.invalidDate": "Insira uma Data válida"
 }

--- a/packages/terra-date-picker/translations/pt-BR.json
+++ b/packages/terra-date-picker/translations/pt-BR.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mês anterior",
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
-  "Terra.datePicker.selected": "selecionado"
+  "Terra.datePicker.selected": "selecionado."
 }

--- a/packages/terra-date-picker/translations/pt-BR.json
+++ b/packages/terra-date-picker/translations/pt-BR.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mês seguinte",
   "Terra.datePicker.previousMonth": "Mês anterior",
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
-  "Terra.datePicker.dateFormatLabel": "Formato da data:"
+  "Terra.datePicker.dateFormatLabel": "Formato da data:",
+  "Terra.datePicker.selected": "selecionado"
 }

--- a/packages/terra-date-picker/translations/pt.json
+++ b/packages/terra-date-picker/translations/pt.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
   "Terra.datePicker.selected": "selecionado.",
-  "Terra.datePicker.invalidDate": "Insira uma Data válida."
+  "Terra.datePicker.invalidDate": "Insira uma Data válida"
 }

--- a/packages/terra-date-picker/translations/pt.json
+++ b/packages/terra-date-picker/translations/pt.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
   "Terra.datePicker.selected": "selecionado.",
-  "Terra.datePicker.invalidDate": "Insira uma Data válida"
+  "Terra.datePicker.invalidDate": "Insira uma Data válida."
 }

--- a/packages/terra-date-picker/translations/pt.json
+++ b/packages/terra-date-picker/translations/pt.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Mês anterior",
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
-  "Terra.datePicker.selected": "selecionado."
+  "Terra.datePicker.selected": "selecionado.",
+  "Terra.datePicker.invalidDate": "Insira uma Data válida"
 }

--- a/packages/terra-date-picker/translations/pt.json
+++ b/packages/terra-date-picker/translations/pt.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Mês anterior",
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
   "Terra.datePicker.dateFormatLabel": "Formato da data:",
-  "Terra.datePicker.selected": "selecionado"
+  "Terra.datePicker.selected": "selecionado."
 }

--- a/packages/terra-date-picker/translations/pt.json
+++ b/packages/terra-date-picker/translations/pt.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Mês seguinte",
   "Terra.datePicker.previousMonth": "Mês anterior",
   "Terra.datePicker.calendarInstructions": "Para alterar a seleção, use as teclas de seta. Pressione Enter para selecionar uma data. Pressione Esc para fechar o pop-up do seletor de datas.",
-  "Terra.datePicker.dateFormatLabel": "Formato da data:"
+  "Terra.datePicker.dateFormatLabel": "Formato da data:",
+  "Terra.datePicker.selected": "selecionado"
 }

--- a/packages/terra-date-picker/translations/sv-SE.json
+++ b/packages/terra-date-picker/translations/sv-SE.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Föregående månad",
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
-  "Terra.datePicker.selected": "valt"
+  "Terra.datePicker.selected": "valt."
 }

--- a/packages/terra-date-picker/translations/sv-SE.json
+++ b/packages/terra-date-picker/translations/sv-SE.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
   "Terra.datePicker.selected": "valt.",
-  "Terra.datePicker.invalidDate": "Ange ett giltigt datum."
+  "Terra.datePicker.invalidDate": "Ange ett giltigt datum"
 }

--- a/packages/terra-date-picker/translations/sv-SE.json
+++ b/packages/terra-date-picker/translations/sv-SE.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Nästa månad",
   "Terra.datePicker.previousMonth": "Föregående månad",
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
-  "Terra.datePicker.dateFormatLabel": "Datumformat:"
+  "Terra.datePicker.dateFormatLabel": "Datumformat:",
+  "Terra.datePicker.selected": "valt"
 }

--- a/packages/terra-date-picker/translations/sv-SE.json
+++ b/packages/terra-date-picker/translations/sv-SE.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
   "Terra.datePicker.selected": "valt.",
-  "Terra.datePicker.invalidDate": "Ange ett giltigt datum"
+  "Terra.datePicker.invalidDate": "Ange ett giltigt datum."
 }

--- a/packages/terra-date-picker/translations/sv-SE.json
+++ b/packages/terra-date-picker/translations/sv-SE.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Föregående månad",
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
-  "Terra.datePicker.selected": "valt."
+  "Terra.datePicker.selected": "valt.",
+  "Terra.datePicker.invalidDate": "Ange ett giltigt datum"
 }

--- a/packages/terra-date-picker/translations/sv.json
+++ b/packages/terra-date-picker/translations/sv.json
@@ -12,5 +12,5 @@
   "Terra.datePicker.previousMonth": "Föregående månad",
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
-  "Terra.datePicker.selected": "valt"
+  "Terra.datePicker.selected": "valt."
 }

--- a/packages/terra-date-picker/translations/sv.json
+++ b/packages/terra-date-picker/translations/sv.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
   "Terra.datePicker.selected": "valt.",
-  "Terra.datePicker.invalidDate": "Ange ett giltigt datum."
+  "Terra.datePicker.invalidDate": "Ange ett giltigt datum"
 }

--- a/packages/terra-date-picker/translations/sv.json
+++ b/packages/terra-date-picker/translations/sv.json
@@ -11,5 +11,6 @@
   "Terra.datePicker.nextMonth": "Nästa månad",
   "Terra.datePicker.previousMonth": "Föregående månad",
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
-  "Terra.datePicker.dateFormatLabel": "Datumformat:"
+  "Terra.datePicker.dateFormatLabel": "Datumformat:",
+  "Terra.datePicker.selected": "valt"
 }

--- a/packages/terra-date-picker/translations/sv.json
+++ b/packages/terra-date-picker/translations/sv.json
@@ -13,5 +13,5 @@
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
   "Terra.datePicker.selected": "valt.",
-  "Terra.datePicker.invalidDate": "Ange ett giltigt datum"
+  "Terra.datePicker.invalidDate": "Ange ett giltigt datum."
 }

--- a/packages/terra-date-picker/translations/sv.json
+++ b/packages/terra-date-picker/translations/sv.json
@@ -12,5 +12,6 @@
   "Terra.datePicker.previousMonth": "Föregående månad",
   "Terra.datePicker.calendarInstructions": "Använd piltangenterna för att ändra urval. Tryck Enter för att välja ett datum. Tryck Escape för att stänga Datumväljaren.",
   "Terra.datePicker.dateFormatLabel": "Datumformat:",
-  "Terra.datePicker.selected": "valt."
+  "Terra.datePicker.selected": "valt.",
+  "Terra.datePicker.invalidDate": "Ange ett giltigt datum"
 }

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated
+  * Updated example for `terra-date-picker` with isInvalid prop and error message.
+
 ## 1.35.0 - (September 14, 2023)
 
 * Added

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/date-picker/example/DatePickerField.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/date-picker/example/DatePickerField.jsx
@@ -7,14 +7,17 @@ const cx = classNames.bind(styles);
 
 const DatePickerFieldExample = () => {
   const [date, setDate] = useState('');
+  const [invalid, setInValid] = useState(false);
 
   const handleDateChange = (event, dateValue) => {
     setDate(dateValue);
+    setInValid(false);
   };
 
   const handleDateChangeRaw = (event, dateValue, metadata) => {
-    if (!metadata.isValidValue) {
+    if (!metadata.isValidValue && metadata.inputValue.length === 10) {
       setDate(null);
+      setInValid(true);
     }
   };
 
@@ -30,6 +33,8 @@ const DatePickerFieldExample = () => {
         datePickerId="default-field"
         onChange={handleDateChange}
         onChangeRaw={handleDateChangeRaw}
+        isInvalid={invalid}
+        error={<p>Enter valid date</p>}
       />
     </div>
   );


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

- Updated screen reader response to announce when invalid dates are entered.
- Updated screen reader response to announce when calendar popup dates are selected.
- Updated example for invalid date entry.


**Why it was changed:**

- Screen reader currently does not provide context when non-number inputs OR invalid dates are entered in Date Picker fields.
- Screen reader fails to announce the selected date under calendar popup. 


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9479 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
