### PR TITLE
[terra-theme-properties] Redwood focus indicator mixin

### DIFF
--- a/packages/terra-theme-properties/CHANGELOG.md
+++ b/packages/terra-theme-properties/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-
+* Added
+  * Added Redwood focus indicator mixin.
+  
 ## 0.2.0 - (January 16, 2024)
 
 * Initial package release.

--- a/packages/terra-theme-properties/src/scss/redwood-mixins.scss
+++ b/packages/terra-theme-properties/src/scss/redwood-mixins.scss
@@ -1,0 +1,23 @@
+/**
+ * Add the focus indicator styles for an element
+ * @param {Boolean} innerRing - Specifies if the focus indicator ring is inside the component.  The default value is false.
+ * @param {Boolean} darkBackground - Specifies if focus indicator ring needs to be adjusted for a dark background.  The default value is false.
+ */
+@mixin terra-focus-indicator($innerRing: false, $darkBackground: false) {
+  // Determine outline color based on background
+  @if $darkBackground {
+    outline-color: var(--default-focus-outline-color-inverse);
+  } @else {
+    outline-color: var(--default-focus-outline-color-normal);
+  }
+
+  // Determine focus indicator ring offset
+  @if $innerRing {
+    outline-offset: var(--default-focus-outline-offset-inside);
+  } @else {
+    outline-offset: var(--default-focus-outline-offset-outside);
+  }
+
+  outline-style: var(--default-focus-outline-style);
+  outline-width: var(--default-focus-outline-width);
+}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
A mixin was created so that consumers could properly render the focus ring for the Redwood theme.

**Why it was changed:**
The mixin was created to ensure proper implementation and consistency.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [X] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10151 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
