### PR TITLE
[date-time-picker] Update Screen reader response not to read visually hidden text with name attribute.

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated screen reader response not to announce name attribute.
+
 ## 4.95.0 - (December 18, 2023)
 
 * Changed

--- a/packages/terra-date-picker/src/DateInput.jsx
+++ b/packages/terra-date-picker/src/DateInput.jsx
@@ -229,7 +229,6 @@ const DatePickerInput = (props) => {
 
   const additionalInputProps = { ...customProps, ...inputAttributes };
   const momentDateFormat = useMemo(() => DateUtil.getFormatByLocale(intl.locale), [intl.locale]);
-  const nameLabelId = `name-label-${uuidv4()}`;
   const dateValue = useMemo(() => (DateUtil.convertToISO8601(value, momentDateFormat)), [momentDateFormat, value]);
   const dateFormatOrder = DateUtil.getDateFormatOrder(momentDateFormat);
   const separator = DateUtil.getDateSeparator(intl.locale);
@@ -734,7 +733,7 @@ const DatePickerInput = (props) => {
       pattern="\d*"
       aria-required={required}
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.dayLabel' })}
-      aria-describedby={dateFormatOrder === DateUtil.dateOrder.DMY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
+      aria-describedby={ariaDescriptionIds}
       id={dayInputId}
     />
   );
@@ -765,7 +764,7 @@ const DatePickerInput = (props) => {
       pattern="\d*"
       aria-required={required}
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.monthLabel' })}
-      aria-describedby={dateFormatOrder === DateUtil.dateOrder.MDY ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
+      aria-describedby={ariaDescriptionIds}
       id={monthInputId}
     />
   );
@@ -796,7 +795,7 @@ const DatePickerInput = (props) => {
       pattern="\d*"
       aria-required={required}
       aria-label={intl.formatMessage({ id: 'Terra.datePicker.yearLabel' })}
-      aria-describedby={dateFormatOrder === DateUtil.dateOrder.YMD ? `${nameLabelId} ${ariaDescriptionIds}` : ariaDescriptionIds}
+      aria-describedby={ariaDescriptionIds}
       id={yearInputId}
     />
   );
@@ -852,7 +851,6 @@ const DatePickerInput = (props) => {
             value={dateValue}
           />
           <VisuallyHiddenText text={value ? `${label}, ${getLocalizedDateForScreenReader(DateUtil.createSafeDate(dateValue, initialTimeZone), { intl, locale: intl.locale })}` : label} />
-          <VisuallyHiddenText id={nameLabelId} text={name} />
           <VisuallyHiddenText
             refCallback={setVisuallyHiddenComponent}
             aria-atomic="true"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DateInput.test.jsx.snap
@@ -94,14 +94,6 @@ exports[`correctly applies the theme context className 1`] = `
               </span>
             </VisuallyHiddenText>
             <VisuallyHiddenText
-              id="name-label-00000000-0000-0000-0000-000000000000"
-            >
-              <span
-                className="visually-hidden-text"
-                id="name-label-00000000-0000-0000-0000-000000000000"
-              />
-            </VisuallyHiddenText>
-            <VisuallyHiddenText
               aria-atomic="true"
               aria-live="assertive"
               aria-relevant="all"
@@ -141,7 +133,7 @@ exports[`correctly applies the theme context className 1`] = `
               }
               month={
                 <Input
-                  aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+                  aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                   aria-label="Terra.datePicker.monthLabel"
                   aria-required={false}
                   className="date-input-month"
@@ -194,7 +186,7 @@ exports[`correctly applies the theme context className 1`] = `
               }
             >
               <Input
-                aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+                aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                 aria-label="Terra.datePicker.monthLabel"
                 aria-required={false}
                 className="date-input-month"
@@ -215,7 +207,7 @@ exports[`correctly applies the theme context className 1`] = `
                 value=""
               >
                 <input
-                  aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+                  aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                   aria-label="Terra.datePicker.monthLabel"
                   aria-required={false}
                   className="form-input orion-fusion-theme date-input-month"
@@ -536,14 +528,6 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
           </span>
         </VisuallyHiddenText>
         <VisuallyHiddenText
-          id="name-label-00000000-0000-0000-0000-000000000000"
-        >
-          <span
-            className="visually-hidden-text"
-            id="name-label-00000000-0000-0000-0000-000000000000"
-          />
-        </VisuallyHiddenText>
-        <VisuallyHiddenText
           aria-atomic="true"
           aria-live="assertive"
           aria-relevant="all"
@@ -583,7 +567,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
           }
           month={
             <Input
-              aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+              aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
               aria-label="Terra.datePicker.monthLabel"
               aria-required={false}
               className="date-input-month"
@@ -636,7 +620,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
           }
         >
           <Input
-            aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+            aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
             aria-label="Terra.datePicker.monthLabel"
             aria-required={false}
             className="date-input-month"
@@ -657,7 +641,7 @@ exports[`should pass in refCallback as the ref prop of the calendar button 1`] =
             value=""
           >
             <input
-              aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+              aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
               aria-label="Terra.datePicker.monthLabel"
               aria-required={false}
               className="form-input date-input-month"
@@ -937,17 +921,13 @@ exports[`should render a date input with isIncomplete and required props 1`] = `
         Terra.datePicker.date
       </span>
       <span
-        class="visually-hidden-text"
-        id="name-label-00000000-0000-0000-0000-000000000000"
-      />
-      <span
         aria-atomic="true"
         aria-live="assertive"
         aria-relevant="all"
         class="visually-hidden-text"
       />
       <input
-        aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+        aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         aria-label="Terra.datePicker.monthLabel"
         aria-required="true"
         class="form-input date-input-month"
@@ -1065,17 +1045,13 @@ exports[`should render a date input with isInvalid prop 1`] = `
         Terra.datePicker.date
       </span>
       <span
-        class="visually-hidden-text"
-        id="name-label-00000000-0000-0000-0000-000000000000"
-      />
-      <span
         aria-atomic="true"
         aria-live="assertive"
         aria-relevant="all"
         class="visually-hidden-text"
       />
       <input
-        aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+        aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         aria-label="Terra.datePicker.monthLabel"
         aria-required="false"
         class="form-input date-input-month"
@@ -1193,17 +1169,13 @@ exports[`should render a default date input 1`] = `
         Terra.datePicker.date
       </span>
       <span
-        class="visually-hidden-text"
-        id="name-label-00000000-0000-0000-0000-000000000000"
-      />
-      <span
         aria-atomic="true"
         aria-live="assertive"
         aria-relevant="all"
         class="visually-hidden-text"
       />
       <input
-        aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+        aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
         aria-label="Terra.datePicker.monthLabel"
         aria-required="false"
         class="form-input date-input-month"
@@ -1417,17 +1389,6 @@ exports[`should render a default date input with all props 1`] = `
           </span>
         </VisuallyHiddenText>
         <VisuallyHiddenText
-          id="name-label-00000000-0000-0000-0000-000000000000"
-          text="date-input"
-        >
-          <span
-            className="visually-hidden-text"
-            id="name-label-00000000-0000-0000-0000-000000000000"
-          >
-            date-input
-          </span>
-        </VisuallyHiddenText>
-        <VisuallyHiddenText
           aria-atomic="true"
           aria-live="assertive"
           aria-relevant="all"
@@ -1468,7 +1429,7 @@ exports[`should render a default date input with all props 1`] = `
           }
           month={
             <Input
-              aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+              aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
               aria-label="Terra.datePicker.monthLabel"
               aria-required={false}
               className="date-input-month"
@@ -1523,7 +1484,7 @@ exports[`should render a default date input with all props 1`] = `
           }
         >
           <Input
-            aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+            aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
             aria-label="Terra.datePicker.monthLabel"
             aria-required={false}
             className="date-input-month"
@@ -1545,7 +1506,7 @@ exports[`should render a default date input with all props 1`] = `
             value="01"
           >
             <input
-              aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+              aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
               aria-label="Terra.datePicker.monthLabel"
               aria-required={false}
               className="form-input date-input-month"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePicker.test.jsx.snap
@@ -364,17 +364,6 @@ exports[`correctly applies the theme context className 1`] = `
                             </span>
                           </VisuallyHiddenText>
                           <VisuallyHiddenText
-                            id="name-label-00000000-0000-0000-0000-000000000000"
-                            text="date-input"
-                          >
-                            <span
-                              className="visually-hidden-text"
-                              id="name-label-00000000-0000-0000-0000-000000000000"
-                            >
-                              date-input
-                            </span>
-                          </VisuallyHiddenText>
-                          <VisuallyHiddenText
                             aria-atomic="true"
                             aria-live="assertive"
                             aria-relevant="all"
@@ -414,7 +403,7 @@ exports[`correctly applies the theme context className 1`] = `
                             }
                             month={
                               <Input
-                                aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+                                aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                                 aria-label="Terra.datePicker.monthLabel"
                                 aria-required={false}
                                 className="date-input-month"
@@ -467,7 +456,7 @@ exports[`correctly applies the theme context className 1`] = `
                             }
                           >
                             <Input
-                              aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+                              aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                               aria-label="Terra.datePicker.monthLabel"
                               aria-required={false}
                               className="date-input-month"
@@ -488,7 +477,7 @@ exports[`correctly applies the theme context className 1`] = `
                               value="01"
                             >
                               <input
-                                aria-describedby="name-label-00000000-0000-0000-0000-000000000000 terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
+                                aria-describedby="terra-date-picker-description-format-00000000-0000-0000-0000-000000000000"
                                 aria-label="Terra.datePicker.monthLabel"
                                 aria-required={false}
                                 className="form-input orion-fusion-theme date-input-month"

--- a/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
+++ b/packages/terra-date-picker/tests/jest/__snapshots__/DatePickerField.test.jsx.snap
@@ -666,17 +666,6 @@ exports[`should render a DatePickerField with props 1`] = `
                                   </span>
                                 </VisuallyHiddenText>
                                 <VisuallyHiddenText
-                                  id="name-label-00000000-0000-0000-0000-000000000000"
-                                  text="test-date-picker"
-                                >
-                                  <span
-                                    className="visually-hidden-text"
-                                    id="name-label-00000000-0000-0000-0000-000000000000"
-                                  >
-                                    test-date-picker
-                                  </span>
-                                </VisuallyHiddenText>
-                                <VisuallyHiddenText
                                   aria-atomic="true"
                                   aria-live="assertive"
                                   aria-relevant="all"
@@ -716,7 +705,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                   }
                                   month={
                                     <Input
-                                      aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-error test-date-picker-help"
+                                      aria-describedby="test-date-picker-error test-date-picker-help"
                                       aria-label="Terra.datePicker.monthLabel"
                                       aria-required={true}
                                       className="date-input-month"
@@ -769,7 +758,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                   }
                                 >
                                   <Input
-                                    aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-error test-date-picker-help"
+                                    aria-describedby="test-date-picker-error test-date-picker-help"
                                     aria-label="Terra.datePicker.monthLabel"
                                     aria-required={true}
                                     className="date-input-month"
@@ -790,7 +779,7 @@ exports[`should render a DatePickerField with props 1`] = `
                                     value="04"
                                   >
                                     <input
-                                      aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-error test-date-picker-help"
+                                      aria-describedby="test-date-picker-error test-date-picker-help"
                                       aria-label="Terra.datePicker.monthLabel"
                                       aria-required={true}
                                       className="form-input date-input-month"
@@ -1551,17 +1540,6 @@ exports[`should render a default DatePickerField component 1`] = `
                                   </span>
                                 </VisuallyHiddenText>
                                 <VisuallyHiddenText
-                                  id="name-label-00000000-0000-0000-0000-000000000000"
-                                  text="test-date-picker"
-                                >
-                                  <span
-                                    className="visually-hidden-text"
-                                    id="name-label-00000000-0000-0000-0000-000000000000"
-                                  >
-                                    test-date-picker
-                                  </span>
-                                </VisuallyHiddenText>
-                                <VisuallyHiddenText
                                   aria-atomic="true"
                                   aria-live="assertive"
                                   aria-relevant="all"
@@ -1601,7 +1579,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                   }
                                   month={
                                     <Input
-                                      aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-help"
+                                      aria-describedby="test-date-picker-help"
                                       aria-label="Terra.datePicker.monthLabel"
                                       aria-required={false}
                                       className="date-input-month"
@@ -1654,7 +1632,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                   }
                                 >
                                   <Input
-                                    aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-help"
+                                    aria-describedby="test-date-picker-help"
                                     aria-label="Terra.datePicker.monthLabel"
                                     aria-required={false}
                                     className="date-input-month"
@@ -1675,7 +1653,7 @@ exports[`should render a default DatePickerField component 1`] = `
                                     value="01"
                                   >
                                     <input
-                                      aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-help"
+                                      aria-describedby="test-date-picker-help"
                                       aria-label="Terra.datePicker.monthLabel"
                                       aria-required={false}
                                       className="form-input date-input-month"
@@ -2544,17 +2522,6 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   </span>
                                 </VisuallyHiddenText>
                                 <VisuallyHiddenText
-                                  id="name-label-00000000-0000-0000-0000-000000000000"
-                                  text="test-date-picker"
-                                >
-                                  <span
-                                    className="visually-hidden-text"
-                                    id="name-label-00000000-0000-0000-0000-000000000000"
-                                  >
-                                    test-date-picker
-                                  </span>
-                                </VisuallyHiddenText>
-                                <VisuallyHiddenText
                                   aria-atomic="true"
                                   aria-live="assertive"
                                   aria-relevant="all"
@@ -2594,7 +2561,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   }
                                   month={
                                     <Input
-                                      aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-help"
+                                      aria-describedby="test-date-picker-help"
                                       aria-label="Terra.datePicker.monthLabel"
                                       aria-required={true}
                                       className="date-input-month"
@@ -2647,7 +2614,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                   }
                                 >
                                   <Input
-                                    aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-help"
+                                    aria-describedby="test-date-picker-help"
                                     aria-label="Terra.datePicker.monthLabel"
                                     aria-required={true}
                                     className="date-input-month"
@@ -2668,7 +2635,7 @@ exports[`should render a valid DatePickerField with props 1`] = `
                                     value="01"
                                   >
                                     <input
-                                      aria-describedby="name-label-00000000-0000-0000-0000-000000000000 test-date-picker-help"
+                                      aria-describedby="test-date-picker-help"
                                       aria-label="Terra.datePicker.monthLabel"
                                       aria-required={true}
                                       className="form-input date-input-month"


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Update Screen reader response not to read visually hidden text with name attribute.

**Why it was changed:**

When user first navigates to the date input field, then the visually hidden text with name attribute is exposed to user which is not contextual and can be confusing.


https://github.com/cerner/terra-framework/assets/132886427/42cc15c4-bea6-4a67-a66d-5e3f659ab4fd


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10137 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
