### PR TITLE
Update Jest snapshots to fix the build

### DIFF
--- a/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
+++ b/packages/terra-application-navigation/tests/jest/utility-menu/__snapshots__/UtilityMenu.test.jsx.snap
@@ -982,7 +982,7 @@ exports[`UtilityMenu should render with function callbacks 1`] = `
                       type="button"
                     >
                       <span
-                        className="button-label text-only"
+                        className="button-label-win text-only"
                       >
                         <span
                           className=""
@@ -1308,7 +1308,7 @@ exports[`UtilityMenu should render with skip callback 1`] = `
                       type="button"
                     >
                       <span
-                        className="button-label text-only"
+                        className="button-label-win text-only"
                       >
                         <span
                           className=""

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -362,7 +362,7 @@ exports[`correctly applies the theme context className 1`] = `
               type="button"
             >
               <span
-                className="button-label icon-only"
+                className="button-label-win icon-only"
               >
                 <span
                   className="icon"
@@ -444,7 +444,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             type="button"
           >
             <span
-              class="button-label icon-only"
+              class="button-label-win icon-only"
             >
               <span
                 class="icon"
@@ -793,7 +793,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
                   type="button"
                 >
                   <span
-                    class="button-label icon-only"
+                    class="button-label-win icon-only"
                   >
                     <span
                       class="icon"
@@ -844,7 +844,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
           type="button"
         >
           <span
-            className="button-label icon-only"
+            className="button-label-win icon-only"
           >
             <span
               className="icon"
@@ -994,7 +994,7 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
       type="button"
     >
       <span
-        class="button-label icon-only"
+        class="button-label-win icon-only"
       >
         <span
           class="icon"
@@ -1120,7 +1120,7 @@ exports[`should render a date input with isInvalid prop 1`] = `
       type="button"
     >
       <span
-        class="button-label icon-only"
+        class="button-label-win icon-only"
       >
         <span
           class="icon"
@@ -1246,7 +1246,7 @@ exports[`should render a default date input 1`] = `
       type="button"
     >
       <span
-        class="button-label icon-only"
+        class="button-label-win icon-only"
       >
         <span
           class="icon"
@@ -1303,7 +1303,7 @@ exports[`should render a default date input with all props 1`] = `
             type="button"
           >
             <span
-              class="button-label icon-only"
+              class="button-label-win icon-only"
             >
               <span
                 class="icon"
@@ -1678,7 +1678,7 @@ exports[`should render a default date input with all props 1`] = `
                   type="button"
                 >
                   <span
-                    class="button-label icon-only"
+                    class="button-label-win icon-only"
                   >
                     <span
                       class="icon"
@@ -1729,7 +1729,7 @@ exports[`should render a default date input with all props 1`] = `
           type="button"
         >
           <span
-            className="button-label icon-only"
+            className="button-label-win icon-only"
           >
             <span
               className="icon"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -638,7 +638,7 @@ exports[`correctly applies the theme context className 1`] = `
                             type="button"
                           >
                             <span
-                              className="button-label icon-only"
+                              className="button-label-win icon-only"
                             >
                               <span
                                 className="icon"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -941,7 +941,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                   type="button"
                                 >
                                   <span
-                                    className="button-label icon-only"
+                                    className="button-label-win icon-only"
                                   >
                                     <span
                                       className="icon"
@@ -1825,7 +1825,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                   type="button"
                                 >
                                   <span
-                                    className="button-label icon-only"
+                                    className="button-label-win icon-only"
                                   >
                                     <span
                                       className="icon"
@@ -2819,7 +2819,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   type="button"
                                 >
                                   <span
-                                    className="button-label icon-only"
+                                    className="button-label-win icon-only"
                                   >
                                     <span
                                       className="icon"

--- a/packages/terra-dialog-modal/tests/jest/__snapshots__/DialogModal.test.jsx.snap
+++ b/packages/terra-dialog-modal/tests/jest/__snapshots__/DialogModal.test.jsx.snap
@@ -46,7 +46,7 @@ exports[`correctly applies the theme context className 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -106,7 +106,7 @@ exports[`should mount an open dialogModal 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -168,7 +168,7 @@ exports[`should mount an open dialogModal 320 width 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -230,7 +230,7 @@ exports[`should mount an open dialogModal 960 width 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -292,7 +292,7 @@ exports[`should mount an open dialogModal 1280 width 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -354,7 +354,7 @@ exports[`should mount an open dialogModal 1600 width 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -416,7 +416,7 @@ exports[`should mount an open dialogModal 1600 width 2`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""
@@ -478,7 +478,7 @@ exports[`should set the rootSelector 1`] = `
         type="button"
       >
         <span
-          className="button-label text-only"
+          className="button-label-win text-only"
         >
           <span
             className=""

--- a/packages/terra-navigation-side-menu/tests/jest/__snapshots__/NavigationSideMenu.test.jsx.snap
+++ b/packages/terra-navigation-side-menu/tests/jest/__snapshots__/NavigationSideMenu.test.jsx.snap
@@ -395,7 +395,7 @@ exports[`Layout correctly applies the theme context className 1`] = `
                               type="button"
                             >
                               <span
-                                className="button-label icon-only"
+                                className="button-label-win icon-only"
                               >
                                 <span
                                   className="icon"

--- a/packages/terra-notification-dialog/tests/jest/__snapshots__/NotificationDialog.test.jsx.snap
+++ b/packages/terra-notification-dialog/tests/jest/__snapshots__/NotificationDialog.test.jsx.snap
@@ -1161,7 +1161,7 @@ exports[`correctly applies the theme context className 1`] = `
                               type="button"
                             >
                               <span
-                                class="button-label text-only"
+                                class="button-label-win text-only"
                               >
                                 <span
                                   class=""
@@ -1177,7 +1177,7 @@ exports[`correctly applies the theme context className 1`] = `
                               type="button"
                             >
                               <span
-                                class="button-label text-only"
+                                class="button-label-win text-only"
                               >
                                 <span
                                   class=""
@@ -1353,7 +1353,7 @@ exports[`correctly applies the theme context className 1`] = `
                                 type="button"
                               >
                                 <span
-                                  className="button-label text-only"
+                                  className="button-label-win text-only"
                                 >
                                   <span
                                     className=""
@@ -1390,7 +1390,7 @@ exports[`correctly applies the theme context className 1`] = `
                                 type="button"
                               >
                                 <span
-                                  className="button-label text-only"
+                                  className="button-label-win text-only"
                                 >
                                   <span
                                     className=""

--- a/packages/terra-popup/tests/jest/__snapshots__/PopupContent.test.jsx.snap
+++ b/packages/terra-popup/tests/jest/__snapshots__/PopupContent.test.jsx.snap
@@ -279,7 +279,7 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                       type="button"
                     >
                       <span
-                        class="button-label icon-only"
+                        class="button-label-win icon-only"
                       >
                         <span
                           class="icon"
@@ -402,7 +402,7 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                             type="button"
                           >
                             <span
-                              class="button-label icon-only"
+                              class="button-label-win icon-only"
                             >
                               <span
                                 class="icon"
@@ -517,7 +517,7 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                               type="button"
                             >
                               <span
-                                class="button-label icon-only"
+                                class="button-label-win icon-only"
                               >
                                 <span
                                   class="icon"
@@ -660,7 +660,7 @@ exports[`PopupContent Prop Tests with header matches the mount snapshot 1`] = `
                             type="button"
                           >
                             <span
-                              className="button-label icon-only"
+                              className="button-label-win icon-only"
                             >
                               <span
                                 className="icon"

--- a/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/Tabs.test.jsx.snap
@@ -1745,7 +1745,7 @@ exports[`Tabs should render with add icon 1`] = `
                         type="button"
                       >
                         <span
-                          className="button-label icon-only"
+                          className="button-label-win icon-only"
                         >
                           <span
                             className="icon"
@@ -2348,7 +2348,7 @@ exports[`Tabs should render with add icon 2`] = `
                         type="button"
                       >
                         <span
-                          className="button-label icon-only"
+                          className="button-label-win icon-only"
                         >
                           <span
                             className="icon"

--- a/packages/terra-tabs/tests/jest/__snapshots__/_AddButton.test.jsx.snap
+++ b/packages/terra-tabs/tests/jest/__snapshots__/_AddButton.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`MoreButton should render a add button with provided props and selection
           type="button"
         >
           <span
-            className="button-label icon-only"
+            className="button-label-win icon-only"
           >
             <span
               className="icon"

--- a/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
+++ b/packages/terra-time-input/tests/jest/__snapshots__/TimeInput.test.jsx.snap
@@ -564,7 +564,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
         type="button"
       >
         <span
-          class="button-label text-only"
+          class="button-label-win text-only"
         >
           <span
             class=""
@@ -583,7 +583,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
         type="button"
       >
         <span
-          class="button-label text-only"
+          class="button-label-win text-only"
         >
           <span
             class=""
@@ -678,7 +678,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
         type="button"
       >
         <span
-          class="button-label text-only"
+          class="button-label-win text-only"
         >
           <span
             class=""
@@ -697,7 +697,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
         type="button"
       >
         <span
-          class="button-label text-only"
+          class="button-label-win text-only"
         >
           <span
             class=""
@@ -792,7 +792,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
         type="button"
       >
         <span
-          class="button-label text-only"
+          class="button-label-win text-only"
         >
           <span
             class=""
@@ -811,7 +811,7 @@ exports[`should not have duplicate ids on the page when multiple date pickers ar
         type="button"
       >
         <span
-          class="button-label text-only"
+          class="button-label-win text-only"
         >
           <span
             class=""
@@ -1363,7 +1363,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons and seconds in
       type="button"
     >
       <span
-        class="button-label text-only"
+        class="button-label-win text-only"
       >
         <span
           class=""
@@ -1382,7 +1382,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons and seconds in
       type="button"
     >
       <span
-        class="button-label text-only"
+        class="button-label-win text-only"
       >
         <span
           class=""
@@ -1480,7 +1480,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons when viewed on
       type="button"
     >
       <span
-        class="button-label text-only"
+        class="button-label-win text-only"
       >
         <span
           class=""
@@ -1499,7 +1499,7 @@ exports[`should render a 12 hour timepicker meridiem with buttons when viewed on
       type="button"
     >
       <span
-        class="button-label text-only"
+        class="button-label-win text-only"
       >
         <span
           class=""


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR updates failing Jest snapshots (due to the changes from https://github.com/cerner/terra-core/pull/3920) so that the build is passing.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

---

Thank you for contributing to Terra.
@cerner/terra
