### PR TITLE
[terra-folder-tree] Fix incorrect screenreader announcement of indexes

### DIFF
--- a/packages/terra-folder-tree/CHANGELOG.md
+++ b/packages/terra-folder-tree/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed screenreader reading the wrong indexes for subfolder items.
+
 ## 1.0.0-alpha.10 - (March 14, 2024)
 
 * Changed

--- a/packages/terra-folder-tree/src/subcomponents/FolderTreeItem.jsx
+++ b/packages/terra-folder-tree/src/subcomponents/FolderTreeItem.jsx
@@ -54,6 +54,16 @@ const propTypes = {
   level: PropTypes.number,
   /**
    * @private
+   * The position of the item among its sibling items in the same group (subfolder).
+   */
+  posInSet: PropTypes.number,
+  /**
+   * @private
+   * Number of sibling items in the same group (subfolder).
+   */
+  setSize: PropTypes.number,
+  /**
+   * @private
    * Ref to the parent folder of the current item.
    */
   parentRef: PropTypes.oneOfType([
@@ -83,6 +93,8 @@ const FolderTreeItem = ({
   level,
   onSelect,
   onToggle,
+  posInSet,
+  setSize,
   subfolderItems,
   parentRef,
   intl,
@@ -103,11 +115,13 @@ const FolderTreeItem = ({
       hidden={!isExpanded}
       ref={subFolderNode}
     >
-      {subfolderItems.map((item) => (
+      {subfolderItems.map((item, index) => (
         <FolderTreeItem
           {...item.props}
           intl={intl}
           level={level + 1}
+          setSize={subfolderItems.length}
+          posInSet={index + 1}
           parentRef={itemNode}
         />
       ))}
@@ -201,6 +215,8 @@ const FolderTreeItem = ({
         aria-expanded={isFolder ? isExpanded : null}
         aria-selected={isSelectable && isSelected}
         onClick={isFolder ? handleToggle : handleSelect}
+        aria-posinset={posInSet}
+        aria-setsize={setSize}
         onKeyDown={handleKeyDown}
         data-item-show-focus
         tabIndex={-1}
@@ -231,7 +247,7 @@ const FolderTreeItem = ({
                   text={`, ${selectableAnnouncement}`}
                 />
               </span>
-)}
+            )}
             alignFitStart="center"
           />
         </span>

--- a/packages/terra-folder-tree/tests/jest/FolderTree.test.jsx
+++ b/packages/terra-folder-tree/tests/jest/FolderTree.test.jsx
@@ -41,8 +41,14 @@ describe('basic folder tree', () => {
 
     expect(subfolder.find('span.fill.fill-block').length).toBe(3);
     expect(subfolder.find('span.fill.fill-block').at(0).text()).toBe('item 1, Terra.folder-tree.item.selectable-announcement');
+    expect(subfolder.find('li[role="treeitem"]').at(0).prop('aria-setsize')).toBe(3);
+    expect(subfolder.find('li[role="treeitem"]').at(0).prop('aria-posinset')).toBe(1);
     expect(subfolder.find('span.fill.fill-block').at(1).text()).toBe('item 2, Terra.folder-tree.item.selectable-announcement');
+    expect(subfolder.find('li[role="treeitem"]').at(1).prop('aria-setsize')).toBe(3);
+    expect(subfolder.find('li[role="treeitem"]').at(1).prop('aria-posinset')).toBe(2);
     expect(subfolder.find('span.fill.fill-block').at(2).text()).toBe('item 3, Terra.folder-tree.item.selectable-announcement');
+    expect(subfolder.find('li[role="treeitem"]').at(2).prop('aria-setsize')).toBe(3);
+    expect(subfolder.find('li[role="treeitem"]').at(2).prop('aria-posinset')).toBe(3);
   });
 
   it('hides folder items when enclosing folder is collapsed', () => {


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR fixes an issue where screenreaders would announce subfolder items with sibling parents as being part of the same group. This has been done by manually setting the values for `aria-setsize` and `aria-posinset` instead of relying on browser calculations.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed
Tested with Voiceover and JAWS.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10283 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
