### PR TITLE
[terra-table] Add Aria Sort to Column Header Cells.

### DIFF
--- a/packages/terra-table/CHANGELOG.md
+++ b/packages/terra-table/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Added `aria-sort` to Column Header Cells when a `sortIndicator` is provided to the column header.
+
 ## 5.17.0 - (March 29, 2024)
 
 * Added

--- a/packages/terra-table/src/subcomponents/ColumnHeaderCell.jsx
+++ b/packages/terra-table/src/subcomponents/ColumnHeaderCell.jsx
@@ -418,6 +418,7 @@ const ColumnHeaderCell = (props) => {
       tabIndex={isGridContext && !hasButtonElement ? -1 : undefined}
       role={!isActionCell ? 'columnheader' : undefined}
       scope={!isActionCell ? 'col' : undefined}
+      aria-sort={sortIndicator}
           // action Cell has to own a corresponding resize handle to avoid a double announcement on handle focus
       aria-owns={ownsResizeHandle ? resizeHandleId : undefined}
       title={!isActionCell ? displayName : action?.label}

--- a/packages/terra-table/src/subcomponents/ColumnHeaderCell.jsx
+++ b/packages/terra-table/src/subcomponents/ColumnHeaderCell.jsx
@@ -391,9 +391,15 @@ const ColumnHeaderCell = (props) => {
         className={cx('header-container')}
         {...hasButtonElement && { ref: columnHeaderCellRef, role: 'button' }}
         tabIndex={buttonTabIndex}
+        aria-sort={sortIndicator}
       >
         {errorIcon}
-        <span aria-hidden className={cx('display-text', { hidden: !isDisplayVisible })}>{displayName}</span>
+        <span
+          aria-hidden
+          className={cx('display-text', { hidden: !isDisplayVisible })}
+        >
+          {displayName}
+        </span>
         {sortIndicatorIcon}
         <VisuallyHiddenText text={headerDescription} />
         {columnHighlightIcon}
@@ -418,7 +424,6 @@ const ColumnHeaderCell = (props) => {
       tabIndex={isGridContext && !hasButtonElement ? -1 : undefined}
       role={!isActionCell ? 'columnheader' : undefined}
       scope={!isActionCell ? 'col' : undefined}
-      aria-sort={sortIndicator}
           // action Cell has to own a corresponding resize handle to avoid a double announcement on handle focus
       aria-owns={ownsResizeHandle ? resizeHandleId : undefined}
       title={!isActionCell ? displayName : action?.label}

--- a/packages/terra-table/tests/jest/__snapshots__/ColumnHeaderCell.test.jsx.snap
+++ b/packages/terra-table/tests/jest/__snapshots__/ColumnHeaderCell.test.jsx.snap
@@ -80,6 +80,7 @@ exports[`ColumnHeaderCell renders a pinned column header cell 1`] = `
     width={100}
   >
     <th
+      aria-sort="ascending"
       className="column-header pinned last-pinned-column"
       id="test-table-Column-0"
       key="Column-0"


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Adds Aria-Sort to the terra-table

**Why it was changed:**
So JAWS can ead the sortable table order.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10327 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
