### PR TITLE
[terra-table] Export Row Selection Column Width

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added documentation for exported constants of `terra-table` in the About page.
+
 ## 1.49.0 - (December 1, 2023)
 
 * Added

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/table/About.1.doc.mdx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/table/About.1.doc.mdx
@@ -77,6 +77,20 @@ import Table from "terra-table";
 
 <TablePropsTable />
 
+### Table Constants
+Enumeration: TableConstants
+
+|Constant|Type|Description|
+|---|---|---|
+|**ROW_SELECTION_COLUMN_WIDTH**|number|The width of the row selection column.|
+
+Enumeration: RowSelectionModes
+
+|Constant|Type|Description|
+|---|---|---|
+|**SINGLE**|string|Single row selection mode|
+|**MULTIPLE**|string|Multiple row selection mode|
+
 ### Column
 A column specifies the data to render a cell in the header row of the Worklist Data Grid.
 

--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Exported the row selection column width via the `TableConstants.ROW_SELECTION_COLUMN_WIDTH`` constant.
+
 ## 5.2.1 - (December 1, 2023)
 
 * Fixed

--- a/packages/terra-table/src/Table.jsx
+++ b/packages/terra-table/src/Table.jsx
@@ -24,9 +24,13 @@ import getFocusableElements from './utils/focusManagement';
 
 const cx = classNames.bind(styles);
 
-export const rowSelectionModes = {
+const RowSelectionModes = {
   SINGLE: 'single',
   MULTIPLE: 'multiple',
+};
+
+const TableConstants = {
+  ROW_SELECTION_COLUMN_WIDTH: 40,
 };
 
 const propTypes = {
@@ -146,7 +150,7 @@ const propTypes = {
    * Enables row selection capabilities for the table.
    * Use 'single' for single row selection and 'multiple' for multi-row selection.
    */
-  rowSelectionMode: PropTypes.oneOf(Object.values(rowSelectionModes)),
+  rowSelectionMode: PropTypes.oneOf(Object.values(RowSelectionModes)),
 
   /**
    * Boolean indicating whether or not the table columns should be displayed. Setting the value to false will hide the columns,
@@ -252,14 +256,14 @@ function Table(props) {
   // Create row selection column object
   const tableRowSelectionColumn = {
     id: 'table-rowSelectionColumn',
-    width: 40,
+    width: TableConstants.ROW_SELECTION_COLUMN_WIDTH,
     displayName: intl.formatMessage({ id: 'Terra.table.row-selection-header-display' }),
     isDisplayVisible: false,
     isSelectable: !!onRowSelectionHeaderSelect,
     isResizable: false,
   };
 
-  const hasSelectableRows = rowSelectionMode === rowSelectionModes.MULTIPLE;
+  const hasSelectableRows = rowSelectionMode === RowSelectionModes.MULTIPLE;
   const displayedColumns = (hasSelectableRows ? [tableRowSelectionColumn] : []).concat(pinnedColumns).concat(overflowColumns);
   const [tableColumns, setTableColumns] = useState(displayedColumns.map((column) => initializeColumn(column)));
 
@@ -312,7 +316,7 @@ function Table(props) {
     }
 
     // Since the row selection mode has changed, the row selection mode needs to be updated.
-    setRowSelectionModeAriaLiveMessage(intl.formatMessage({ id: rowSelectionMode === rowSelectionModes.MULTIPLE ? 'Terra.table.row-selection-mode-enabled' : 'Terra.table.row-selection-mode-disabled' }));
+    setRowSelectionModeAriaLiveMessage(intl.formatMessage({ id: rowSelectionMode === RowSelectionModes.MULTIPLE ? 'Terra.table.row-selection-mode-enabled' : 'Terra.table.row-selection-mode-disabled' }));
 
     setTableColumns(displayedColumns.map((column) => initializeColumn(column)));
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -607,3 +611,4 @@ Table.propTypes = propTypes;
 Table.defaultProps = defaultProps;
 
 export default React.memo(injectIntl(Table));
+export { TableConstants, RowSelectionModes };

--- a/packages/terra-table/src/index.js
+++ b/packages/terra-table/src/index.js
@@ -1,4 +1,4 @@
-import Table from './Table';
+import Table, { TableConstants } from './Table';
 import GridContext, { GridConstants } from './utils/GridContext';
 import cellShape from './proptypes/cellShape';
 import columnShape from './proptypes/columnShape';
@@ -8,5 +8,5 @@ import validateRowHeaderIndex from './proptypes/validators';
 
 export default Table;
 export {
-  GridContext, GridConstants, cellShape, columnShape, rowShape, sectionShape, validateRowHeaderIndex,
+  GridContext, GridConstants, TableConstants, cellShape, columnShape, rowShape, sectionShape, validateRowHeaderIndex,
 };


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
The row selection column width was exported for the Terra Table.

**Why it was changed:**
Consumers needed to adjust their container by the width of the column when the column was made visible.  The constant provides a means to supply this value to consumers.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [X] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
N/A

**This PR resolves:**

UXPLATFORM-9913 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
