### PR TITLE
[terra-tabs] Fixes screen reader response when tabs are closed.

### DIFF
--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed screen reader response when active tabs are closed.
+
 ## 7.11.0 - (October 20, 2023)
 
 * Added

--- a/packages/terra-tabs/src/common-tabs/_Tab.jsx
+++ b/packages/terra-tabs/src/common-tabs/_Tab.jsx
@@ -192,7 +192,7 @@ const Tab = ({
       if (index === 0) {
         element = document.getElementById(tabIds[index + 1]);
       }
-      const ariaLabel = label ? `${label} ${deleteTabLabel}` : '';
+      const ariaLabel = label ? `${label} ${deleteTabLabel}. ${element.title}` : '';
       if (element) {
         element.setAttribute('aria-label', ariaLabel);
         element.focus();

--- a/packages/terra-tabs/src/common-tabs/_Tab.jsx
+++ b/packages/terra-tabs/src/common-tabs/_Tab.jsx
@@ -192,7 +192,7 @@ const Tab = ({
       if (index === 0) {
         element = document.getElementById(tabIds[index + 1]);
       }
-      const ariaLabel = label ? `${label} ${deleteTabLabel}. ${element.title}` : '';
+      const ariaLabel = label ? `${label} ${deleteTabLabel}, ${element.title}` : '';
       if (element) {
         element.setAttribute('aria-label', ariaLabel);
         element.focus();


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Fixes response when tabs are closed.


**Why it was changed:**

Deleted/Closed tab was announced as "tab_name removed, selected....." 


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9765 <!-- Jira Number or issue Number. Please do not link to Jira. -->


Updated response (Same with JAWS and VO)
<img width="1680" alt="Screenshot 2023-10-20 at 6 46 49 PM" src="https://github.com/cerner/terra-framework/assets/40137430/d287fa1b-058e-4eae-92a7-62a0b4d235ac">



---

Thank you for contributing to Terra.
@cerner/terra
