### PR TITLE
[terra-popup] Popup example with table issue fix

### DIFF
--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fixed
   * Fixed popup click events propagating to elements underneath it.
 
+## 6.71.0 - (October 3, 2023)
+
 * Added
   * Added aria-label prop for terra-popup to announce the close instruction.
 

--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-## 6.71.0 - (October 3, 2023)
+* Fixed
+  * Using a popup in a table but row receiving focus when clicking on popup.
 
 * Added
   * Added aria-label prop for terra-popup to announce the close instruction.

--- a/packages/terra-popup/CHANGELOG.md
+++ b/packages/terra-popup/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Using a popup in a table but row receiving focus when clicking on popup.
+  * Fixed popup click events propagating to elements underneath it.
 
 * Added
   * Added aria-label prop for terra-popup to announce the close instruction.

--- a/packages/terra-popup/src/Popup.jsx
+++ b/packages/terra-popup/src/Popup.jsx
@@ -101,6 +101,10 @@ const propTypes = {
    * String that labels the popup for screen readers.
    */
   ariaLabel: PropTypes.string,
+  /**
+   * Callback function to handle click events on the popup.
+   */
+  onClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -252,6 +256,7 @@ class Popup extends React.Component {
         isHeightAutomatic={this.props.contentHeight === 'auto'}
         isWidthAutomatic={this.props.contentWidth === 'auto'}
         isFocusedDisabled={this.props.isContentFocusDisabled}
+        onClick={this.props.onClick}
       >
         {this.props.children}
       </PopupContent>
@@ -277,6 +282,7 @@ class Popup extends React.Component {
       onRequestClose,
       targetRef,
       targetAttachment,
+      ...customProps
     } = this.props;
     /* eslint-enable no-unused-vars */
 
@@ -318,6 +324,7 @@ class Popup extends React.Component {
           onPosition={this.handleOnPosition}
           targetRef={targetRef}
           targetAttachment={tAttachment}
+          {...customProps}
         >
           {hookshotContent}
         </Hookshot>

--- a/packages/terra-popup/tests/jest/__snapshots__/Popup.test.jsx.snap
+++ b/packages/terra-popup/tests/jest/__snapshots__/Popup.test.jsx.snap
@@ -79,6 +79,7 @@ exports[`correctly applies the theme context className 1`] = `
           isEnabled={true}
           isOpen={true}
           onPosition={[Function]}
+          popupContentRole="dialog"
           targetAttachment={
             Object {
               "horizontal": "center",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Defect is when "click" event on pop-up does not bleed through to other components / controls.

**Why it was changed:**
If we render a popup in a table, if the user clicks on that popup, a table row will still receive the click.
The popup needs to "absorb" the click event and not allow it to "bubble" up or "bleed through" to other controls.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9651 <!-- Jira Number or issue Number. Please do not link to Jira. -->

Pre Implementation->

https://github.com/cerner/terra-framework/assets/126875089/e1150961-bc4f-466a-a411-bd5a47c9962c

Post Implementation->

https://github.com/cerner/terra-framework/assets/126875089/e3a36674-ced5-499b-801e-a78e80317906



---

Thank you for contributing to Terra.
@cerner/terra
