### PR TITLE
removed the banner

### DIFF
--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Updated cell selection.
 
 * Added
-  * Added `isSelectable`` prop to column shape.
+  * Added `isSelectable` prop to column shape.
 
 ## 1.0.0-alpha.4 - (December 18, 2023)
 

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-* Updated
+* Changed
   * Updated `terra-time-input` example to have visual label.
-  * Updated `terra-compact-interactive-list` examples.
+  * Updated `terra-compact-interactive-list` implementation guide and examples.
 
 ## 1.53.0 - (December 18, 2023)
 
@@ -16,7 +16,6 @@
 * Changed
   * Updated examples and tests for expand all/collapse all for `terra-folder-tree`.
   * Updated `terra-theme-provider` examples to show the new ability to specify a theme density.
-  * Updated `terra-compact-interactive-list` implementation guide and examples.
   
 ## 1.52.0 - (December 13, 2023)
 

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Updated
   * Updated `terra-time-input` example to have visual label.
+  * Updated `terra-compact-interactive-list` examples.
 
 ## 1.53.0 - (December 18, 2023)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/About.1.doc.mdx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/About.1.doc.mdx
@@ -16,9 +16,6 @@ import CompactInteractiveListPropsTable from 'terra-compact-interactive-list/src
 * [Terra Standards](/components/cerner-terra-framework-docs/compact-interactive-list/about#terra-standards)
 
 ## Overview
-<Notice variant="important" ariaLevel="2">
-The Terra Compact Interactive List component is currently under alpha release. Breaking changes can occur between releases until it is stable with the 1.0 release.
-</Notice>
 
 The Terra Compact Interactive List component provides a way to render a collection of interactive information in a list format that has a single tab stop. You can arrange the list in columns to fit a wide space, and the user can move between them with the arrow keys.
 


### PR DESCRIPTION
### Summary
This PR:

1. Removes the "compact interactive list is under alpha release" banner. 
2. Adds a CHANGELOG entry for the previously made changes to the `terra-framework-docs`.
3. Corrects a typo in the CHANGELOG in `terra-compact-list`.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [X] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review
