### PR TITLE
[terra-worklist-data-grid] Fixes column index out of range for displayed columns

### DIFF
--- a/packages/terra-data-grid/CHANGELOG.md
+++ b/packages/terra-data-grid/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added
   * Added support for orange and green column highlighting.
 
+* Fixed
+  * Fixes column index out of bounds in row selection mode.
+
 ## 1.18.0 - (March 5, 2024)
 
 * Changed

--- a/packages/terra-data-grid/src/DataGrid.jsx
+++ b/packages/terra-data-grid/src/DataGrid.jsx
@@ -247,10 +247,12 @@ const DataGrid = forwardRef((props, ref) => {
     setFocusedRow(newRowIndex);
     setFocusedCol(newColIndex);
 
-    focusedCellRef.current = {
-      rowId: grid.current.rows[newRowIndex].getAttribute('data-row-id'),
-      columnId: displayedColumns[newColIndex].id,
-    };
+    if (newColIndex < displayedColumns.length) {
+      focusedCellRef.current = {
+        rowId: grid.current.rows[newRowIndex].getAttribute('data-row-id'),
+        columnId: displayedColumns[newColIndex].id,
+      };
+    }
 
     if (makeActiveElement) {
       let focusedCell;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Fixes page crash issue of worklist data grid in row selection mode. 


**Why it was changed:**

column index range exceeds the displayed column length in row selection mode when toggled on/off in last column of grid.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10242 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
