### PR TITLE
Release 25/01

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39554,13 +39554,13 @@
       }
     },
     "packages/terra-data-grid": {
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
         "keycode-js": "^3.1.0",
         "prop-types": "^15.5.8",
-        "terra-table": "^5.4.0",
+        "terra-table": "^5.5.0",
         "terra-visually-hidden-text": "^2.36.0"
       },
       "devDependencies": {
@@ -39573,7 +39573,7 @@
       }
     },
     "packages/terra-date-input": {
-      "version": "1.49.0",
+      "version": "1.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -39584,7 +39584,7 @@
         "terra-icon": "^3.19.0",
         "terra-mixins": "^1.0.0",
         "terra-theme-context": "^1.9.0",
-        "terra-time-input": "^4.60.0",
+        "terra-time-input": "^4.61.0",
         "terra-visually-hidden-text": "^2.0.0",
         "uuid": "3.4.0"
       },
@@ -39599,7 +39599,7 @@
       }
     },
     "packages/terra-date-picker": {
-      "version": "4.96.0",
+      "version": "4.97.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -39627,7 +39627,7 @@
       }
     },
     "packages/terra-date-time-picker": {
-      "version": "4.103.0",
+      "version": "4.104.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -39636,9 +39636,9 @@
         "prop-types": "^15.5.8",
         "terra-abstract-modal": "^3.45.0",
         "terra-button": "^3.3.0",
-        "terra-date-picker": "^4.96.0",
+        "terra-date-picker": "^4.97.0",
         "terra-theme-context": "^1.9.0",
-        "terra-time-input": "^4.60.0"
+        "terra-time-input": "^4.61.0"
       },
       "devDependencies": {
         "terra-form-field": "^4.5.0",
@@ -39651,7 +39651,7 @@
       }
     },
     "packages/terra-dialog-modal": {
-      "version": "3.99.0",
+      "version": "3.100.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.0.0",
@@ -39664,7 +39664,7 @@
         "terra-action-footer": "^2.0.0",
         "terra-action-header": "^2.0.0",
         "terra-button": "^3.3.0",
-        "terra-date-picker": "^4.96.0",
+        "terra-date-picker": "^4.97.0",
         "terra-form-select": "^6.8.0",
         "terra-popup": "^6.74.0"
       },
@@ -39737,15 +39737,15 @@
       }
     },
     "packages/terra-form-validation": {
-      "version": "1.95.0",
+      "version": "1.96.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "final-form": "^4.6.0",
         "prop-types": "^15.5.8",
         "react-final-form": ">=5.0.2 <7.0.0",
         "terra-button": "^3.3.0",
-        "terra-date-input": "^1.49.0",
-        "terra-date-picker": "^4.96.0",
+        "terra-date-input": "^1.50.0",
+        "terra-date-picker": "^4.97.0",
         "terra-form-checkbox": "^4.8.0",
         "terra-form-field": "^4.5.0",
         "terra-form-input": "^4.4.0",
@@ -39763,7 +39763,7 @@
     },
     "packages/terra-framework-docs": {
       "name": "@cerner/terra-framework-docs",
-      "version": "1.59.0",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.7.0",
@@ -39779,10 +39779,10 @@
         "terra-collapsible-menu-view": "^6.88.0",
         "terra-compact-interactive-list": "^1.1.0",
         "terra-content-container": "^3.0.0",
-        "terra-data-grid": "^1.11.0",
-        "terra-date-input": "^1.49.0",
-        "terra-date-picker": "^4.96.0",
-        "terra-date-time-picker": "^4.103.0",
+        "terra-data-grid": "^1.12.0",
+        "terra-date-input": "^1.50.0",
+        "terra-date-picker": "^4.97.0",
+        "terra-date-time-picker": "^4.104.0",
         "terra-disclosure-manager": "^4.43.0",
         "terra-embedded-content-consumer": "^3.43.0",
         "terra-file-path": "^1.5.0",
@@ -39810,12 +39810,12 @@
         "terra-slide-panel-manager": "^5.89.0",
         "terra-slider": "^1.2.0",
         "terra-spacer": "^3.59.0",
-        "terra-table": "^5.4.0",
+        "terra-table": "^5.5.0",
         "terra-tabs": "^7.16.0",
         "terra-text": "^4.49.0",
         "terra-theme-context": "^1.9.0",
         "terra-theme-provider": "^4.16.0",
-        "terra-time-input": "^4.60.0",
+        "terra-time-input": "^4.61.0",
         "terra-toolbar": "^1.27.0"
       },
       "engines": {
@@ -40122,7 +40122,7 @@
       }
     },
     "packages/terra-table": {
-      "version": "5.4.0",
+      "version": "5.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -40205,7 +40205,7 @@
       }
     },
     "packages/terra-time-input": {
-      "version": "4.60.0",
+      "version": "4.61.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/packages/terra-date-input/CHANGELOG.md
+++ b/packages/terra-date-input/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.50.0 - (January 25, 2024)
+
 * Added
   * Added black dashed border when input gets focused.
   * Added screen reader support for error messages.

--- a/packages/terra-date-input/package.json
+++ b/packages/terra-date-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-date-input",
   "main": "lib/DateInput.js",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "description": "The DateInput allows for easy data entry of known dates like birthdays, anniversaries, etc. The display of the DateInput is localized based on the locale but can be customized via the `displayFormat` prop. The DateInput uses the ISO 8601 format for date values (YYYY-MM-DD).",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "terra-icon": "^3.19.0",
     "terra-mixins": "^1.0.0",
     "terra-theme-context": "^1.9.0",
-    "terra-time-input": "^4.60.0",
+    "terra-time-input": "^4.61.0",
     "terra-visually-hidden-text": "^2.0.0",
     "uuid": "3.4.0"
   },

--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.97.0 - (January 25, 2024)
+
 * Changed
   * Updated metadata as argument for onBlur callback.
 

--- a/packages/terra-date-picker/package.json
+++ b/packages/terra-date-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-date-picker",
   "main": "lib/DatePicker.js",
-  "version": "4.96.0",
+  "version": "4.97.0",
   "description": "The terra-date-picker component provides users a way to enter or select a date from the date picker.",
   "repository": {
     "type": "git",

--- a/packages/terra-date-time-picker/CHANGELOG.md
+++ b/packages/terra-date-time-picker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.104.0 - (January 25, 2024)
+
 * Changed
   * Updated metadata as argument for onBlur callback.
 

--- a/packages/terra-date-time-picker/package.json
+++ b/packages/terra-date-time-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-date-time-picker",
   "main": "lib/DateTimePicker.js",
-  "version": "4.103.0",
+  "version": "4.104.0",
   "description": "The DateTimePicker component has a date picker for selecting date and a time input for entering time",
   "repository": {
     "type": "git",
@@ -33,9 +33,9 @@
     "prop-types": "^15.5.8",
     "terra-abstract-modal": "^3.45.0",
     "terra-button": "^3.3.0",
-    "terra-date-picker": "^4.96.0",
+    "terra-date-picker": "^4.97.0",
     "terra-theme-context": "^1.9.0",
-    "terra-time-input": "^4.60.0"
+    "terra-time-input": "^4.61.0"
   },
   "devDependencies": {
     "terra-form-field": "^4.5.0",

--- a/packages/terra-dialog-modal/CHANGELOG.md
+++ b/packages/terra-dialog-modal/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 3.100.0 - (January 25, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 3.99.0 - (January 22, 2024)
 
 * Changed

--- a/packages/terra-dialog-modal/package.json
+++ b/packages/terra-dialog-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-dialog-modal",
   "main": "lib/DialogModal.js",
-  "version": "3.99.0",
+  "version": "3.100.0",
   "description": "The Dialog Modal allows dynamic height modals. It's limited use case, as dynamic heights break with more complicated DOM structures. If content is too complicated, the terra-modal-manager should be used. The components is placed at an 8000 z-index. The dialog supports release and request focus props similar to terra-popup and terra-date-picker, so it can be presented from another modal with focus.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "terra-action-footer": "^2.0.0",
     "terra-action-header": "^2.0.0",
     "terra-button": "^3.3.0",
-    "terra-date-picker": "^4.96.0",
+    "terra-date-picker": "^4.97.0",
     "terra-form-select": "^6.8.0",
     "terra-popup": "^6.74.0"
   },

--- a/packages/terra-form-validation/CHANGELOG.md
+++ b/packages/terra-form-validation/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.96.0 - (January 25, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 1.95.0 - (January 22, 2024)
 
 * Changed

--- a/packages/terra-form-validation/package.json
+++ b/packages/terra-form-validation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-form-validation",
   "main": "lib/FormValidationUtil.js",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "description": "Form Validation Examples for Terra",
   "repository": {
     "type": "git",
@@ -33,8 +33,8 @@
     "prop-types": "^15.5.8",
     "react-final-form": ">=5.0.2 <7.0.0",
     "terra-button": "^3.3.0",
-    "terra-date-input": "^1.49.0",
-    "terra-date-picker": "^4.96.0",
+    "terra-date-input": "^1.50.0",
+    "terra-date-picker": "^4.97.0",
     "terra-form-checkbox": "^4.8.0",
     "terra-form-field": "^4.5.0",
     "terra-form-input": "^4.4.0",

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
-* Changed
-  * Added `date-picker`, `time-input` and `date-time picker` tests to display new metadata.
-
 ## Unreleased
+
+## 1.60.0 - (January 25, 2024)
 
 * Added
   * Updated `date-input` examples to allow screen reader response for error message.
@@ -13,6 +12,9 @@
 
 * Fixed
   * Fixed label value when we have 12 hours time format in `terra-time-input` examples.
+
+* Changed
+  * Added `date-picker`, `time-input` and `date-time picker` tests to display new metadata.
 
 ## 1.59.0 - (January 22, 2024)
 

--- a/packages/terra-framework-docs/package.json
+++ b/packages/terra-framework-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-framework-docs",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Contains documentation for packages in the terra-framework monorepo",
   "main": "index.js",
   "publishConfig": {
@@ -45,9 +45,9 @@
     "terra-compact-interactive-list": "^1.1.0",
     "terra-content-container": "^3.0.0",
     "terra-data-grid": "^1.11.0",
-    "terra-date-input": "^1.49.0",
-    "terra-date-picker": "^4.96.0",
-    "terra-date-time-picker": "^4.103.0",
+    "terra-date-input": "^1.50.0",
+    "terra-date-picker": "^4.97.0",
+    "terra-date-time-picker": "^4.104.0",
     "terra-disclosure-manager": "^4.43.0",
     "terra-embedded-content-consumer": "^3.43.0",
     "terra-file-path": "^1.5.0",
@@ -80,7 +80,7 @@
     "terra-text": "^4.49.0",
     "terra-theme-context": "^1.9.0",
     "terra-theme-provider": "^4.16.0",
-    "terra-time-input": "^4.60.0",
+    "terra-time-input": "^4.61.0",
     "terra-toolbar": "^1.27.0"
   }
 }

--- a/packages/terra-time-input/CHANGELOG.md
+++ b/packages/terra-time-input/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.61.0 - (January 25, 2024)
+
 * Changed
   * Added metadata as argument for onBlur callback.
 * Fixed

--- a/packages/terra-time-input/package.json
+++ b/packages/terra-time-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-time-input",
   "main": "lib/TimeInput.js",
-  "version": "4.60.0",
+  "version": "4.61.0",
   "description": "A controlled input component for entering time.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
The following components are released -
  - terra-date-input@1.50.0
  - terra-date-picker@4.97.0
  - terra-date-time-picker@4.104.0
  - terra-dialog-modal@3.100.0
  - terra-form-validation@1.96.0
  - @cerner/terra-framework-docs@1.60.0
  - terra-time-input@4.61.0
 
**What was changed:**


**Why it was changed:**



### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
