### PR TITLE
[terra-data-grid] Added screen reader messages for changes in column sort direction

### DIFF
--- a/packages/terra-data-grid/CHANGELOG.md
+++ b/packages/terra-data-grid/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added screen reader messages for changes in column sort direction.
+
 ## 0.6.0 - (September 14, 2023)
 
 * Breaking Changes

--- a/packages/terra-data-grid/src/DataGrid.jsx
+++ b/packages/terra-data-grid/src/DataGrid.jsx
@@ -298,12 +298,13 @@ function DataGrid(props) {
 
       if (previousSortedColumn.id !== currentSortedColumn.id
       || previousSortedColumn.sortIndicator !== currentSortedColumn.sortIndicator) {
-        alert(`Trigger Sort Message ${currentSortedColumn.displayName} - ${currentSortedColumn.sortIndicator}`);
-        setCellAriaLiveMessage(intl.formatMessage({
-          id: 'Terra.table.sort-direction-changed',
-          column: currentSortedColumn.displayName,
-          sortDirection: currentSortedColumn.sortIndicator,
-        }));
+        setCellAriaLiveMessage(intl.formatMessage(
+          { id: 'Terra.table.sort-direction-changed' },
+          {
+            column: currentSortedColumn.displayName,
+            sortDirection: currentSortedColumn.sortIndicator,
+          },
+        ));
       }
     }
 

--- a/packages/terra-data-grid/src/DataGrid.jsx
+++ b/packages/terra-data-grid/src/DataGrid.jsx
@@ -112,6 +112,12 @@ const propTypes = {
    * rendered to allow for row selection to occur.
    */
   hasSelectableRows: PropTypes.bool,
+
+  /**
+   * @private
+   * The intl object containing translations. This is retrieved from the context automatically by injectIntl.
+   */
+  intl: PropTypes.shape({ formatMessage: PropTypes.func }).isRequired,
 };
 
 const defaultProps = {
@@ -141,6 +147,7 @@ function DataGrid(props) {
     onRangeSelection,
     hasSelectableRows,
     rowHeaderIndex,
+    intl,
   } = props;
 
   if (pinnedColumns.length === 0) {
@@ -177,6 +184,8 @@ function DataGrid(props) {
 
   const hasReceivedFocus = useRef(false);
   const handleFocus = useRef(true);
+
+  const sortedColumn = useRef(null);
 
   const [focusedRow, setFocusedRow] = useState(0);
   const [focusedCol, setFocusedCol] = useState(0);
@@ -282,6 +291,24 @@ function DataGrid(props) {
       });
     }
     setPinnedColumnOffsets(offsetArray);
+
+    const currentSortedColumn = dataGridColumns.find((column) => !!column.sortIndicator);
+    if (sortedColumn.current) {
+      const previousSortedColumn = { ...sortedColumn.current };
+
+      if (previousSortedColumn.id !== currentSortedColumn.id
+      || previousSortedColumn.sortIndicator !== currentSortedColumn.sortIndicator) {
+        alert(`Trigger Sort Message ${currentSortedColumn.displayName} - ${currentSortedColumn.sortIndicator}`);
+        setCellAriaLiveMessage(intl.formatMessage({
+          id: 'Terra.table.sort-direction-changed',
+          column: currentSortedColumn.displayName,
+          sortDirection: currentSortedColumn.sortIndicator,
+        }));
+      }
+    }
+
+    sortedColumn.current = currentSortedColumn;
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataGridColumns]);
 

--- a/packages/terra-data-grid/translations/en-US.json
+++ b/packages/terra-data-grid/translations/en-US.json
@@ -15,5 +15,6 @@
   "Terra.worklistDataGrid.row-selection-mode-enabled": "Row Selection Mode enabled.",
   "Terra.worklistDataGrid.row-selection-mode-disabled": "Row Selection Mode disabled",
   "Terra.worklistDataGrid.all-rows-selected" : "All rows selected",
-  "Terra.worklistDataGrid.all-rows-unselected" : "No rows selected"
+  "Terra.worklistDataGrid.all-rows-unselected" : "No rows selected",
+  "Terra.table.sort-direction-changed" : "{column} column sorted {sortDirection}"
 }

--- a/packages/terra-data-grid/translations/en.json
+++ b/packages/terra-data-grid/translations/en.json
@@ -15,5 +15,6 @@
   "Terra.worklistDataGrid.row-selection-mode-enabled": "Row Selection Mode enabled.",
   "Terra.worklistDataGrid.row-selection-mode-disabled": "Row Selection Mode disabled",
   "Terra.worklistDataGrid.all-rows-selected" : "All rows selected",
-  "Terra.worklistDataGrid.all-rows-unselected" : "No rows selected"
+  "Terra.worklistDataGrid.all-rows-unselected" : "No rows selected",
+  "Terra.table.sort-direction-changed" : "{column} column sorted {sortDirection}"
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Added screen reader messages for changes in column sort direction.

**Why it was changed:**
The change was made to ensure that screen reader users have audible feedback when the sort order of the column changes.  Testing found that this is not the default behavior even with appropriate ARIA attributes.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

The functionality was tested using the Voice Over screen reader to validate the changes.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9685 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
