### PR TITLE
[compact-interactive-list] Examples updated to remove redundant button announcement.

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * Updated the `terra-data-grid` and `terra-table` focusable cell examples to remove confusion caused by column header names.
+  * Updated `terra-compact-interactive-list` examples to remove redundant button announcement.
 
 ## 1.77.0 - (March 25, 2024)
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/BasicCompactInteractiveList.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/BasicCompactInteractiveList.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/FixedWidthColumns.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/FixedWidthColumns.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/HorizontalFlow.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/HorizontalFlow.jsx
@@ -10,7 +10,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/ResponsiveColumns.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/ResponsiveColumns.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/ResponsiveColumnsMaxWidth.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/ResponsiveColumnsMaxWidth.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/ScalableUnits.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/ScalableUnits.jsx
@@ -10,7 +10,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/VerticalFlow.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/VerticalFlow.jsx
@@ -10,7 +10,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/WidthBreakpoints.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/compact-interactive-list/Examples.2/WidthBreakpoints.jsx
@@ -10,7 +10,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/Borderless.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/Borderless.test.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/FixedWidthColumns.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/FixedWidthColumns.test.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/InconsistentWidthUnits.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/InconsistentWidthUnits.test.jsx
@@ -10,7 +10,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/ResponsiveColumns.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/ResponsiveColumns.test.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/ResponsiveColumnsMaxWidth.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/ResponsiveColumnsMaxWidth.test.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/ScalableUnits.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/ScalableUnits.test.jsx
@@ -9,7 +9,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/WidthBreakpoints.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/WidthBreakpoints.test.jsx
@@ -11,7 +11,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;

--- a/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/WidthBreakpointsHorizontalFlow.test.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/test/compact-interactive-list/WidthBreakpointsHorizontalFlow.test.jsx
@@ -10,7 +10,7 @@ const FeaturedIcon = () => {
   const [isFeatured, setIsFeatured] = useState(false);
   const onButtonClick = () => setIsFeatured(!isFeatured);
   return (
-    isFeatured ? <Button variant="utility" text="Featured button" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Featured off button" icon={<IconFeaturedOff />} onClick={onButtonClick} />
+    isFeatured ? <Button variant="utility" text="Unfavorite item" icon={<IconFeatured />} onClick={onButtonClick} /> : <Button variant="utility" text="Favorite item" icon={<IconFeaturedOff />} onClick={onButtonClick} />
   );
 };
 const iconResultsNormal = <IconMultipleResultsNormal a11yLabel="Results normal" height="1.5em" width="1.5em" />;


### PR DESCRIPTION
 Updated `terra-compact-interactive-list` examples to remove the word "button" from terra-button text, which was leading to the word "button" to be announced twice. 

Previously Featured buttons (represented by star icon in examples), had text that would read "Featured button". That text would be announced by assistive technologies, followed by the second "button" word, to indicate that it was a button element. The text was replaced to read "Favorite Item", hence the full announcement changed to be "Favorite Item Button".

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

To test with JAWS, in Compact Interactive List examples tab to the compact interactive list, then using arrow keys navigate to the star icon:

<img width="595" alt="Screenshot 2024-03-27 at 5 32 31 PM" src="https://github.com/cerner/terra-framework/assets/119358186/802843f1-5081-4736-b97a-ccf0181281f4">

The announcement should be "Favorite Item Button", not "Featured Button Button".

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

**This PR resolves:**
UXPLATFORM-10261
