### PR TITLE
[terra-framework-docs] Update prefix for examples, tests, and remove redundant XFC Provider initialization for terra-embedded-content-consumer

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Changed
+  * Updated path prefix to include `/terra-framework/` and remove redundant XFC Provider initialization for the examples and tests in `terra-embedded-content-consumer`.
 
 ## 1.50.0 - (December 5, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/BasicConsumer.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/BasicConsumer.jsx
@@ -6,7 +6,9 @@ import '../providers/EmbeddedContentConsumerCommon.module.scss';
 Consumer.init();
 const BasicConsumer = () => (
   <EmbeddedContentConsumer
-    src="../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider"
+    // Use `../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+    // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+    src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider"
     title="Basic content example"
     options={{ resizeConfig: { scrolling: true, fixedHeight: '200px' } }}
   />

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/BasicConsumerWithScrolling.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/BasicConsumerWithScrolling.jsx
@@ -7,7 +7,9 @@ Consumer.init();
 
 const BasicConsumerWithScrolling = () => (
   <EmbeddedContentConsumer
-    src="../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider-with-scrolling"
+    // Use `../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+    // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+    src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider-with-scrolling"
     title="Basic content example of scrolling is enabled"
     options={{
       resizeConfig: { scrolling: true, fixedWidth: '100%', fixedHeight: '120px' },

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/CustomEventConsumer.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/CustomEventConsumer.jsx
@@ -15,7 +15,9 @@ const eventHandlers = [{
 const CustomEventConsumer = () => (
   <div id="CustomEvent">
     <EmbeddedContentConsumer
-      src="../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-event-provider"
+      // Use `../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+      // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+      src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-event-provider"
       title="Custom Event Example"
       eventHandlers={eventHandlers}
     />

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/CustomEventsConsumer.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/CustomEventsConsumer.jsx
@@ -43,7 +43,9 @@ class CustomEventsConsumer extends React.Component {
     return (
       <div id="CustomEvents">
         <EmbeddedContentConsumer
-          src="../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-events-provider"
+          // Use `../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+          // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+          src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-events-provider"
           title="Custom events example"
           options={{ iframeAttrs: { id: 'custom-events-consumer-frame' } }}
           onMount={this.onMount}

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/DataStatusConsumer.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/example/DataStatusConsumer.jsx
@@ -40,7 +40,9 @@ const onAuthorize = () => {
 
 const DataStatusConsumer = () => (
   <EmbeddedContentConsumer
-    src="../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/data-status-provider"
+    // Use `../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+    // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+    src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/data-status-provider"
     onMount={onMount}
     onLaunch={onLaunch}
     onAuthorize={onAuthorize}

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/BasicProvider.provider.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/BasicProvider.provider.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import { Provider } from 'xfc';
 import classNames from 'classnames/bind';
 import ProviderTestTemplate from 'terra-embedded-content-consumer/lib/EmbeddedContentProviderTestTemplate';
 import styles from './EmbeddedContentConsumerCommon.module.scss';
 
 const cx = classNames.bind(styles);
-
-Provider.init({
-  acls: ['*'],
-  secret: () => (Promise.resolve('Success')),
-});
 
 const BasicProvider = () => (
   <ProviderTestTemplate>

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/BasicProviderWithScrolling.provider.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/BasicProviderWithScrolling.provider.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import { Provider } from 'xfc';
 import classNames from 'classnames/bind';
 import ProviderTestTemplate from 'terra-embedded-content-consumer/lib/EmbeddedContentProviderTestTemplate';
 import styles from './EmbeddedContentConsumerCommon.module.scss';
 
 const cx = classNames.bind(styles);
-
-Provider.init({
-  acls: ['*'],
-  secret: () => (Promise.resolve('Success')),
-});
 
 const BasicProviderWithScrolling = () => (
   <ProviderTestTemplate>

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/CustomEventProvider.provider.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/CustomEventProvider.provider.jsx
@@ -6,11 +6,6 @@ import styles from './EmbeddedContentConsumerCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-Provider.init({
-  acls: ['*'],
-  secret: () => (Promise.resolve('Success')),
-});
-
 class EmbeddedContent extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/CustomEventsProvider.provider.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/CustomEventsProvider.provider.jsx
@@ -6,11 +6,6 @@ import styles from './EmbeddedContentConsumerCommon.module.scss';
 
 const cx = classNames.bind(styles);
 
-Provider.init({
-  acls: ['*'],
-  secret: () => (Promise.resolve('Success')),
-});
-
 class EmbeddedContent extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/DataStatusProvider.provider.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/embedded-content-consumer/providers/DataStatusProvider.provider.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import { Provider } from 'xfc';
 import classNames from 'classnames/bind';
 import ProviderTestTemplate from 'terra-embedded-content-consumer/lib/EmbeddedContentProviderTestTemplate';
 import styles from './EmbeddedContentConsumerCommon.module.scss';
 
 const cx = classNames.bind(styles);
-
-Provider.init({
-  acls: ['*'],
-  secret: () => (Promise.resolve('Success')),
-});
 
 const DataStatusProvider2 = () => (
   <ProviderTestTemplate>

--- a/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/BasicConsumer.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/BasicConsumer.test.jsx
@@ -13,7 +13,9 @@ const BasicConsumer = () => (
     <h2>Embedded Content</h2>
     <p>The following is an embedded content within an iframe.</p>
     <EmbeddedContentConsumer
-      src="../../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider"
+      // Use `../../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+      // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+      src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider"
       className={cx('iframe')}
       options={{ iframeAttrs: { id: 'basic-consumer-frame' }, resizeConfig: { scrolling: true, fixedWidth: '100%', fixedHeight: '200px' } }}
       title="Basic Consumer"

--- a/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/BasicConsumerWithNoScrolling.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/BasicConsumerWithNoScrolling.test.jsx
@@ -13,7 +13,9 @@ const BasicConsumerWithNoScrolling = () => (
     <h2>Embedded Content</h2>
     <p>The following is an embedded content within an iframe, no scrolling.</p>
     <EmbeddedContentConsumer
-      src="../../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider"
+      // Use `../../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+      // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+      src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider"
       className={cx('iframe')}
       options={{ iframeAttrs: { id: 'basic-consumer-frame' }, resizeConfig: { scrolling: false, fixedWidth: '100%', fixedHeight: '200px' } }}
       title="Basic Consumer"

--- a/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/BasicConsumerWithScrolling.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/BasicConsumerWithScrolling.test.jsx
@@ -13,7 +13,9 @@ const BasicConsumerWithScrolling = () => (
     <h2>Embedded Content</h2>
     <p>The following is an embedded content within an iframe.</p>
     <EmbeddedContentConsumer
-      src="../../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider-with-scrolling"
+      // Use `../../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+      // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+      src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/basic-provider-with-scrolling"
       className={cx('iframe')}
       title="Basic Consumer with Scrolling"
       options={{

--- a/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/CustomEventConsumer.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/CustomEventConsumer.test.jsx
@@ -21,7 +21,9 @@ const CustomEventConsumer = () => (
     <p>The following is an embedded content within an iframe.</p>
     <div id="CustomEvent">
       <EmbeddedContentConsumer
-        src="../../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-event-provider"
+        // Use `../../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+        // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+        src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-event-provider"
         className={cx('iframe')}
         eventHandlers={eventHandlers}
         title="Basic Consumer"

--- a/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/CustomEventsConsumer.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/CustomEventsConsumer.test.jsx
@@ -49,7 +49,9 @@ class CustomEventsConsumer extends React.Component {
         <p>The following is an embedded content within an iframe.</p>
         <div id="CustomEvents">
           <EmbeddedContentConsumer
-            src="../../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-events-provider"
+            // Use `../../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+            // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+            src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/custom-events-provider"
             className={cx('iframe')}
             title="Custom events example"
             options={{ iframeAttrs: { id: 'custom-events-consumer-frame' }, resizeConfig: { scrolling: true } }}

--- a/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/DataStatusConsumer.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/embedded-content-consumer/consumers/DataStatusConsumer.test.jsx
@@ -46,7 +46,9 @@ const DataStatusConsumer = () => (
     <h2>Embedded Content</h2>
     <p>The following is an embedded content within an iframe.</p>
     <EmbeddedContentConsumer
-      src="../../../../#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/data-status-provider"
+      // Use `../../../../` prefix if there is any changes to the providers file so we can see changes during the PR-preview build.
+      // Otherwise, keep the existing `/terra-framework/` prefix so the page will load when viewing the live site under /terra-ui and /terra-framework.
+      src="/terra-framework/#/raw/provider/cerner-terra-framework-docs/embedded-content-consumer/providers/data-status-provider"
       className={cx('iframe')}
       onMount={onMount}
       onLaunch={onLaunch}


### PR DESCRIPTION

<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

Update prefix for examples, tests, and remove redundant XFC Provider initialization for terra-embedded-content-consumer

**What was changed:**
Update prefix for examples, tests, and remove redundant XFC Provider initialization for terra-embedded-content-consumer

**Why it was changed:**
- In order to correct file not found when viewing the examples and tests in terra-embedded-content-consumer
- Remove redundant XFC Provider initialization in the providers


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9772  <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
