### PR TITLE
[terra-tabs] Fixes axe core violations, SR response for hidden tabs

### DIFF
--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -3,10 +3,14 @@
 ## Unreleased
 
 * Changed
-  * Additional padding of 10px on the left and right of tab content body 
-    is removed for framework styles.
+  * Additional padding of 10px on the left and right of tab content body is removed for framework styles.
   * Box shadow container style removed for framework variant tabs.
   * Fixes large tab content display with scrollable view.
+
+* Fixed
+  * Fixed Axe core violations for close button added on 
+    terra-tabs on both face-up tab and hidden tab.
+  * Fixed issue in screen reader instruction for hidden tabs   where add tab instruction is announced even in absence of add button.
 
 ## 7.8.0 - (September 21, 2023)
 

--- a/packages/terra-tabs/src/common-tabs/_HiddenTab.jsx
+++ b/packages/terra-tabs/src/common-tabs/_HiddenTab.jsx
@@ -217,6 +217,7 @@ const HiddenTab = ({
   const addTabWithSuggestion = intl.formatMessage({ id: 'Terra.tabs.addbutton.focus' });
   const responseId = `terra-hidden-tab-pane-response=${uuidv4()}`;
   const addbuttonresponseId = `terra-hidden-tab-pane-response=${uuidv4()}`;
+  const closeResponseId = `terra-tab-close-response=${uuidv4()}`;
 
   if (isDraggable) {
     return (
@@ -245,6 +246,13 @@ const HiddenTab = ({
     );
   }
 
+  let responseDescriptionId;
+  if (showAddButton) {
+    responseDescriptionId = addbuttonresponseId;
+  } else if (isClosable) {
+    responseDescriptionId = closeResponseId;
+  }
+
   return (
     <div
       {...attributes}
@@ -253,21 +261,21 @@ const HiddenTab = ({
       role={showAddButton ? 'button' : 'tab'}
       className={hiddenClassNames}
       aria-disabled={isDisabled}
-      aria-describedby={addbuttonresponseId}
+      aria-describedby={responseDescriptionId}
     >
       <VisuallyHiddenText aria-hidden id={addbuttonresponseId} text={addTabWithSuggestion} />
+      <VisuallyHiddenText aria-hidden id={closeResponseId} text={tabDeleteLabel} />
       <div className={cx('checkbox')}>{isSelected ? <IconCheckmark /> : null}</div>
       {showIcon && icon}
       <div className={cx('label', { 'with-icon': showIcon })}>{label}</div>
       {isClosable && (
-      <button
-        className={cx('tabs-remove-button')}
-        type="button"
-        aria-label={tabDeleteLabel}
-        onClick={onCloseClick}
-      >
-        <IconClose />
-      </button>
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+        <div
+          className={cx('tabs-remove-button')}
+          onClick={onCloseClick}
+        >
+          <IconClose />
+        </div>
       )}
     </div>
   );

--- a/packages/terra-tabs/src/common-tabs/_Tab.jsx
+++ b/packages/terra-tabs/src/common-tabs/_Tab.jsx
@@ -281,7 +281,8 @@ const Tab = ({
       role="tab"
       aria-disabled={isDisabled}
       className={variant === 'framework' ? paneClassNames : tabClassNames}
-      title={isClosable ? `${label}. ${tabDeleteLabel}` : label}
+      title={label}
+      aria-label={isClosable ? `${label}. ${tabDeleteLabel}` : label}
       tabIndex={isSelected ? 0 : -1}
       data-terra-tabs-show-focus-styles
     >

--- a/packages/terra-tabs/src/common-tabs/_Tab.jsx
+++ b/packages/terra-tabs/src/common-tabs/_Tab.jsx
@@ -247,7 +247,8 @@ const Tab = ({
             aria-controls={associatedPanelId}
             role="tab"
             className={variant === 'framework' ? paneClassNames : tabClassNames}
-            title={isClosable ? `${label}. ${tabDeleteLabel}` : label}
+            title={label}
+            aria-label={isClosable ? `${label}. ${tabDeleteLabel}` : label}
             aria-describedby={responseId}
             tabIndex={isSelected ? 0 : -1}
             data-terra-tabs-show-focus-styles

--- a/packages/terra-tabs/src/common-tabs/_Tab.jsx
+++ b/packages/terra-tabs/src/common-tabs/_Tab.jsx
@@ -172,9 +172,6 @@ const Tab = ({
 
   if (isIconOnly) {
     attributes['aria-label'] = label;
-    if (isClosable && label) {
-      attributes['aria-label'] = `${label} . ${tabDeleteLabel}`;
-    }
   }
 
   function onCloseClick(event) {
@@ -250,7 +247,7 @@ const Tab = ({
             aria-controls={associatedPanelId}
             role="tab"
             className={variant === 'framework' ? paneClassNames : tabClassNames}
-            title={label}
+            title={isClosable ? `${label}. ${tabDeleteLabel}` : label}
             aria-describedby={responseId}
             tabIndex={isSelected ? 0 : -1}
             data-terra-tabs-show-focus-styles
@@ -265,8 +262,6 @@ const Tab = ({
             {isClosable && (
             <div
               className={cx('tabs-remove-button')}
-              type="button"
-              aria-label={`. ${tabDeleteLabel}`}
               onClick={onCloseClick}
             >
               <IconClose />
@@ -286,7 +281,7 @@ const Tab = ({
       role="tab"
       aria-disabled={isDisabled}
       className={variant === 'framework' ? paneClassNames : tabClassNames}
-      title={label}
+      title={isClosable ? `${label}. ${tabDeleteLabel}` : label}
       tabIndex={isSelected ? 0 : -1}
       data-terra-tabs-show-focus-styles
     >
@@ -295,14 +290,14 @@ const Tab = ({
         {(!customDisplay && !isIconOnly) && <span className={variant === 'framework' ? cy('label') : cx('label')}>{label}</span>}
       </div>
       {isClosable && (
-      <div
-        className={cx('tabs-remove-button')}
-        type="button"
-        aria-label={`. ${tabDeleteLabel}`}
-        onClick={onCloseClick}
-      >
-        <IconClose />
-      </div>
+      <>
+        <div
+          className={cx('tabs-remove-button')}
+          onClick={onCloseClick}
+        >
+          <IconClose />
+        </div>
+      </>
       )}
     </div>
   );

--- a/packages/terra-tabs/tests/jest/__snapshots__/Tab.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/Tab.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Tab correctly applies the theme context className 1`] = `
 <div
   aria-disabled={false}
+  aria-label="Default"
   aria-selected={false}
   className="tab is-text-only orion-fusion-theme"
   data-focus-styles-enabled={true}
@@ -35,6 +36,7 @@ exports[`Tab correctly applies the theme context className 1`] = `
 exports[`Tab should render a common tab as disabled when indicated 1`] = `
 <div
   aria-disabled={true}
+  aria-label="Label"
   aria-selected={false}
   className="tab is-disabled is-text-only"
   data-focus-styles-enabled={false}
@@ -67,6 +69,7 @@ exports[`Tab should render a common tab as disabled when indicated 1`] = `
 exports[`Tab should render a common tab with custom props 1`] = `
 <div
   aria-disabled={false}
+  aria-label="Default"
   aria-selected={false}
   className="tab is-text-only"
   data-focus-styles-enabled={true}

--- a/packages/terra-tabs/tests/jest/__snapshots__/TabPane.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/TabPane.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`TabPane correctly applies the theme context className 1`] = `
 <div
   aria-disabled={false}
+  aria-label="Default"
   aria-selected={false}
   className="tab is-text-only orion-fusion-theme"
   data-focus-styles-enabled={true}
@@ -35,6 +36,7 @@ exports[`TabPane correctly applies the theme context className 1`] = `
 exports[`TabPane should render a default component with label 1`] = `
 <div
   aria-disabled={false}
+  aria-label="Default"
   aria-selected={false}
   className="tab is-text-only"
   data-focus-styles-enabled={true}
@@ -67,6 +69,7 @@ exports[`TabPane should render a default component with label 1`] = `
 exports[`TabPane should render with a custom display when provided 1`] = `
 <div
   aria-disabled={false}
+  aria-label="Label"
   aria-selected={false}
   className="tab is-text-only"
   data-focus-styles-enabled={true}
@@ -97,6 +100,7 @@ exports[`TabPane should render with a custom display when provided 1`] = `
 exports[`TabPane should render with icon and label 1`] = `
 <div
   aria-disabled={false}
+  aria-label="Label"
   aria-selected={false}
   className="tab"
   data-focus-styles-enabled={true}

--- a/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
@@ -230,6 +230,7 @@ exports[`Tabs correctly applies the theme context className 1`] = `
                       <div
                         aria-controls="terra-common-tabs-default-panel"
                         aria-disabled={false}
+                        aria-label="Default"
                         aria-selected={true}
                         className="tab is-active is-text-only orion-fusion-theme"
                         data-focus-styles-enabled={true}
@@ -755,6 +756,7 @@ exports[`Tabs should not render add icon if onSelectAddButton is passed as null 
                     <div
                       aria-controls="application-id-default-panel"
                       aria-disabled={false}
+                      aria-label="Default"
                       aria-selected={true}
                       className="tab is-text-only is-active"
                       data-focus-styles-enabled={true}
@@ -1519,6 +1521,7 @@ exports[`Tabs should render with add icon 1`] = `
                     <div
                       aria-controls="application-id-default-panel"
                       aria-disabled={false}
+                      aria-label="Default"
                       aria-selected={true}
                       className="tab is-text-only is-active"
                       data-focus-styles-enabled={true}
@@ -2121,6 +2124,7 @@ exports[`Tabs should render with add icon 2`] = `
                     <div
                       aria-controls="application-id-default-panel"
                       aria-disabled={false}
+                      aria-label="Default"
                       aria-selected={true}
                       className="tab is-text-only is-active"
                       data-focus-styles-enabled={true}
@@ -2717,6 +2721,7 @@ exports[`Tabs should render with close icon 1`] = `
                     <div
                       aria-controls="application-id-default-panel"
                       aria-disabled={false}
+                      aria-label="Default"
                       aria-selected={true}
                       className="tab is-text-only is-active"
                       data-focus-styles-enabled={true}

--- a/packages/terra-tabs/tests/jest/__snapshots__/_HiddenTab.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/_HiddenTab.test.jsx.snap
@@ -107,7 +107,6 @@ exports[`HiddenTab should render a hidden tab with provided props and selection 
     >
       <div
         aria-controls="panel-1"
-        aria-describedby="terra-hidden-tab-pane-response=00000000-0000-0000-0000-000000000000"
         aria-disabled={false}
         aria-selected={false}
         className="hidden"
@@ -181,6 +180,19 @@ exports[`HiddenTab should render a hidden tab with provided props and selection 
             id="terra-hidden-tab-pane-response=00000000-0000-0000-0000-000000000000"
           >
             Terra.tabs.addbutton.focus
+          </span>
+        </VisuallyHiddenText>
+        <VisuallyHiddenText
+          aria-hidden={true}
+          id="terra-tab-close-response=00000000-0000-0000-0000-000000000000"
+          text="Terra.tabs.hint.removable"
+        >
+          <span
+            aria-hidden={true}
+            className="visually-hidden-text"
+            id="terra-tab-close-response=00000000-0000-0000-0000-000000000000"
+          >
+            Terra.tabs.hint.removable
           </span>
         </VisuallyHiddenText>
         <div

--- a/packages/terra-tabs/tests/jest/__snapshots__/_TabDropDown.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/_TabDropDown.test.jsx.snap
@@ -170,7 +170,6 @@ exports[`TabDropDown should render the dropdown with provided hidden tabs 1`] = 
             >
               <div
                 aria-controls="panel-1"
-                aria-describedby="terra-hidden-tab-pane-response=00000000-0000-0000-0000-000000000000"
                 aria-disabled={false}
                 aria-selected={false}
                 className="hidden"
@@ -195,6 +194,19 @@ exports[`TabDropDown should render the dropdown with provided hidden tabs 1`] = 
                     id="terra-hidden-tab-pane-response=00000000-0000-0000-0000-000000000000"
                   >
                     Terra.tabs.addbutton.focus
+                  </span>
+                </VisuallyHiddenText>
+                <VisuallyHiddenText
+                  aria-hidden={true}
+                  id="terra-tab-close-response=00000000-0000-0000-0000-000000000000"
+                  text="Terra.tabs.hint.removable"
+                >
+                  <span
+                    aria-hidden={true}
+                    className="visually-hidden-text"
+                    id="terra-tab-close-response=00000000-0000-0000-0000-000000000000"
+                  >
+                    Terra.tabs.hint.removable
                   </span>
                 </VisuallyHiddenText>
                 <div
@@ -275,7 +287,6 @@ exports[`TabDropDown should render the dropdown with provided hidden tabs 1`] = 
             >
               <div
                 aria-controls="panel-2"
-                aria-describedby="terra-hidden-tab-pane-response=00000000-0000-0000-0000-000000000000"
                 aria-disabled={false}
                 aria-selected={false}
                 className="hidden"
@@ -300,6 +311,19 @@ exports[`TabDropDown should render the dropdown with provided hidden tabs 1`] = 
                     id="terra-hidden-tab-pane-response=00000000-0000-0000-0000-000000000000"
                   >
                     Terra.tabs.addbutton.focus
+                  </span>
+                </VisuallyHiddenText>
+                <VisuallyHiddenText
+                  aria-hidden={true}
+                  id="terra-tab-close-response=00000000-0000-0000-0000-000000000000"
+                  text="Terra.tabs.hint.removable"
+                >
+                  <span
+                    aria-hidden={true}
+                    className="visually-hidden-text"
+                    id="terra-tab-close-response=00000000-0000-0000-0000-000000000000"
+                  >
+                    Terra.tabs.hint.removable
                   </span>
                 </VisuallyHiddenText>
                 <div


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

- Fixed Axe core violations for close button added on terra-tabs on both face-up tab and hidden tab.
- Fixed issue in screen reader instruction for hidden tabs where add tab instruction is announced even in absence of add button.



**Why it was changed:**

- Screen reader instructions are inappropriate for hidden tabs. when we navigate to hidden tabs screen reader announce press space or enter to add new tab even when there is no add button available on menu ( as shown in the screenshot of VO). We need to add the instruction only of onAddSelect callback is provided.
- Axe core violations for close button added on terra-tabs on both face-up tab and hidden tab.
`Ensures ARIA attributes are allowed for an element's role` 
`Ensures interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies`

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9690 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
