### PR TITLE
Updated package-lock with main.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39471,6 +39471,10 @@
       "resolved": "packages/terra-file-path",
       "link": true
     },
+    "node_modules/terra-folder-tree": {
+      "resolved": "packages/terra-folder-tree",
+      "link": true
+    },
     "node_modules/terra-form-checkbox": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/terra-form-checkbox/-/terra-form-checkbox-4.21.0.tgz",
@@ -39859,6 +39863,10 @@
     },
     "node_modules/terra-slide-panel-manager": {
       "resolved": "packages/terra-slide-panel-manager",
+      "link": true
+    },
+    "node_modules/terra-slider": {
+      "resolved": "packages/terra-slider",
       "link": true
     },
     "node_modules/terra-spacer": {
@@ -43213,7 +43221,7 @@
       }
     },
     "packages/terra-collapsible-menu-view": {
-      "version": "6.82.0",
+      "version": "6.83.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43225,7 +43233,7 @@
         "terra-hyperlink": "^2.61.0",
         "terra-icon": "^3.57.1",
         "terra-list": "^4.0.0",
-        "terra-menu": "^6.78.1",
+        "terra-menu": "^6.79.0",
         "terra-mixins": "^1.0.0",
         "terra-theme-context": "^1.8.0"
       },
@@ -43236,7 +43244,7 @@
       }
     },
     "packages/terra-data-grid": {
-      "version": "0.8.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43379,13 +43387,38 @@
       }
     },
     "packages/terra-file-path": {
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
         "keycode-js": "^3.1.0",
         "prop-types": "^15.5.8",
-        "terra-collapsible-menu-view": "^6.82.0"
+        "terra-collapsible-menu-view": "^6.83.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.22.10",
+        "@babel/core": "^7.22.10",
+        "@babel/preset-react": "^7.22.5",
+        "@cerner/eslint-config-terra": "^5.4.0",
+        "@cerner/jest-config-terra": "^1.5.0",
+        "enzyme-to-json": "^3.6.2",
+        "eslint": "^7.32.0",
+        "jest": "^26.6.3",
+        "stylelint": "^13.13.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5",
+        "react-dom": "^16.8.5",
+        "react-intl": "^2.8.0 || 3 || 4 || 5"
+      }
+    },
+    "packages/terra-folder-tree": {
+      "version": "0.1.1-alpha.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "keycode-js": "^3.1.0",
+        "prop-types": "^15.5.8"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.10",
@@ -43431,7 +43464,7 @@
     },
     "packages/terra-framework-docs": {
       "name": "@cerner/terra-framework-docs",
-      "version": "1.42.0",
+      "version": "1.43.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.7.0",
@@ -43444,15 +43477,16 @@
         "terra-arrange": "^3.53.0",
         "terra-brand-footer": "^3.11.0",
         "terra-button": "^3.3.0",
-        "terra-collapsible-menu-view": "^6.82.0",
+        "terra-collapsible-menu-view": "^6.83.0",
         "terra-content-container": "^3.0.0",
-        "terra-data-grid": "^0.8.1",
+        "terra-data-grid": "^1.0.0",
         "terra-date-input": "^1.46.0",
         "terra-date-picker": "^4.92.0",
         "terra-date-time-picker": "^4.98.0",
         "terra-disclosure-manager": "^4.43.0",
         "terra-embedded-content-consumer": "^3.39.0",
-        "terra-file-path": "^0.3.0",
+        "terra-file-path": "^1.0.0",
+        "terra-folder-tree": "^0.1.1-alpha.0",
         "terra-form-field": "^4.27.0",
         "terra-form-fieldset": "^2.74.0",
         "terra-form-input": "^4.4.0",
@@ -43462,7 +43496,7 @@
         "terra-hookshot": "^5.41.0",
         "terra-infinite-list": "^3.42.0",
         "terra-layout": "^4.38.0",
-        "terra-menu": "^6.78.1",
+        "terra-menu": "^6.79.0",
         "terra-modal-manager": "^6.67.0",
         "terra-navigation-layout": "^5.39.0",
         "terra-navigation-prompt": "^1.77.0",
@@ -43472,10 +43506,11 @@
         "terra-section-header": "^2.0.0",
         "terra-slide-group": "^4.33.0",
         "terra-slide-panel": "^3.46.0",
-        "terra-slide-panel-manager": "^5.82.0",
+        "terra-slide-panel-manager": "^5.83.0",
+        "terra-slider": "^1.0.1",
         "terra-spacer": "^3.59.0",
-        "terra-table": "^5.1.0-alpha.0",
-        "terra-tabs": "^7.11.0",
+        "terra-table": "^5.1.1-alpha.0",
+        "terra-tabs": "^7.11.1",
         "terra-text": "^4.49.0",
         "terra-theme-context": "^1.8.0",
         "terra-theme-provider": "^4.13.0",
@@ -43553,7 +43588,7 @@
       "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
     },
     "packages/terra-menu": {
-      "version": "6.78.1",
+      "version": "6.79.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43750,7 +43785,7 @@
       }
     },
     "packages/terra-slide-panel-manager": {
-      "version": "5.82.0",
+      "version": "5.83.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43761,7 +43796,7 @@
         "terra-slide-panel": "^3.46.0"
       },
       "devDependencies": {
-        "terra-collapsible-menu-view": "^6.82.0"
+        "terra-collapsible-menu-view": "^6.83.0"
       },
       "peerDependencies": {
         "react": "^16.8.5",
@@ -43769,8 +43804,35 @@
         "terra-disclosure-manager": "^4.16.0"
       }
     },
+    "packages/terra-slider": {
+      "version": "1.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "terra-theme-context": "^1.8.0",
+        "terra-visually-hidden-text": "^2.0.0",
+        "uuid": "3.4.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.22.10",
+        "@babel/core": "^7.22.10",
+        "@babel/preset-react": "^7.22.5",
+        "@cerner/eslint-config-terra": "^5.4.0",
+        "@cerner/jest-config-terra": "^1.5.0",
+        "enzyme-to-json": "^3.6.2",
+        "eslint": "^7.32.0",
+        "jest": "^26.6.3",
+        "stylelint": "^13.13.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5",
+        "react-dom": "^16.8.5",
+        "react-intl": "^2.8.0 || 3 || 4 || 5"
+      }
+    },
     "packages/terra-table": {
-      "version": "5.1.0-alpha.0",
+      "version": "5.1.1-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43789,7 +43851,7 @@
       }
     },
     "packages/terra-tabs": {
-      "version": "7.11.0",
+      "version": "7.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43802,7 +43864,7 @@
         "terra-content-container": "^3.0.0",
         "terra-divider": "^3.33.0",
         "terra-icon": "^3.19.0",
-        "terra-menu": "^6.78.1",
+        "terra-menu": "^6.79.0",
         "terra-responsive-element": "^5.0.0",
         "terra-theme-context": "^1.8.0",
         "terra-visually-hidden-text": "^2.36.0",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR updates package-lock so that it is up to date with main.

Note: The build is failing due to an a sub dependency update (https://github.com/cerner/terra-framework/actions/runs/6659718947/job/18099412922?pr=1857). While we haven't been able to identify the dependency yet, we were able to to get it to work with this package-lock.json. 

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [X] Other (please describe below)
- [ ] No tests are needed

The change was tested by running `npm start` to make sure that the project compiles and starts correctly.

![CleanShot 2023-10-26 at 17 05 28](https://github.com/cerner/terra-framework/assets/38024451/8d61c34c-f029-4a0e-a720-db12bfbaf8eb)


### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->



---

Thank you for contributing to Terra.
@cerner/terra
