### PR TITLE
Fix for Active Key Indicator.

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Changed
   * Updated examples and tests for `terra-worklist-data-grid` to properly update row selection data.
   * Migrated `terra-worklist-data-grid` docs/tests to new `terra-data-grid`.
+  * Updated add tabs examples to be controlled tabs.
 
 * Updated
   * Updated example for `terra-date-picker` with isInvalid prop.

--- a/packages/terra-framework-docs/package.json
+++ b/packages/terra-framework-docs/package.json
@@ -52,6 +52,7 @@
     "terra-file-path": "^0.1.0",
     "terra-form-input": "^4.4.0",
     "terra-form-select": "^6.8.0",
+    "terra-form-radio": "^4.12.0",
     "terra-grid": "^6.0.0",
     "terra-hookshot": "^5.41.0",
     "terra-infinite-list": "^3.42.0",

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/AddCloseTab.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/AddCloseTab.jsx
@@ -92,9 +92,15 @@ const AddCloseTab = () => {
     setTabs(tabsArray);
   };
 
+  const handleSelection = (event, selectedKey) => {
+    if (selectedKey !== activeKey) {
+      setActiveKey(selectedKey);
+    }
+  };
+
   return (
     <div className={cx('content-wrapper')}>
-      <Tabs activeKey={activeKey} setFocusOnContent isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
+      <Tabs onChange={handleSelection} activeKey={activeKey} setFocusOnContent isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
         { tabs.map((tab) => (
           <Tabs.Pane label={tab.label} isIconOnly={tab.isIconOnly} customDisplay={tab.customDisplay} isDisabled={tab.isDisabled} icon={tab.icon} key={tab.key} id={tab.key}>
             <TabContentTemplate label={tab.content} />

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/AddCloseTabInteractive.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/AddCloseTabInteractive.jsx
@@ -128,9 +128,15 @@ const AddCloseTabInteractive = () => {
     setTabs(tabsArray);
   };
 
+  const handleSelection = (event, selectedKey) => {
+    if (selectedKey !== activeKey) {
+      setActiveKey(selectedKey);
+    }
+  };
+
   return (
     <div className={cx('content-wrapper')}>
-      <Tabs activeKey={activeKey} isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
+      <Tabs onChange={handleSelection} activeKey={activeKey} isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
         { tabs.map((tab) => (
           <Tabs.Pane label={tab.label} isIconOnly={tab.isIconOnly} customDisplay={tab.customDisplay} isDisabled={tab.isDisabled} icon={tab.icon} key={tab.key} id={tab.key}>
             <TabContentTemplate label={tab.content}>

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/AddTab.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/tabs/example/AddTab.jsx
@@ -82,9 +82,15 @@ const AddTab = () => {
     setTabs(tabsArray);
   };
 
+  const handleSelection = (event, selectedKey) => {
+    if (selectedKey !== activeKey) {
+      setActiveKey(selectedKey);
+    }
+  };
+
   return (
     <div className={cx('content-wrapper')}>
-      <Tabs isDraggable setFocusOnContent activeKey={activeKey} onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab">
+      <Tabs onChange={handleSelection} isDraggable setFocusOnContent activeKey={activeKey} onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab">
         { tabs.map((tab) => (
           <Tabs.Pane label={tab.label} isIconOnly={tab.isIconOnly} customDisplay={tab.customDisplay} isDisabled={tab.isDisabled} icon={tab.icon} key={tab.key} id={tab.key}>
             <TabContentTemplate label={tab.content} />

--- a/packages/terra-framework-docs/src/terra-dev-site/test/tabs/Tabs/AddCloseInteractiveTab.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/tabs/Tabs/AddCloseInteractiveTab.test.jsx
@@ -123,9 +123,15 @@ function AddCloseTabInteractive() {
     setTabs(tabsArray);
   };
 
+  const handleSelection = (event, selectedKey) => {
+    if (selectedKey !== activeKey) {
+      setActiveKey(selectedKey);
+    }
+  };
+
   return (
     <div className={cx('content-wrapper-default')} id="tabs-container">
-      <Tabs activeKey={activeKey} isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
+      <Tabs onChange={handleSelection} activeKey={activeKey} isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
         { tabs.map((tab) => (
           <Tabs.Pane label={tab.label} isIconOnly={tab.isIconOnly} customDisplay={tab.customDisplay} isDisabled={tab.isDisabled} icon={tab.icon} key={tab.key} id={tab.key}>
             <TabContentTemplate label={tab.content}>

--- a/packages/terra-framework-docs/src/terra-dev-site/test/tabs/Tabs/AddCloseTab.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/tabs/Tabs/AddCloseTab.test.jsx
@@ -91,9 +91,15 @@ function AddTabandCloseTab() {
     setTabs(tabsArray);
   };
 
+  const handleSelection = (event, selectedKey) => {
+    if (selectedKey !== activeKey) {
+      setActiveKey(selectedKey);
+    }
+  };
+
   return (
     <div className={cx('content-wrapper-default')} id="tabs-container">
-      <Tabs setFocusOnContent activeKey={activeKey} isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
+      <Tabs onChange={handleSelection} setFocusOnContent activeKey={activeKey} isClosable onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab" onTabClose={handleTabClose}>
         { tabs.map((tab) => (
           <Tabs.Pane label={tab.label} isIconOnly={tab.isIconOnly} customDisplay={tab.customDisplay} isDisabled={tab.isDisabled} icon={tab.icon} key={tab.key} id={tab.key}>
             <TabContentTemplate label={tab.content} />

--- a/packages/terra-framework-docs/src/terra-dev-site/test/tabs/Tabs/AddNewTabs.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/tabs/Tabs/AddNewTabs.test.jsx
@@ -83,9 +83,15 @@ const AddNewTabs = () => {
     setTabs(tabsArray);
   };
 
+  const handleSelection = (event, selectedKey) => {
+    if (selectedKey !== activeKey) {
+      setActiveKey(selectedKey);
+    }
+  };
+
   return (
     <div className={cx('content-wrapper-default')} id="tabs-container">
-      <Tabs setFocusOnContent activeKey={activeKey} onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab">
+      <Tabs onChange={handleSelection} setFocusOnContent activeKey={activeKey} onSelectAddButton={addMoreTabPanes} ariaLabelAddTab="Add Tab">
         { tabs.map((tab) => (
           <Tabs.Pane label={tab.label} isIconOnly={tab.isIconOnly} customDisplay={tab.customDisplay} isDisabled={tab.isDisabled} icon={tab.icon} key={tab.key} id={tab.key}>
             <TabContentTemplate label={tab.content} />

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 * Added
   * Added prop to support the focus traverse within the tab content.
-  * Fix for Active Key Style issue.
+
+* Fixed
+  * Fixed Active Key Style issue.
 
 ## 7.6.0 - (September 5, 2023)
 

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Added prop to support the focus traverse within the tab content.
 
 * Fixed
-  * Fixed Active Key Style issue.
+  * Fixed tab active indicator issue.
 
 ## 7.6.0 - (September 5, 2023)
 

--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added
   * Added prop to support the focus traverse within the tab content.
+  * Fix for Active Key Style issue.
 
 ## 7.6.0 - (September 5, 2023)
 

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -137,16 +137,9 @@ class Tabs extends React.Component {
     } = this.props;
 
     const commonTabItems = [];
-    const tabKeys = [];
 
-    if (this.props.children && this.props.children.length > 0) {
-      this.props.children.forEach(child => {
-        tabKeys.push(child.key);
-      });
-    }
-
-    const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
-    const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
+    const foundActiveTabKey = React.Children.toArray(this.props.children).filter(child => child.key === this.props.activeKey);
+    const activeTabKey = (foundActiveTabKey) ? foundActiveTabKey.key : this.state.activeKey;
 
     React.Children.forEach(children, child => {
       let content;

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -144,8 +144,8 @@ class Tabs extends React.Component {
         tabKeys.push(child.key);
       });
     }
-    const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
-    const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
+    const foundActiveTabKey = React.Children.toArray(children).filter(child => child.key === this.props.activeKey);
+    const activeTabKey = (foundActiveTabKey) ? foundActiveTabKey.key : this.state.activeKey;
 
     React.Children.forEach(children, child => {
       let content;

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -137,7 +137,13 @@ class Tabs extends React.Component {
     } = this.props;
 
     const commonTabItems = [];
-    const activeTabKey = this.state.activeKey || this.props.activeKey;
+    const tabKeys = [];
+
+    this.props.children.forEach(child => {
+      tabKeys.push(child.key);
+    });
+    const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
+    const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
 
     React.Children.forEach(children, child => {
       let content;

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -139,9 +139,11 @@ class Tabs extends React.Component {
     const commonTabItems = [];
     const tabKeys = [];
 
-    this.props.children.forEach(child => {
-      tabKeys.push(child.key);
-    });
+    if (this.props.children && this.props.children.length > 0) {
+      this.props.children.forEach(child => {
+        tabKeys.push(child.key);
+      });
+    }
     const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
     const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
 

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -137,15 +137,9 @@ class Tabs extends React.Component {
     } = this.props;
 
     const commonTabItems = [];
-    const tabKeys = [];
 
-    if (this.props.children && this.props.children.length > 0) {
-      this.props.children.forEach(child => {
-        tabKeys.push(child.key);
-      });
-    }
-    const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
-    const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
+    const foundActiveTabKey = React.Children.toArray(this.props.children).filter(child => child.key === this.props.activeKey);
+    const activeTabKey = foundActiveTabKey.length > 0 ? this.props.activeKey : this.state.activeKey;
 
     React.Children.forEach(children, child => {
       let content;

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -144,8 +144,9 @@ class Tabs extends React.Component {
         tabKeys.push(child.key);
       });
     }
-    const foundActiveTabKey = React.Children.toArray(children).filter(child => child.key === this.props.activeKey);
-    const activeTabKey = (foundActiveTabKey) ? foundActiveTabKey.key : this.state.activeKey;
+
+    const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
+    const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
 
     React.Children.forEach(children, child => {
       let content;

--- a/packages/terra-tabs/src/Tabs.jsx
+++ b/packages/terra-tabs/src/Tabs.jsx
@@ -137,9 +137,15 @@ class Tabs extends React.Component {
     } = this.props;
 
     const commonTabItems = [];
+    const tabKeys = [];
 
-    const foundActiveTabKey = React.Children.toArray(this.props.children).filter(child => child.key === this.props.activeKey);
-    const activeTabKey = (foundActiveTabKey) ? foundActiveTabKey.key : this.state.activeKey;
+    if (this.props.children && this.props.children.length > 0) {
+      this.props.children.forEach(child => {
+        tabKeys.push(child.key);
+      });
+    }
+    const foundActiveTabKey = tabKeys.find(element => element === this.props.activeKey);
+    const activeTabKey = foundActiveTabKey ? this.props.activeKey : this.state.activeKey;
 
     React.Children.forEach(children, child => {
       let content;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

If an active tab key is present in the tab data, the active key variable is set to prop active key else state the active key.

**Why it was changed:**

On Selecting the tab, the Dotted Focus is added but the underlined active key tab indicator is missing.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9640 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
