### PR TITLE
Release for Nov 20, 2023

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43263,13 +43263,13 @@
       }
     },
     "packages/terra-data-grid": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
         "keycode-js": "^3.1.0",
         "prop-types": "^15.5.8",
-        "terra-table": "^5.1.1-alpha.1",
+        "terra-table": "^5.1.1-alpha.2",
         "terra-visually-hidden-text": "^2.36.0"
       },
       "devDependencies": {
@@ -43485,7 +43485,7 @@
     },
     "packages/terra-framework-docs": {
       "name": "@cerner/terra-framework-docs",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.7.0",
@@ -43501,7 +43501,7 @@
         "terra-collapsible-menu-view": "^6.84.0",
         "terra-compact-interactive-list": "^0.1.0",
         "terra-content-container": "^3.0.0",
-        "terra-data-grid": "^1.1.0",
+        "terra-data-grid": "^1.2.0",
         "terra-date-input": "^1.46.0",
         "terra-date-picker": "^4.93.0",
         "terra-date-time-picker": "^4.99.0",
@@ -43529,9 +43529,9 @@
         "terra-slide-group": "^4.33.0",
         "terra-slide-panel": "^3.46.0",
         "terra-slide-panel-manager": "^5.84.0",
-        "terra-slider": "^1.1.0",
+        "terra-slider": "^1.1.1",
         "terra-spacer": "^3.59.0",
-        "terra-table": "^5.1.1-alpha.1",
+        "terra-table": "^5.1.1-alpha.2",
         "terra-tabs": "^7.11.2",
         "terra-text": "^4.49.0",
         "terra-theme-context": "^1.8.0",
@@ -43827,7 +43827,7 @@
       }
     },
     "packages/terra-slider": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43854,7 +43854,7 @@
       }
     },
     "packages/terra-table": {
-      "version": "5.1.1-alpha.1",
+      "version": "5.1.1-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/packages/terra-data-grid/CHANGELOG.md
+++ b/packages/terra-data-grid/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.2.0 - (November 20, 2023)
+
 * Fixed
   * Fixed issue where focus was given to the column header instead of its button element.
   * Fixed issue where row selection was being announced twice in Worklist Data Grid.

--- a/packages/terra-data-grid/package.json
+++ b/packages/terra-data-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-data-grid",
   "main": "lib/index.js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Package containing data grid container components that enable users to navigate the grid information using directional navigation keys.",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "classnames": "^2.2.5",
     "keycode-js": "^3.1.0",
     "prop-types": "^15.5.8",
-    "terra-table": "^5.1.1-alpha.1",
+    "terra-table": "^5.1.1-alpha.2",
     "terra-visually-hidden-text": "^2.36.0"
   },
   "devDependencies": {

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.45.0 - (November 20, 2023)
+
 * Added
   * Added example to `terra-table` to show column states and sorting;
   * Added new test for Terra Slider component for long field labels.

--- a/packages/terra-framework-docs/package.json
+++ b/packages/terra-framework-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-framework-docs",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "description": "Contains documentation for packages in the terra-framework monorepo",
   "main": "index.js",
   "publishConfig": {
@@ -44,7 +44,7 @@
     "terra-collapsible-menu-view": "^6.84.0",
     "terra-compact-interactive-list": "^0.1.0",
     "terra-content-container": "^3.0.0",
-    "terra-data-grid": "^1.1.0",
+    "terra-data-grid": "^1.2.0",
     "terra-date-input": "^1.46.0",
     "terra-date-picker": "^4.93.0",
     "terra-date-time-picker": "^4.99.0",
@@ -72,9 +72,9 @@
     "terra-slide-group": "^4.33.0",
     "terra-slide-panel": "^3.46.0",
     "terra-slide-panel-manager": "^5.84.0",
-    "terra-slider": "^1.1.0",
+    "terra-slider": "^1.1.1",
     "terra-spacer": "^3.59.0",
-    "terra-table": "^5.1.1-alpha.1",
+    "terra-table": "^5.1.1-alpha.2",
     "terra-tabs": "^7.11.2",
     "terra-text": "^4.49.0",
     "terra-theme-context": "^1.8.0",

--- a/packages/terra-slider/CHANGELOG.md
+++ b/packages/terra-slider/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+
+## 1.1.1 - (November 20, 2023)
+
 * Fix
   * Fixed wrapping issue for min/max labels on slider.
 

--- a/packages/terra-slider/package.json
+++ b/packages/terra-slider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-slider",
   "main": "lib/Slider.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Terra Slider component provides users a way to select a value from a given range by sliding a thumb along a bar to track the value.",
   "repository": {
     "type": "git",

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 5.1.1-alpha.2 - (November 20, 2023)
+
 * Breaking Changes
   * Renamed `hasColumnHeaders` prop to `hasVisibleColumnHeaders`.
 

--- a/packages/terra-table/package.json
+++ b/packages/terra-table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-table",
   "main": "lib/index.js",
-  "version": "5.1.1-alpha.1",
+  "version": "5.1.1-alpha.2",
   "description": "The Terra Table component provides user a way to display data in an accessible table format.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary

The following packages will be released:

  - terra-data-grid@1.2.0
  - @cerner/terra-framework-docs@1.45.0
  - terra-slider@1.1.1
  - terra-table@5.1.1-alpha.2

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

---

Thank you for contributing to Terra.
@cerner/terra
