### PR TITLE
Release for January 2nd, 2024

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43613,7 +43613,7 @@
       }
     },
     "packages/terra-compact-interactive-list": {
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43629,7 +43629,7 @@
       }
     },
     "packages/terra-data-grid": {
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43648,7 +43648,7 @@
       }
     },
     "packages/terra-date-input": {
-      "version": "1.47.0",
+      "version": "1.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43658,7 +43658,7 @@
         "terra-icon": "^3.19.0",
         "terra-mixins": "^1.0.0",
         "terra-theme-context": "^1.9.0",
-        "terra-time-input": "^4.59.0",
+        "terra-time-input": "^4.60.0",
         "terra-visually-hidden-text": "^2.0.0",
         "uuid": "3.4.0"
       },
@@ -43701,7 +43701,7 @@
       }
     },
     "packages/terra-date-time-picker": {
-      "version": "4.101.0",
+      "version": "4.102.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -43712,7 +43712,7 @@
         "terra-button": "^3.3.0",
         "terra-date-picker": "^4.95.0",
         "terra-theme-context": "^1.9.0",
-        "terra-time-input": "^4.59.0"
+        "terra-time-input": "^4.60.0"
       },
       "devDependencies": {
         "terra-form-field": "^4.5.0",
@@ -43845,14 +43845,14 @@
       }
     },
     "packages/terra-form-validation": {
-      "version": "1.92.0",
+      "version": "1.93.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "final-form": "^4.6.0",
         "prop-types": "^15.5.8",
         "react-final-form": ">=5.0.2 <7.0.0",
         "terra-button": "^3.3.0",
-        "terra-date-input": "^1.47.0",
+        "terra-date-input": "^1.48.0",
         "terra-date-picker": "^4.95.0",
         "terra-form-checkbox": "^4.8.0",
         "terra-form-field": "^4.5.0",
@@ -43871,7 +43871,7 @@
     },
     "packages/terra-framework-docs": {
       "name": "@cerner/terra-framework-docs",
-      "version": "1.53.0",
+      "version": "1.54.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.7.0",
@@ -43885,12 +43885,12 @@
         "terra-brand-footer": "^3.12.0",
         "terra-button": "^3.3.0",
         "terra-collapsible-menu-view": "^6.87.0",
-        "terra-compact-interactive-list": "^1.0.0-alpha.4",
+        "terra-compact-interactive-list": "^1.0.0",
         "terra-content-container": "^3.0.0",
-        "terra-data-grid": "^1.9.0",
-        "terra-date-input": "^1.47.0",
+        "terra-data-grid": "^1.10.0",
+        "terra-date-input": "^1.48.0",
         "terra-date-picker": "^4.95.0",
-        "terra-date-time-picker": "^4.101.0",
+        "terra-date-time-picker": "^4.102.0",
         "terra-disclosure-manager": "^4.43.0",
         "terra-embedded-content-consumer": "^3.43.0",
         "terra-file-path": "^1.3.0",
@@ -43923,7 +43923,7 @@
         "terra-text": "^4.49.0",
         "terra-theme-context": "^1.9.0",
         "terra-theme-provider": "^4.14.0",
-        "terra-time-input": "^4.59.0",
+        "terra-time-input": "^4.60.0",
         "terra-toolbar": "^1.27.0"
       },
       "engines": {
@@ -44323,7 +44323,7 @@
       }
     },
     "packages/terra-time-input": {
-      "version": "4.59.0",
+      "version": "4.60.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.0 - (January 2, 2024)
+
 * Changed
   * Updated `handleMouseDown` method for a cell.
   * Updated lowlight theme styling.

--- a/packages/terra-compact-interactive-list/package.json
+++ b/packages/terra-compact-interactive-list/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-compact-interactive-list",
   "main": "lib/index.js",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0",
   "description": "The Terra Compact Interactive List component provides users a way to render a collection of interactive data in a list format into a single tab stop.",
   "repository": {
     "type": "git",

--- a/packages/terra-data-grid/CHANGELOG.md
+++ b/packages/terra-data-grid/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.10.0 - (January 2, 2024)
+
 * Added 
   * Added translations for flowsheet.
 

--- a/packages/terra-data-grid/package.json
+++ b/packages/terra-data-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-data-grid",
   "main": "lib/index.js",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Package containing data grid container components that enable users to navigate the grid information using directional navigation keys.",
   "repository": {
     "type": "git",

--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.48.0 - (January 2, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 1.47.0 - (December 18, 2023)
 
 * Changed

--- a/packages/terra-date-input/package.json
+++ b/packages/terra-date-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-date-input",
   "main": "lib/DateInput.js",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "description": "The DateInput allows for easy data entry of known dates like birthdays, anniversaries, etc. The display of the DateInput is localized based on the locale but can be customized via the `displayFormat` prop. The DateInput uses the ISO 8601 format for date values (YYYY-MM-DD).",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "terra-icon": "^3.19.0",
     "terra-mixins": "^1.0.0",
     "terra-theme-context": "^1.9.0",
-    "terra-time-input": "^4.59.0",
+    "terra-time-input": "^4.60.0",
     "terra-visually-hidden-text": "^2.0.0",
     "uuid": "3.4.0"
   },

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.102.0 - (January 2, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 4.101.0 - (December 18, 2023)
 
 * Changed

--- a/packages/terra-date-time-picker/package.json
+++ b/packages/terra-date-time-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-date-time-picker",
   "main": "lib/DateTimePicker.js",
-  "version": "4.101.0",
+  "version": "4.102.0",
   "description": "The DateTimePicker component has a date picker for selecting date and a time input for entering time",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "terra-button": "^3.3.0",
     "terra-date-picker": "^4.95.0",
     "terra-theme-context": "^1.9.0",
-    "terra-time-input": "^4.59.0"
+    "terra-time-input": "^4.60.0"
   },
   "devDependencies": {
     "terra-form-field": "^4.5.0",

--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.93.0 - (January 2, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 1.92.0 - (December 18, 2023)
 
 * Changed

--- a/packages/terra-form-validation/package.json
+++ b/packages/terra-form-validation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-form-validation",
   "main": "lib/FormValidationUtil.js",
-  "version": "1.92.0",
+  "version": "1.93.0",
   "description": "Form Validation Examples for Terra",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "prop-types": "^15.5.8",
     "react-final-form": ">=5.0.2 <7.0.0",
     "terra-button": "^3.3.0",
-    "terra-date-input": "^1.47.0",
+    "terra-date-input": "^1.48.0",
     "terra-date-picker": "^4.95.0",
     "terra-form-checkbox": "^4.8.0",
     "terra-form-field": "^4.5.0",

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.54.0 - (January 2, 2024)
+
 * Changed
   * Updated `terra-time-input` example to have visual label.
   * Updated `terra-embedded-content-consumer` example to fix axe error.

--- a/packages/terra-framework-docs/package.json
+++ b/packages/terra-framework-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-framework-docs",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "description": "Contains documentation for packages in the terra-framework monorepo",
   "main": "index.js",
   "publishConfig": {
@@ -42,12 +42,12 @@
     "terra-brand-footer": "^3.12.0",
     "terra-button": "^3.3.0",
     "terra-collapsible-menu-view": "^6.87.0",
-    "terra-compact-interactive-list": "^1.0.0-alpha.4",
+    "terra-compact-interactive-list": "^1.0.0",
     "terra-content-container": "^3.0.0",
-    "terra-data-grid": "^1.9.0",
-    "terra-date-input": "^1.47.0",
+    "terra-data-grid": "^1.10.0",
+    "terra-date-input": "^1.48.0",
     "terra-date-picker": "^4.95.0",
-    "terra-date-time-picker": "^4.101.0",
+    "terra-date-time-picker": "^4.102.0",
     "terra-disclosure-manager": "^4.43.0",
     "terra-embedded-content-consumer": "^3.43.0",
     "terra-file-path": "^1.3.0",
@@ -80,7 +80,7 @@
     "terra-text": "^4.49.0",
     "terra-theme-context": "^1.9.0",
     "terra-theme-provider": "^4.14.0",
-    "terra-time-input": "^4.59.0",
+    "terra-time-input": "^4.60.0",
     "terra-toolbar": "^1.27.0"
   }
 }

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.60.0 - (January 2, 2024)
+
 * Changed
   * Updated screen response to announce when invalid time is entered.
 

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-time-input",
   "main": "lib/TimeInput.js",
-  "version": "4.59.0",
+  "version": "4.60.0",
   "description": "A controlled input component for entering time.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The following packages will be released:

  - terra-compact-interactive-list@1.0.0
  - terra-data-grid@1.10.0
  - terra-date-input@1.48.0
  - terra-date-time-picker@4.102.0
  - terra-form-validation@1.93.0
  - @cerner/terra-framework-docs@1.54.0
  - terra-time-input@4.60.0
