### PR TITLE
[Terra-Pills] Resolves Sass Error caused due to usage of @supports selector rule

### DIFF
--- a/packages/terra-pills/CHANGELOG.md
+++ b/packages/terra-pills/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Replaced `:-moz-is-html` selector with `@-moz-document` to resolve Mini-Css-Plugin issue.
+
 ## 1.16.1 - (January 10, 2024)
 
 * Fixed

--- a/packages/terra-pills/src/subcomponents/Pill.module.scss
+++ b/packages/terra-pills/src/subcomponents/Pill.module.scss
@@ -364,7 +364,7 @@
       }
     }
 
-    @supports selector(:-moz-is-html) {
+    @-moz-document url-prefix() {
       .rollup-pill-label { 
         top: var(--terra-pills-rollup-pill-label-moz-top, -0.02em); // Text alignment for Firefox
       }
@@ -381,7 +381,7 @@
     }
   }
 
-  @supports selector(:-moz-is-html) {
+  @-moz-document url-prefix() {
     .pill-label {
       top: var(--terra-pills-pill-label-moz-top, -0.02em); // Text alignment for Firefox
     }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
terra-pills uses `@supports selector(:-moz-is-html)` to apply firefox specific styles of pill label. `selector` rule is not supported on older version of mini-css-extract-plugin due to this applications which are dependent on packages like terra-toolkit, webpack-config-terra, mini-css-extract-plugin < 3 has error `**_SassError: Invalid CSS after "    @supports ": expected @supports condition (e.g. (display: flexbox)), was "selector(:-moz-is-h"_**` 

**What was changed:**
Unsupported browser specific rule `@supports selector(:-moz-is-html)` is replaced with supported rule `@-moz-document url-prefix()` 

**Why it was changed:**
Since most of clinical applications are not planning to have tech upgrade sooner, unsupported css rule `@supports selector(:-moz-is-html)` is blocking applications from using terra-pills.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Tested on Firefox browser to verify browser specific styles are being shown on Firefox browser.

<img width="1727" alt="Screenshot 2024-01-17 at 11 02 34 PM" src="https://github.com/cerner/terra-framework/assets/12869809/a38103b7-8ad7-400f-8963-868a3431fd49">

orion-component-example-js build was failing before code changes 

<img width="1032" alt="Screenshot 2024-01-17 at 11 27 11 PM" src="https://github.com/cerner/terra-framework/assets/12869809/dba04cf7-01bb-467a-8277-d66730772914">


After code changes

<img width="1095" alt="Screenshot 2024-01-17 at 11 27 46 PM" src="https://github.com/cerner/terra-framework/assets/12869809/85190cdf-cf23-4742-99d6-fbe6f870ca34">


This change was tested using:
- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [X] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
