### PR TITLE
[terra-folder-tree] Update cursor style for interactable regions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44234,7 +44234,7 @@
       }
     },
     "packages/terra-table": {
-      "version": "5.2.1",
+      "version": "5.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/packages/terra-folder-tree/CHANGELOG.md
+++ b/packages/terra-folder-tree/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated cursor style to pointer for clickable regions.
+
 ## 1.0.0-alpha.2 - (December 5, 2023)
 
 * Added

--- a/packages/terra-folder-tree/src/subcomponents/FolderTreeItem.jsx
+++ b/packages/terra-folder-tree/src/subcomponents/FolderTreeItem.jsx
@@ -98,10 +98,16 @@ const FolderTreeItem = ({
     cx(
       'folder-tree-item',
       { selected: isSelected },
-      { folder: isFolder },
       theme.className,
     ),
   );
+
+  const handleRadioButtonClick = (event) => {
+    // Stop click propagation to prevent triggering expand/collapse when selecting folders
+    event.stopPropagation();
+
+    onClick();
+  };
 
   return (
     <>
@@ -110,15 +116,17 @@ const FolderTreeItem = ({
         role="treeitem"
         aria-expanded={isFolder ? isExpanded : null}
         aria-selected={isSelected}
-        onClick={onToggle}
-        onKeyDown={onToggle}
+        onClick={isFolder ? onToggle : onClick}
+        onKeyDown={isFolder ? onToggle : onClick}
       >
         <input
           type="radio"
           checked={isSelected}
           onChange={onClick}
+          onClick={handleRadioButtonClick}
           aria-hidden // Hiding the radio button from assistive technology since they cannot be grouped correctly
           tabIndex={-1} // Prevent tabbing to the button since it should not be read or acknowledged by assistive technology
+          className={cx('radio')}
         />
         {/* eslint-disable-next-line react/forbid-dom-props */}
         <span style={{ paddingLeft: `${level}rem` }}>

--- a/packages/terra-folder-tree/src/subcomponents/FolderTreeItem.module.scss
+++ b/packages/terra-folder-tree/src/subcomponents/FolderTreeItem.module.scss
@@ -15,11 +15,8 @@
   
     &:hover {
       background-color: var(--terra-folder-tree-item-hover-background-color, #f4fafe);
+      cursor: pointer;
     }
-  }
-  
-  .folder:hover {
-    cursor: pointer;
   }
 
   .selected {
@@ -30,5 +27,9 @@
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  .radio:hover {
+    cursor: pointer;
   }
 }

--- a/packages/terra-folder-tree/tests/jest/FolderTree.test.jsx
+++ b/packages/terra-folder-tree/tests/jest/FolderTree.test.jsx
@@ -82,4 +82,26 @@ describe('basic folder tree', () => {
     expect(expandedFolder.find('.folder-tree-item').prop('aria-expanded')).toBe(true);
     expect(expandedFolder.find('.subfolder').prop('hidden')).toBe(false);
   });
+
+  it('does not trigger expand/collapse on folder selection', () => {
+    const onClick = jest.fn();
+    const onToggle = jest.fn();
+
+    const wrapper = shallowWithIntl(
+      <FolderTreeItem
+        label="Animals"
+        onClick={onClick}
+        onToggle={onToggle}
+        subfolderItems={[
+          (<FolderTreeItem label="Dog" />),
+        ]}
+      />,
+    ).dive();
+
+    const radioButton = wrapper.find('.radio');
+    radioButton.simulate('click', { stopPropagation: () => {} });
+
+    expect(onClick).toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
 });

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated examples and tests for `terra-folder-tree`.
+
 ## 1.50.0 - (December 5, 2023)
 
 * Added

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/folder-tree/Examples.2/ExpandCollapseFolderTree.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/folder-tree/Examples.2/ExpandCollapseFolderTree.jsx
@@ -16,6 +16,10 @@ const ExpandCollapseFolderTree = () => {
     'projects-4': false,
   });
 
+  const handleSelect = (key) => {
+    setSelectedKey(key);
+  };
+
   const handleExpandCollapseKeys = (key) => {
     const newExpandedKeys = {
       ...expandedKeys,
@@ -35,7 +39,7 @@ const ExpandCollapseFolderTree = () => {
           key="projects"
           isSelected={selectedKey === 'projects'}
           isExpanded={expandedKeys.projects}
-          onClick={() => { setSelectedKey('projects'); }}
+          onClick={() => { handleSelect('projects'); }}
           onToggle={() => { handleExpandCollapseKeys('projects'); }}
           subfolderItems={[
             <FolderTree.Item
@@ -43,7 +47,7 @@ const ExpandCollapseFolderTree = () => {
               key="projects-2"
               isSelected={selectedKey === 'projects-2'}
               isExpanded={expandedKeys['projects-2']}
-              onClick={() => { setSelectedKey('projects-2'); handleExpandCollapseKeys('projects-2'); }}
+              onClick={() => { handleSelect('projects-2'); }}
               onToggle={() => { handleExpandCollapseKeys('projects-2'); }}
               subfolderItems={[
                 <FolderTree.Item
@@ -51,7 +55,7 @@ const ExpandCollapseFolderTree = () => {
                   key="projects-3"
                   isSelected={selectedKey === 'projects-3'}
                   isExpanded={expandedKeys['projects-3']}
-                  onClick={() => { setSelectedKey('projects-3'); handleExpandCollapseKeys('projects-3'); }}
+                  onClick={() => { handleSelect('projects-3'); }}
                   onToggle={() => { handleExpandCollapseKeys('projects-3'); }}
                   subfolderItems={[
                     <FolderTree.Item
@@ -59,7 +63,7 @@ const ExpandCollapseFolderTree = () => {
                       key="projects-4"
                       isSelected={selectedKey === 'projects-4'}
                       isExpanded={expandedKeys['projects-4']}
-                      onClick={() => { setSelectedKey('projects-4'); handleExpandCollapseKeys('projects-4'); }}
+                      onClick={() => { handleSelect('projects-4'); }}
                       onToggle={() => { handleExpandCollapseKeys('projects-4'); }}
                       subfolderItems={[
                         <FolderTree.Item

--- a/packages/terra-framework-docs/src/terra-dev-site/test/folder-tree/ExpandCollapseFolderTree.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/folder-tree/ExpandCollapseFolderTree.test.jsx
@@ -10,6 +10,10 @@ const ExpandCollapseFolderTree = () => {
     'projects-4': false,
   });
 
+  const handleSelect = (key) => {
+    setSelectedKey(key);
+  };
+
   const handleExpandCollapseKeys = (key) => {
     const newExpandedKeys = {
       ...expandedKeys,
@@ -29,7 +33,7 @@ const ExpandCollapseFolderTree = () => {
           key="projects"
           isSelected={selectedKey === 'projects'}
           isExpanded={expandedKeys.projects}
-          onClick={() => { setSelectedKey('projects'); }}
+          onClick={() => { handleSelect('projects'); }}
           onToggle={() => { handleExpandCollapseKeys('projects'); }}
           subfolderItems={[
             <FolderTree.Item
@@ -37,7 +41,7 @@ const ExpandCollapseFolderTree = () => {
               key="projects-2"
               isSelected={selectedKey === 'projects-2'}
               isExpanded={expandedKeys['projects-2']}
-              onClick={() => { setSelectedKey('projects-2'); handleExpandCollapseKeys('projects-2'); }}
+              onClick={() => { handleSelect('projects-2'); }}
               onToggle={() => { handleExpandCollapseKeys('projects-2'); }}
               subfolderItems={[
                 <FolderTree.Item
@@ -45,7 +49,7 @@ const ExpandCollapseFolderTree = () => {
                   key="projects-3"
                   isSelected={selectedKey === 'projects-3'}
                   isExpanded={expandedKeys['projects-3']}
-                  onClick={() => { setSelectedKey('projects-3'); handleExpandCollapseKeys('projects-3'); }}
+                  onClick={() => { handleSelect('projects-3'); }}
                   onToggle={() => { handleExpandCollapseKeys('projects-3'); }}
                   subfolderItems={[
                     <FolderTree.Item
@@ -53,7 +57,7 @@ const ExpandCollapseFolderTree = () => {
                       key="projects-4"
                       isSelected={selectedKey === 'projects-4'}
                       isExpanded={expandedKeys['projects-4']}
-                      onClick={() => { setSelectedKey('projects-4'); handleExpandCollapseKeys('projects-4'); }}
+                      onClick={() => { handleSelect('projects-4'); }}
                       onToggle={() => { handleExpandCollapseKeys('projects-4'); }}
                       subfolderItems={[
                         <FolderTree.Item


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This change updates the cursor style for folder tree rows to be a pointer so that there is a visual cue that the regions are clickable. This also updates the selection behavior so that folder rows can only be selected by the radio button and clicking anywhere else on the row will toggle expand/collapse, and non-folder rows can be selected by clicking anywhere in the row.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9978 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
