### PR TITLE
[terra-notification-dialog] Fixed Runtime exception due to invalid action props.

### DIFF
--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+ * Added check to throw error when invalid data type is used for action buttons.
+
 ## 4.37.0 - (December 11, 2023)
 
 * Changed

--- a/packages/terra-notification-dialog/src/NotificationDialog.jsx
+++ b/packages/terra-notification-dialog/src/NotificationDialog.jsx
@@ -159,7 +159,7 @@ const NotificationDialog = (props) => {
     ...customProps
   } = props;
 
-  if (acceptAction === undefined && rejectAction === undefined) {
+  if ((typeof acceptAction !== 'object' && typeof rejectAction !== 'object') || (acceptAction === undefined && rejectAction === undefined)) {
     throw new Error('Either the `acceptAction` or `rejectAction` props must be provided for Notification dialog');
   }
 


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Fixed condition to throw an error when consumers pass wrong prop type and empty values for `acceptAction` and `rejectAction props`.

**What was changed:**

Consumers were running into runtime exceptions while passing empty strings to the 2 props above.

**Why it was changed:**

Added check to throw an error if invalid prop type and/or empty values are passed.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10081 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
