### PR TITLE
[terra-table] Remove Console Warning Message when No Pinned Columns

### DIFF
--- a/packages/terra-data-grid/CHANGELOG.md
+++ b/packages/terra-data-grid/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Removed console warning message when no pinned columns exist.
+
 ## 1.5.0 - (December 1, 2023)
 
 * Changed

--- a/packages/terra-data-grid/src/utils/constants.js
+++ b/packages/terra-data-grid/src/utils/constants.js
@@ -1,7 +1,0 @@
-const ERRORS = {};
-ERRORS.ROW_HEADER_INDEX_EXCEEDS_PINNED = 'Prop rowHeaderIndex exceeds the size of pinnedColumns.';
-ERRORS.ROW_HEADER_INDEX_LESS_THAN_ZERO = 'Prop rowHeaderIndex must be a positive integer.';
-ERRORS.ROW_HEADER_INDEX_NOT_AN_INTEGER = 'Prop rowHeaderIndex must be an integer.';
-ERRORS.PINNED_COLUMNS_UNDEFINED = 'To be properly accessible, the row header column should be a pinned column. please set pinned columns';
-
-export default ERRORS;

--- a/packages/terra-data-grid/tests/jest/DataGrid.test.jsx
+++ b/packages/terra-data-grid/tests/jest/DataGrid.test.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
-import { mountWithIntl, shallowWithIntl } from 'terra-enzyme-intl';
+import { mountWithIntl } from 'terra-enzyme-intl';
 import { v4 as uuidv4 } from 'uuid';
 import DataGrid from '../../src/DataGrid';
-import ERRORS from '../../src/utils/constants';
 
 // Source data for tests
 const dataFile = {
@@ -244,46 +243,5 @@ describe('with pinned columns', () => {
     const pinnedColumnHeaderCells = wrapper.find('.pinned');
 
     expect(pinnedColumnHeaderCells).toHaveLength(1 * (dataFile.rows.length + 1));
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(ERRORS.PINNED_COLUMNS_UNDEFINED)); // eslint-disable-line no-console
-  });
-});
-
-describe('Error handling - prop types', () => {
-  it('throws an error if rowHeaderIndex is not an integer', () => {
-    shallowWithIntl(
-      <DataGrid
-        id="test-terra-data-grid"
-        rows={dataFile.rows}
-        rowHeaderIndex="2"
-      />,
-    );
-
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining(ERRORS.ROW_HEADER_INDEX_NOT_AN_INTEGER)); // eslint-disable-line no-console
-  });
-
-  it('throws an error if rowHeaderIndex is not a positive integer', () => {
-    shallowWithIntl(
-      <DataGrid
-        id="test-terra-data-grid"
-        rows={dataFile.rows}
-        rowHeaderIndex={-1}
-      />,
-    );
-
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining(ERRORS.ROW_HEADER_INDEX_LESS_THAN_ZERO)); // eslint-disable-line no-console
-  });
-
-  it('throws an error if rowHeaderIndex is greater than the length of pinned columns', () => {
-    shallowWithIntl(
-      <DataGrid
-        id="test-terra-data-grid"
-        pinnedColumns={dataFile.cols.slice(0, 2)}
-        overflowColumns={dataFile.cols.slice(2)}
-        rowHeaderIndex={2}
-        rows={dataFile.rows}
-      />,
-    );
-
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining(ERRORS.ROW_HEADER_INDEX_EXCEEDS_PINNED)); // eslint-disable-line no-console
   });
 });

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Removed console warning message when no pinned columns exist.
+
 ## 5.2.1 - (December 1, 2023)
 
 * Fixed

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -13,7 +13,6 @@ import Section from './subcomponents/Section';
 import ColumnHeader from './subcomponents/ColumnHeader';
 import ColumnContext from './utils/ColumnContext';
 import columnShape from './proptypes/columnShape';
-import ERRORS from './utils/constants';
 import GridContext, { GridConstants } from './utils/GridContext';
 import rowShape from './proptypes/rowShape';
 import validateRowHeaderIndex from './proptypes/validators';
@@ -207,11 +206,6 @@ function Table(props) {
     rowHeaderIndex,
     intl,
   } = props;
-
-  if (pinnedColumns.length === 0) {
-    // eslint-disable-next-line no-console
-    console.warn(ERRORS.PINNED_COLUMNS_UNDEFINED);
-  }
 
   // Manage column resize
   const [tableHeight, setTableHeight] = useState(0);

--- a/packages/terra-table/src/utils/constants.js
+++ b/packages/terra-table/src/utils/constants.js
@@ -2,7 +2,6 @@ const ERRORS = {
   ROW_HEADER_INDEX_EXCEEDS_PINNED: 'Prop rowHeaderIndex exceeds the size of pinnedColumns.',
   ROW_HEADER_INDEX_LESS_THAN_ZERO: 'Prop rowHeaderIndex must be a positive integer.',
   ROW_HEADER_INDEX_NOT_AN_INTEGER: 'Prop rowHeaderIndex must be an integer.',
-  PINNED_COLUMNS_UNDEFINED: 'To be properly accessible, the row header column should be a pinned column. please set pinned columns',
 };
 
 export default ERRORS;

--- a/packages/terra-table/tests/jest/Table.test.jsx
+++ b/packages/terra-table/tests/jest/Table.test.jsx
@@ -474,7 +474,6 @@ describe('with pinned columns', () => {
     const pinnedColumnHeaderCells = wrapper.find('.pinned');
 
     expect(pinnedColumnHeaderCells).toHaveLength(1 * (tableData.rows.length + 1));
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(ERRORS.PINNED_COLUMNS_UNDEFINED)); // eslint-disable-line no-console
   });
 });
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
The console messages that triggered when no pinned columns were defined were removed.

**Why it was changed:**
Several use cases were identified where pinned columns were not required.  The console warnings were confusing consumers and making code maintenance difficult.  The warnings introduce error fatigue and errors were being missed in the development process.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [X] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-9904 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
