### PR TITLE
[terra-compact-interactive list] Fix to put focus on first item only on initial render

### DIFF
--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Changed to put focus on first item only on initial render.
+  * Changed to avoid focus being set to the first cell on multiple re-renders.
 
 ## 1.15.0 - (April 4, 2024)
 

--- a/packages/terra-compact-interactive-list/CHANGELOG.md
+++ b/packages/terra-compact-interactive-list/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Changed to put focus on first item only on initial render.
+
 ## 1.15.0 - (April 4, 2024)
 
 * Changed

--- a/packages/terra-compact-interactive-list/src/CompactInteractiveList.jsx
+++ b/packages/terra-compact-interactive-list/src/CompactInteractiveList.jsx
@@ -159,7 +159,8 @@ const CompactInteractiveList = (props) => {
     if (listRef?.current && focusedCell?.current) {
       focusedCell.current = getFocusedCellIds(listRef?.current, columns, { row: 0, cell: 0 });
     }
-  }, [listRef, focusedCell, columns]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const focusCell = ({ row, cell }) => {
     // add 1 to the row number to accommodate for hidden header


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Fix to put focus on first item only on initial render by adding empty dependency array in useEffect.

**Why it was changed:**
MPages custom lifecycle method is triggering the react lifecycle method unexpectedly hence a workaround is added.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10272 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
