### PR TITLE
[terra-tabs]: More Button is Not Accessible using Keyboard or Mouse / Additional White Space Added

### DIFF
--- a/packages/terra-tabs/CHANGELOG.md
+++ b/packages/terra-tabs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixes dropdown list overflow and reset left position value after close.
+
 ## 7.23.0 - (March 25, 2024)
 
 * Changed

--- a/packages/terra-tabs/src/common-tabs/TabDropDown.module.scss
+++ b/packages/terra-tabs/src/common-tabs/TabDropDown.module.scss
@@ -8,6 +8,7 @@
     border-top-right-radius: 0;
     height: 1px;
     margin: -1px;
+    max-height: 75vh;
     max-width: var(--terra-tabs-workspace-tab-drop-down-max-width, 187px);
     min-width: var(--terra-tabs-workspace-tab-drop-down-min-width, 150px);
     opacity: 0;

--- a/packages/terra-tabs/src/common-tabs/_TabDropDown.jsx
+++ b/packages/terra-tabs/src/common-tabs/_TabDropDown.jsx
@@ -79,6 +79,7 @@ const TabDropDown = ({
       disableOnClickOutside();
       document.removeEventListener('keydown', handleKeyDown);
       dropDownRef.current.scrollTop = 0;
+      dropDownRef.current.style.left = 0;
     }
 
     return (() => {


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Added max height to the dropdown container and reset the left position value to 0 when dropdown is closed.

**Why it was changed:**

More Button is Not Accessible using Keyboard or Mouse / Additional White Space Added in Revenue cycle application

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
