### PR TITLE
rowHeaderIndex prop validation added

### DIFF
--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `rowHeaderIndex` prop validation.
+
 ## 1.0.1 - (January 10, 2024)
 
 * Fixed

--- a/packages/terra-compact-interactive-list/src/CompactInteractiveList.jsx
+++ b/packages/terra-compact-interactive-list/src/CompactInteractiveList.jsx
@@ -34,6 +34,7 @@ import {
   getFocusedCellIds,
 } from './utils/keyHandlerUtils';
 import getFocusableElements from '../../terra-table/src/utils/focusManagement';
+import validateRowHeaderIndex from './proptypes/validators';
 
 const cx = classNames.bind(styles);
 
@@ -110,7 +111,7 @@ const propTypes = {
   /**
    * A zero-based index indicating which column represents the row header.
    */
-  rowHeaderIndex: PropTypes.number,
+  rowHeaderIndex: validateRowHeaderIndex,
 };
 
 const defaultProps = {

--- a/packages/terra-compact-interactive-list/src/proptypes/validators.js
+++ b/packages/terra-compact-interactive-list/src/proptypes/validators.js
@@ -1,0 +1,18 @@
+import { ERRORS } from '../utils/constants';
+
+// eslint-disable-next-line consistent-return
+const validateRowHeaderIndex = (props) => {
+  if (!Number.isInteger(props.rowHeaderIndex)) {
+    return new Error(ERRORS.ROW_HEADER_INDEX_NOT_AN_INTEGER);
+  }
+
+  if (props.rowHeaderIndex < 0) {
+    return new Error(ERRORS.ROW_HEADER_INDEX_LESS_THAN_ZERO);
+  }
+
+  if (props.columns.length && props.rowHeaderIndex >= props.columns.length) {
+    return new Error(ERRORS.ROW_HEADER_INDEX_EXCEEDS_COLUMNS);
+  }
+};
+
+export default validateRowHeaderIndex;

--- a/packages/terra-compact-interactive-list/src/utils/constants.js
+++ b/packages/terra-compact-interactive-list/src/utils/constants.js
@@ -34,3 +34,9 @@ export const WARNINGS = {
   COLUMN_MAX_WIDTH_UNIT_TYPE: 'columnMaximumWidth prop has different unitType than the one used in columns. It will be disregarded.',
   COLUMN_WIDTH_INCONSISTENT_TYPE: 'width, minimumWidth, and maximumWidth properties should be of the same unit type across all the columns (px, em, and rem are supported types).',
 };
+
+export const ERRORS = {
+  ROW_HEADER_INDEX_EXCEEDS_COLUMNS: 'Prop rowHeaderIndex exceeds the number of semantic columns in the row.',
+  ROW_HEADER_INDEX_LESS_THAN_ZERO: 'Prop rowHeaderIndex must be a positive integer.',
+  ROW_HEADER_INDEX_NOT_AN_INTEGER: 'Prop rowHeaderIndex must be an integer.',
+};


### PR DESCRIPTION
### Summary
This PR adds `rowHeaderIndex` prop validation similarly to how it is done in `terra-table` component here:
https://github.com/cerner/terra-framework/blob/main/packages/terra-table/src/proptypes/validators.js
https://github.com/cerner/terra-framework/blob/main/packages/terra-table/src/utils/constants.js

### Testing
This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

Testing steps:

1. In `terra-framework-docs` I went to a `compact-interactive-list` example and changed the `rowHeaderIndex` prop to the integer value that exceeded the number of semantic columns in a row. In developer tool consol I observed the error stating that *Prop rowHeaderIndex exceeds the number of semantic columns in the row*:

<img width="1134" alt="Screenshot 2024-01-17 at 11 42 40 AM" src="https://github.com/cerner/terra-framework/assets/119358186/0213622d-e2b5-44ff-a288-c97b8341ec1f">

2. I changed the `rowHeaderIndex` prop value to -1 and observed the error stating that *Prop rowHeaderIndex must be a positive integer*:

<img width="981" alt="Screenshot 2024-01-17 at 11 43 31 AM" src="https://github.com/cerner/terra-framework/assets/119358186/b9de205b-1ef4-4521-8211-be0be2681265">

3. I changed the `rowHeaderIndex` prop value to a string and observed the error stating that *Prop rowHeaderIndex must be an integer*:

<img width="980" alt="Screenshot 2024-01-17 at 11 53 53 AM" src="https://github.com/cerner/terra-framework/assets/119358186/0176878b-c3ba-4a45-94a5-b3a4f7a144af">

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR is part of:**
UXPLATFORM-10114
