### PR TITLE
Feb 29 release compact-interactive-list cell focus fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39576,7 +39576,7 @@
       }
     },
     "packages/terra-compact-interactive-list": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -39803,7 +39803,7 @@
     },
     "packages/terra-framework-docs": {
       "name": "@cerner/terra-framework-docs",
-      "version": "1.69.0",
+      "version": "1.70.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerner/terra-docs": "^1.7.0",
@@ -39817,7 +39817,7 @@
         "terra-brand-footer": "^3.12.0",
         "terra-button": "^3.3.0",
         "terra-collapsible-menu-view": "^6.90.0",
-        "terra-compact-interactive-list": "^1.6.0",
+        "terra-compact-interactive-list": "^1.6.1",
         "terra-content-container": "^3.0.0",
         "terra-data-grid": "^1.16.0",
         "terra-date-input": "^1.53.0",

--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.6.1 - (February 29, 2024)
+
 * Fixed
   * Added check for cell element existence before focusing.
 

--- a/packages/terra-compact-interactive-list/package.json
+++ b/packages/terra-compact-interactive-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terra-compact-interactive-list",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The Terra Compact Interactive List component provides users a way to render a collection of interactive data in a list format into a single tab stop.",
   "author": "Cerner Corporation",
   "repository": {

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.70.0 - (February 29, 2024)
+
+* Changed
+  * Minor dependency version bump.
+
 ## 1.69.0 - (February 28, 2024)
 
 * Added

--- a/packages/terra-framework-docs/package.json
+++ b/packages/terra-framework-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-framework-docs",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "Contains documentation for packages in the terra-framework monorepo",
   "author": "Cerner Corporation",
   "repository": {
@@ -45,7 +45,7 @@
     "terra-brand-footer": "^3.12.0",
     "terra-button": "^3.3.0",
     "terra-collapsible-menu-view": "^6.90.0",
-    "terra-compact-interactive-list": "^1.6.0",
+    "terra-compact-interactive-list": "^1.6.1",
     "terra-content-container": "^3.0.0",
     "terra-data-grid": "^1.16.0",
     "terra-date-input": "^1.53.0",


### PR DESCRIPTION
The following packages will be released:

  - terra-compact-interactive-list@1.6.1
  - @cerner/terra-framework-docs@1.70.0
