### PR TITLE
[terra-menu] - Fixed SR not announcing menu group name information.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39396,6 +39396,10 @@
       "resolved": "packages/terra-collapsible-menu-view",
       "link": true
     },
+    "node_modules/terra-compact-interactive-list": {
+      "resolved": "packages/terra-compact-interactive-list",
+      "link": true
+    },
     "node_modules/terra-content-container": {
       "version": "3.39.1",
       "resolved": "https://registry.npmjs.org/terra-content-container/-/terra-content-container-3.39.1.tgz",
@@ -43243,6 +43247,21 @@
         "react-intl": ">=2.8.0, <6.0.0"
       }
     },
+    "packages/terra-compact-interactive-list": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "keycode-js": "^3.1.0",
+        "prop-types": "^15.5.8",
+        "terra-theme-context": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5",
+        "react-dom": "^16.8.5",
+        "react-intl": "2 || 3 || 4 || 5"
+      }
+    },
     "packages/terra-data-grid": {
       "version": "1.0.0",
       "license": "Apache-2.0",
@@ -43478,6 +43497,7 @@
         "terra-brand-footer": "^3.11.0",
         "terra-button": "^3.3.0",
         "terra-collapsible-menu-view": "^6.83.0",
+        "terra-compact-interactive-list": "^0.1.0",
         "terra-content-container": "^3.0.0",
         "terra-data-grid": "^1.0.0",
         "terra-date-input": "^1.46.0",

--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Removed
+  * Removed ariaLabel first class prop because Consumer can still pass in aria-label through custom props.
+
 ## 6.83.0 - (October 25, 2023)
 
 * Changed
@@ -23,7 +26,7 @@
   * Added the ability to add hyperlinks.
   * Added `isMultiSelect` prop to support multiselect group items.
   * Added aria-label prop for `collapsible-menu-view` to announce group information.
-  
+
 * Fixed
   * Fixed responsive menu icon not being vertical in the lowlight and fusion themes.
 
@@ -105,7 +108,7 @@
 * Added
   * Added `isStartAligned` prop
   * Added new Jest test and snapshots
-  
+
 ## 6.65.0 - (March 29, 2023)
 
 * Changed

--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Removed
-  * Removed ariaLabel first class prop because Consumer can still pass in aria-label through custom props.
+* Added
+  * Added `GroupId` prop that used in menu item for `aria-describedby` that labels the group for accessibility.
 
 ## 6.83.0 - (October 25, 2023)
 

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -30,7 +30,7 @@ const propTypes = {
    * String that labels the group for accessibility.
    */
   ariaLabel: PropTypes.string,
-   /**
+  /**
    * String that used in menu item for aria-describedby that labels the group for accessibility.
    */
   GroupId: PropTypes.string,

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -26,6 +26,14 @@ const propTypes = {
    * A list of keys of the CollapsibleMenuView.Items that should be selected.
    */
   selectedKeys: PropTypes.arrayOf(PropTypes.string),
+  /**
+   * String that labels the group for accessibility.
+   */
+  ariaLabel: PropTypes.string,
+   /**
+   * String that used in menu item for aria-describedby that labels the group for accessibility.
+   */
+  GroupId: PropTypes.string,
 };
 
 const defaultProps = {
@@ -70,6 +78,8 @@ class CollapsibleMenuViewItemGroup extends React.Component {
       onChange,
       isMultiSelect,
       selectedKeys,
+      ariaLabel,
+      GroupId,
       ...customProps
     } = this.props;
 
@@ -85,7 +95,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
         });
         return (
           <li role="none">
-            <div {...customProps} role="group">
+            <div {...customProps} role="group" id={GroupId}>
               {cloneChildren}
             </div>
           </li>
@@ -94,7 +104,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
       if (onChange) {
         return (
           <li role="none">
-            <Menu.ItemGroup {...customProps} onChange={this.handleMenuOnChange}>
+            <Menu.ItemGroup {...customProps} onChange={this.handleMenuOnChange} id={GroupId}>
               {children}
             </Menu.ItemGroup>
           </li>

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -33,7 +33,7 @@ const propTypes = {
   /**
    * String that used in menu item for aria-describedby that labels the group for accessibility.
    */
-  GroupId: PropTypes.string,
+  groupId: PropTypes.string,
 };
 
 const defaultProps = {
@@ -79,7 +79,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
       isMultiSelect,
       selectedKeys,
       ariaLabel,
-      GroupId,
+      groupId,
       ...customProps
     } = this.props;
 
@@ -95,7 +95,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
         });
         return (
           <li role="none">
-            <div {...customProps} role="group" id={GroupId}>
+            <div {...customProps} role="group" id={groupId} aria-label={ariaLabel}>
               {cloneChildren}
             </div>
           </li>
@@ -104,7 +104,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
       if (onChange) {
         return (
           <li role="none">
-            <Menu.ItemGroup {...customProps} onChange={this.handleMenuOnChange} id={GroupId}>
+            <Menu.ItemGroup {...customProps} onChange={this.handleMenuOnChange} id={groupId} aria-label={ariaLabel}>
               {children}
             </Menu.ItemGroup>
           </li>
@@ -125,7 +125,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
     ]);
 
     return (
-      <ButtonGroup {...customProps} isMultiSelect={isMultiSelect} onChange={onChange} className={buttonGroupClassNames} selectedKeys={selectedKeys}>
+      <ButtonGroup {...customProps} isMultiSelect={isMultiSelect} onChange={onChange} className={buttonGroupClassNames} selectedKeys={selectedKeys} aria-label={ariaLabel}>
         {children}
       </ButtonGroup>
     );

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItemGroup.jsx
@@ -26,10 +26,6 @@ const propTypes = {
    * A list of keys of the CollapsibleMenuView.Items that should be selected.
    */
   selectedKeys: PropTypes.arrayOf(PropTypes.string),
-  /**
-   * String that labels the group for accessibility.
-   */
-  ariaLabel: PropTypes.string,
 };
 
 const defaultProps = {
@@ -74,7 +70,6 @@ class CollapsibleMenuViewItemGroup extends React.Component {
       onChange,
       isMultiSelect,
       selectedKeys,
-      ariaLabel,
       ...customProps
     } = this.props;
 
@@ -99,7 +94,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
       if (onChange) {
         return (
           <li role="none">
-            <Menu.ItemGroup {...customProps} onChange={this.handleMenuOnChange} aria-label={ariaLabel}>
+            <Menu.ItemGroup {...customProps} onChange={this.handleMenuOnChange}>
               {children}
             </Menu.ItemGroup>
           </li>
@@ -120,7 +115,7 @@ class CollapsibleMenuViewItemGroup extends React.Component {
     ]);
 
     return (
-      <ButtonGroup {...customProps} isMultiSelect={isMultiSelect} onChange={onChange} className={buttonGroupClassNames} selectedKeys={selectedKeys} aria-label={ariaLabel}>
+      <ButtonGroup {...customProps} isMultiSelect={isMultiSelect} onChange={onChange} className={buttonGroupClassNames} selectedKeys={selectedKeys}>
         {children}
       </ButtonGroup>
     );

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added aria-label custom prop and ariaDescribedBy first class prop for `terra-collapsible-menu-view` and `terra-menu` to help describe the intent of the group information.
+  * Added `aria-label`  and `ariaDescribedBy` for `terra-collapsible-menu-view` and `terra-menu` to help describe the intent of the group information.
 
 ## 1.43.0 - (October 25, 2023)
 

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added aria-label custom prop and ariaDescribedBy first class prop for `terra-collapsible-menu-view` and `terra-menu` to help describe the intent of the group information.
+
 ## 1.43.0 - (October 25, 2023)
 
 * Added

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `aria-label`  and `ariaDescribedBy` for `terra-collapsible-menu-view` and `terra-menu` to help describe the intent of the group information.
+  * Added `aria-label` and `ariaDescribedBy` props.
 
 ## 1.43.0 - (October 25, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/AlwaysCollapsedMenuItemsDemo.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/AlwaysCollapsedMenuItemsDemo.jsx
@@ -53,7 +53,7 @@ class AlwaysCollapsedMenuItemsDemo extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="divider1" />
-        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" id="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Single Selection" groupId="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/AlwaysCollapsedMenuItemsDemo.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/AlwaysCollapsedMenuItemsDemo.jsx
@@ -53,11 +53,12 @@ class AlwaysCollapsedMenuItemsDemo extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="divider1" />
-        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Single Selection" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" id="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"
             key="tableView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'tableView'}
@@ -66,6 +67,7 @@ class AlwaysCollapsedMenuItemsDemo extends React.Component {
             icon={<IconVisualization />}
             text="Chart View"
             key="chartView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'chartView'}
@@ -74,6 +76,7 @@ class AlwaysCollapsedMenuItemsDemo extends React.Component {
             icon={<IconTreemap />}
             text="Treemap View"
             key="treemapView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'treemapView'}

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewDemo.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewDemo.jsx
@@ -90,7 +90,7 @@ class CollapsibleMenuViewDemo extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" id="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" GroupId="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewDemo.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewDemo.jsx
@@ -90,7 +90,7 @@ class CollapsibleMenuViewDemo extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" GroupId="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Single Selection" groupId="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewDemo.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewDemo.jsx
@@ -90,11 +90,12 @@ class CollapsibleMenuViewDemo extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Single Selection" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" id="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"
             key="tableView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'tableView'}
@@ -103,6 +104,7 @@ class CollapsibleMenuViewDemo extends React.Component {
             icon={<IconVisualization />}
             text="Chart View"
             key="chartView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'chartView'}
@@ -111,6 +113,7 @@ class CollapsibleMenuViewDemo extends React.Component {
             icon={<IconTreemap />}
             text="Treemap View"
             key="treemapView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'treemapView'}

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewStartAligned.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewStartAligned.jsx
@@ -90,11 +90,12 @@ class CollapsibleMenuViewStartAligned extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Single Selection" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" id="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"
             key="tableView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'tableView'}
@@ -103,6 +104,7 @@ class CollapsibleMenuViewStartAligned extends React.Component {
             icon={<IconVisualization />}
             text="Chart View"
             key="chartView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'chartView'}
@@ -111,6 +113,7 @@ class CollapsibleMenuViewStartAligned extends React.Component {
             icon={<IconTreemap />}
             text="Treemap View"
             key="treemapView"
+            ariaDescribedBy="view-type-single-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.displayType === 'treemapView'}

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewStartAligned.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewStartAligned.jsx
@@ -90,7 +90,7 @@ class CollapsibleMenuViewStartAligned extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup aria-label="View Type Single Selection" id="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Single Selection" groupId="view-type-single-select" key="ViewTypeSelection" selectedKeys={[this.state.displayType]} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewWithMultiSelectItems.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewWithMultiSelectItems.jsx
@@ -77,11 +77,12 @@ class CollapsibleMenuViewWithMultiSelectItems extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Multi Selection" key="ViewTypeSelection" isMultiSelect selectedKeys={this.state.selectedKeys} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup aria-label="View Type Multi Selection" id="view-type-multi-select" key="ViewTypeSelection" isMultiSelect selectedKeys={this.state.selectedKeys} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"
             key="tableView"
+            ariaDescribedBy="view-type-multi-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.selectedKeys.includes('tableView')}
@@ -90,6 +91,7 @@ class CollapsibleMenuViewWithMultiSelectItems extends React.Component {
             icon={<IconFlowsheet />}
             text="Expanded View"
             key="expandedView"
+            ariaDescribedBy="view-type-multi-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.selectedKeys.includes('expandedView')}
@@ -98,6 +100,7 @@ class CollapsibleMenuViewWithMultiSelectItems extends React.Component {
             icon={<IconVisualization />}
             text="Trending View"
             key="trendingView"
+            ariaDescribedBy="view-type-multi-select"
             isIconOnly
             shouldCloseOnClick={false}
             isSelected={this.state.selectedKeys.includes('trendingView')}

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewWithMultiSelectItems.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewWithMultiSelectItems.jsx
@@ -77,7 +77,7 @@ class CollapsibleMenuViewWithMultiSelectItems extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup aria-label="View Type Multi Selection" GroupId="view-type-multi-select" key="ViewTypeSelection" isMultiSelect selectedKeys={this.state.selectedKeys} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup ariaLabel="View Type Multi Selection" groupId="view-type-multi-select" key="ViewTypeSelection" isMultiSelect selectedKeys={this.state.selectedKeys} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewWithMultiSelectItems.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/collapsible-menu-view/example/CollapsibleMenuViewWithMultiSelectItems.jsx
@@ -77,7 +77,7 @@ class CollapsibleMenuViewWithMultiSelectItems extends React.Component {
           ]}
         />
         <CollapsibleMenuView.Divider key="Divider2" />
-        <CollapsibleMenuView.ItemGroup aria-label="View Type Multi Selection" id="view-type-multi-select" key="ViewTypeSelection" isMultiSelect selectedKeys={this.state.selectedKeys} onChange={this.handleDisplayTypeChange}>
+        <CollapsibleMenuView.ItemGroup aria-label="View Type Multi Selection" GroupId="view-type-multi-select" key="ViewTypeSelection" isMultiSelect selectedKeys={this.state.selectedKeys} onChange={this.handleDisplayTypeChange}>
           <CollapsibleMenuView.Item
             icon={<IconTable />}
             text="Table View"

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/menu/example/BasicMenu.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/menu/example/BasicMenu.jsx
@@ -181,10 +181,10 @@ class BasicMenu extends React.Component {
               ]}
             />
             <Menu.Divider key="Divider3" />
-            <Menu.ItemGroup key="Group" onChange={this.handleOnChange}>
-              <Menu.Item text="Behavioral Health" key="GroupItem1" isSelected={this.state.groupSelectedIndex === 0} />
-              <Menu.Item text="Ambulatory Surgery Center" key="GroupItem2" isSelected={this.state.groupSelectedIndex === 1} />
-              <Menu.Item text="Critical Care" key="GroupItem3" isSelected={this.state.groupSelectedIndex === 2} isDisabled />
+            <Menu.ItemGroup key="Group" aria-label="Health Information" id="health-info" onChange={this.handleOnChange}>
+              <Menu.Item ariaDescribedBy="health-info" text="Behavioral Health" key="GroupItem1" isSelected={this.state.groupSelectedIndex === 0} />
+              <Menu.Item ariaDescribedBy="health-info" text="Ambulatory Surgery Center" key="GroupItem2" isSelected={this.state.groupSelectedIndex === 1} />
+              <Menu.Item ariaDescribedBy="health-info" text="Critical Care" key="GroupItem3" isSelected={this.state.groupSelectedIndex === 2} isDisabled />
             </Menu.ItemGroup>
           </Menu>
           <Button onClick={this.handleButtonClick} text="Explore Clinical Solution" aria-haspopup icon={<IconCaretDown />} isReversed refCallback={this.setButtonNode} />

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added ariaDescribedBy first class prop to announce group information.
+  * Added `ariaDescribedBy` prop for `menu-item` to announce group information.
 
 ## 6.79.0 - (October 25, 2023)
 

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added ariaDescribedBy first class prop to announce group information.
+
 ## 6.79.0 - (October 25, 2023)
 
 * Changed
@@ -98,9 +101,9 @@
 
 ## 6.65.1 - (April 12, 2023)
 
-* Fixed 
+* Fixed
   * Fixed issue of navigation on menu header click.
-  
+
 * Added
   * Allow screen readers to recognise as menu button
   * Added context for menu item index, item with submenu and selected/unselected state
@@ -114,7 +117,7 @@
 
 * Changed
   * Allow existing classnames on icon to be retained
-  
+
 ## 6.63.0 - (February 14, 2023)
 
 * Changed

--- a/packages/terra-menu/src/MenuItem.jsx
+++ b/packages/terra-menu/src/MenuItem.jsx
@@ -384,7 +384,6 @@ class MenuItem extends React.Component {
             aria-selected={(isMacOs && toggleable) ? markAsToggled : undefined}
             tabIndex="0"
             aria-disabled={isDisabled}
-            aria-describedby={ariaDescribedBy}
           >
             {content}
           </li>

--- a/packages/terra-menu/src/MenuItem.jsx
+++ b/packages/terra-menu/src/MenuItem.jsx
@@ -123,6 +123,11 @@ const propTypes = {
    * The intl object to be injected for translations. Provided by the injectIntl function.
    */
   intl: PropTypes.shape({ formatMessage: PropTypes.func }).isRequired,
+  /**
+   * If additional visible information text is used, provide a string containing the IDs for html elements that
+   * help describe the intent of the group of menu.
+   */
+  ariaDescribedBy: PropTypes.string,
 };
 
 const defaultProps = {
@@ -246,6 +251,7 @@ class MenuItem extends React.Component {
       isInstructionsForUse,
       isSelectable,
       isToggleable,
+      ariaDescribedBy,
       subMenuItems,
       isActive,
       icon,
@@ -378,6 +384,7 @@ class MenuItem extends React.Component {
             aria-selected={(isMacOs && toggleable) ? markAsToggled : undefined}
             tabIndex="0"
             aria-disabled={isDisabled}
+            aria-describedby={ariaDescribedBy}
           >
             {content}
           </li>

--- a/packages/terra-menu/src/_MenuContent.jsx
+++ b/packages/terra-menu/src/_MenuContent.jsx
@@ -119,6 +119,7 @@ class MenuContent extends React.Component {
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onKeyDownBackButton = this.onKeyDownBackButton.bind(this);
     this.validateFocus = this.validateFocus.bind(this);
+    this.ariaDescribedByHandle = this.ariaDescribedByHandle.bind(this);
     this.needsFocus = props.isFocused;
     this.handleContainerRef = this.handleContainerRef.bind(this);
     this.menuHeaderId = `terra-menu-headertitle-${uuidv4()}`;
@@ -342,6 +343,23 @@ class MenuContent extends React.Component {
     );
   }
 
+  ariaDescribedByHandle(value, index) {
+    let ariaDescribedByValue;
+    if (MenuUtils.isMac()) {
+      ariaDescribedByValue = value.props.ariaDescribedBy;
+    }
+    if (!MenuUtils.isMac()) {
+      if (!this.props.index && this.props.showHeader && index === 0 && value.props.ariaDescribedBy) {
+        ariaDescribedByValue = `${this.menuTopHeaderId} ${value.props.ariaDescribedBy}`;
+      } else if (!this.props.index && this.props.showHeader && index === 0 && value.props.ariaDescribedBy === undefined) {
+        ariaDescribedByValue = this.menuTopHeaderId;
+      } else {
+        ariaDescribedByValue = value.props.ariaDescribedBy;
+      }
+    }
+    return ariaDescribedByValue;
+  }
+
   render() {
     let index = -1;
     const totalItems = MenuUtils.totalItems(this.props.children);
@@ -356,7 +374,7 @@ class MenuContent extends React.Component {
         index += 1;
         const onKeyDown = this.wrapOnKeyDown(item, index, item.props.isDisabled);
         const isActive = this.state.focusIndex === index;
-
+        const ariaDescribedByHandleValue = this.ariaDescribedByHandle(item, index);
         newItem = React.cloneElement(item, {
           onClick,
           onKeyDown,
@@ -364,20 +382,21 @@ class MenuContent extends React.Component {
           totalItems,
           index,
           intl: this.props.intl,
-          'aria-describedby': !MenuUtils.isMac() && !this.props.index && this.props.showHeader && index === 0 ? this.menuTopHeaderId : undefined,
+          'aria-describedby': ariaDescribedByHandleValue,
         });
         // If the child has children then it is an item group, so iterate through it's children
       } else if (item.props.children) {
         const children = item.props.children ? [] : undefined;
         React.Children.forEach(item.props.children, (child) => {
           index += 1;
+          const ariaDescribedByHandleValue = this.ariaDescribedByHandle(child, index);
           const clonedElement = React.cloneElement(child, {
             onKeyDown: this.wrapOnKeyDown(child, index, child.props.isDisabled),
             isActive: index === this.state.focusIndex,
             totalItems,
             index,
             intl: this.props.intl,
-            'aria-describedby': !MenuUtils.isMac() && !this.props.index && this.props.showHeader && index === 0 ? this.menuTopHeaderId : undefined,
+            'aria-describedby': ariaDescribedByHandleValue,
           });
           children.push(clonedElement);
         });

--- a/packages/terra-menu/src/_MenuContent.jsx
+++ b/packages/terra-menu/src/_MenuContent.jsx
@@ -344,20 +344,11 @@ class MenuContent extends React.Component {
   }
 
   ariaDescribedByHandle(value, index) {
-    let ariaDescribedByValue;
-    if (MenuUtils.isMac()) {
-      ariaDescribedByValue = value.props.ariaDescribedBy;
+    if (!MenuUtils.isMac() && !this.props.index && this.props.showHeader && index === 0) {
+      const ariaDescribedByValue = (value.props.ariaDescribedBy) ? ` ${value.props.ariaDescribedBy}` : '';
+      return `${this.menuTopHeaderId}${ariaDescribedByValue}`;
     }
-    if (!MenuUtils.isMac()) {
-      if (!this.props.index && this.props.showHeader && index === 0 && value.props.ariaDescribedBy) {
-        ariaDescribedByValue = `${this.menuTopHeaderId} ${value.props.ariaDescribedBy}`;
-      } else if (!this.props.index && this.props.showHeader && index === 0 && value.props.ariaDescribedBy === undefined) {
-        ariaDescribedByValue = this.menuTopHeaderId;
-      } else {
-        ariaDescribedByValue = value.props.ariaDescribedBy;
-      }
-    }
-    return ariaDescribedByValue;
+    return value.props.ariaDescribedBy;
   }
 
   render() {

--- a/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
+++ b/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
@@ -252,6 +252,7 @@ exports[`Menu correctly applies the theme context className 1`] = `
                                 role="menu"
                               >
                                 <li
+                                  aria-describedby="terra-menu-headertitle-00000000-0000-0000-0000-000000000000"
                                   aria-disabled="false"
                                   class="item orion-fusion-theme"
                                   data-terra-menu-interactive-item="true"
@@ -611,6 +612,7 @@ exports[`Menu correctly applies the theme context className 1`] = `
                                                     totalItems={1}
                                                   >
                                                     <li
+                                                      aria-describedby="terra-menu-headertitle-00000000-0000-0000-0000-000000000000"
                                                       aria-disabled={false}
                                                       className="item orion-fusion-theme"
                                                       data-terra-menu-interactive-item={true}

--- a/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
+++ b/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
@@ -252,7 +252,6 @@ exports[`Menu correctly applies the theme context className 1`] = `
                                 role="menu"
                               >
                                 <li
-                                  aria-describedby="terra-menu-headertitle-00000000-0000-0000-0000-000000000000"
                                   aria-disabled="false"
                                   class="item orion-fusion-theme"
                                   data-terra-menu-interactive-item="true"
@@ -612,7 +611,6 @@ exports[`Menu correctly applies the theme context className 1`] = `
                                                     totalItems={1}
                                                   >
                                                     <li
-                                                      aria-describedby="terra-menu-headertitle-00000000-0000-0000-0000-000000000000"
                                                       aria-disabled={false}
                                                       className="item orion-fusion-theme"
                                                       data-terra-menu-interactive-item={true}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
Screen Reader not fetching group name information because we are wrapping group role items within menu role

**What was changed:**
If additional group information text is used, provide a string containing the IDs for html elements that help describe the intent of the group of menu. so added `aria-describedby` attribute in menu items and passing group id to aria-describedby 

**Why it was changed:**
Screen Reader not fetching group name information


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9744 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra


### Before fix

https://github.com/cerner/terra-framework/assets/127083404/46c15e3f-f449-456b-aaeb-0f35ec7b8a91


## After fix

https://github.com/cerner/terra-framework/assets/127083404/981fea85-6551-41c6-9c9c-c83e02f1d8c8


## JAWS response for collapsible-menu and terra-menu
<img width="1099" alt="Screenshot 2023-10-20 at 11 59 16 AM" src="https://github.com/cerner/terra-framework/assets/127083404/fdfe414c-8458-481b-8e43-20ed2ad4f16a">
<img width="1099" alt="Screenshot 2023-10-20 at 11 55 57 AM" src="https://github.com/cerner/terra-framework/assets/127083404/15dcd806-3672-4221-86aa-a4377ec678ea">
<img width="1099" alt="Screenshot 2023-10-20 at 12 10 32 PM" src="https://github.com/cerner/terra-framework/assets/127083404/81a8b0db-8d4e-42da-8def-8f5b32f37f1d">


