### PR TITLE
[Date-Time-Picker] Month/Year changing redundant announcement fix

### DIFF
--- a/packages/terra-date-picker/CHANGELOG.md
+++ b/packages/terra-date-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Fix for month/year SR redundant reading in Jaws.
+
 ## 4.100.0 - (February 28, 2024)
 
 * Changed

--- a/packages/terra-date-picker/src/react-datepicker/calendar.jsx
+++ b/packages/terra-date-picker/src/react-datepicker/calendar.jsx
@@ -288,6 +288,7 @@ export default class Calendar extends React.Component {
   }
 
   handleDropdownClick(event){
+    console.log("CHECKING THIS dropdown clicked")
     if(event.keyCode === KeyCode.KEY_UP || event.keyCode === KeyCode.KEY_DOWN ) {
       this.setState({ calendarIsKeyboardFocused : true});
     }
@@ -465,7 +466,7 @@ export default class Calendar extends React.Component {
       isMonthChanged: true,
       date: getStartOfMonth(setYear(cloneDate(this.state.date), year))
     })
-    this.props.setPreSelection(getStartOfMonth(setYear(cloneDate(this.state.date), year)),dateValues.YEAR,year);
+    //this.props.setPreSelection(getStartOfMonth(setYear(cloneDate(this.state.date), year)),dateValues.YEAR,year);
   }
 
   changeMonth = (month) => {
@@ -473,7 +474,7 @@ export default class Calendar extends React.Component {
       isMonthChanged: true,
       date: getStartOfMonth(setMonth(cloneDate(this.state.date), month))
     }, () => this.handleMonthChange(this.state.date))
-    this.props.setPreSelection(getStartOfMonth(setMonth(cloneDate(this.state.date), month)),dateValues.MONTH,month);
+   // this.props.setPreSelection(getStartOfMonth(setMonth(cloneDate(this.state.date), month)),dateValues.MONTH,month);
   }
 
   header = (date = this.state.date) => {

--- a/packages/terra-date-picker/src/react-datepicker/calendar.jsx
+++ b/packages/terra-date-picker/src/react-datepicker/calendar.jsx
@@ -288,7 +288,6 @@ export default class Calendar extends React.Component {
   }
 
   handleDropdownClick(event){
-    console.log("CHECKING THIS dropdown clicked")
     if(event.keyCode === KeyCode.KEY_UP || event.keyCode === KeyCode.KEY_DOWN ) {
       this.setState({ calendarIsKeyboardFocused : true});
     }
@@ -466,7 +465,6 @@ export default class Calendar extends React.Component {
       isMonthChanged: true,
       date: getStartOfMonth(setYear(cloneDate(this.state.date), year))
     })
-    //this.props.setPreSelection(getStartOfMonth(setYear(cloneDate(this.state.date), year)),dateValues.YEAR,year);
   }
 
   changeMonth = (month) => {
@@ -474,7 +472,6 @@ export default class Calendar extends React.Component {
       isMonthChanged: true,
       date: getStartOfMonth(setMonth(cloneDate(this.state.date), month))
     }, () => this.handleMonthChange(this.state.date))
-   // this.props.setPreSelection(getStartOfMonth(setMonth(cloneDate(this.state.date), month)),dateValues.MONTH,month);
   }
 
   header = (date = this.state.date) => {


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
Currently when navigating through the Date Picker popup and selecting a value for "Month"/ "Year", will only expose the selected value. But, the selected value is getting exposed twice as "February, Month Combobox February", .

**What was changed:**


**Why it was changed:**



### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
