### PR TITLE
check if element exists before focusing added

### DIFF
--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Added check for cell element existence before focusing.
+
 ## 1.5.0 - (February 28, 2024)
 
 * Changed

--- a/packages/terra-compact-interactive-list/src/CompactInteractiveList.jsx
+++ b/packages/terra-compact-interactive-list/src/CompactInteractiveList.jsx
@@ -154,14 +154,16 @@ const CompactInteractiveList = (props) => {
 
   const focusCell = ({ row, cell }) => {
     // add 1 to the row number to accommodate for hidden header
-    const focusedCellElement = listRef.current.children[row + 1].children[cell];
-    const interactiveChildren = getFocusableElements(focusedCellElement);
-    if (interactiveChildren?.length > 0 && interactiveChildren[0]) {
-      // currently a cell can have only one interact-able element in it, which gets auto-focused.
-      interactiveChildren[0].focus();
-    } else {
-      // cell gets focus if there is no interact-able elements in it.
-      focusedCellElement.focus();
+    const focusedCellElement = listRef.current?.children[row + 1]?.children[cell];
+    if (focusedCellElement) {
+      const interactiveChildren = getFocusableElements(focusedCellElement);
+      if (interactiveChildren?.length > 0 && interactiveChildren[0]) {
+        // currently a cell can have only one interact-able element in it, which gets auto-focused.
+        interactiveChildren[0].focus();
+      } else {
+        // cell gets focus if there is no interact-able elements in it.
+        focusedCellElement.focus();
+      }
     }
   };
 


### PR DESCRIPTION
### Summary
This PR adds a check if row and cell element exist before focusing on the last one. That allows to avoid errors in cases the cell implementation is different from documented.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

**This PR resolves:**
MPAGESCORE-91600