### PR TITLE
[terra-collapsible-menu-view] Removes dialog role for menu and sets aria-haspopup

### DIFF
--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Set aria-haspopup value to boolean.
+
 ## 6.97.0 - (April 4, 2024)
 
 * Changed

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuViewItem.jsx
@@ -149,7 +149,7 @@ class CollapsibleMenuViewItem extends React.Component {
           button={(
             <Button
               {...attributes}
-              aria-haspopup="dialog"
+              aria-haspopup
               icon={icon}
               text={text}
               isReversed={isReversed}

--- a/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
+++ b/packages/terra-collapsible-menu-view/tests/jest/CollapsibleMenuViewItem.test.jsx
@@ -65,7 +65,7 @@ describe('CollapsibleMenuViewItem', () => {
         <CollapsibleMenuViewItem text="Default Item 2" key="defaultItem2" />,
       ]}
     />);
-    expect(wrapper.find('Button').prop('aria-haspopup')).toEqual('dialog');
+    expect(wrapper.find('Button').prop('aria-haspopup')).toBe(true);
   });
 
   it('should render a disabled button when isDisabled is set', () => {

--- a/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
+++ b/packages/terra-collapsible-menu-view/tests/jest/__snapshots__/CollapsibleMenuViewItem.test.jsx.snap
@@ -680,7 +680,7 @@ exports[`CollapsibleMenuViewItem should render a menu when subMenuItems are give
 <CollapsibleMenu
   button={
     <Button
-      aria-haspopup="dialog"
+      aria-haspopup={true}
       intl={
         Object {
           "defaultFormats": Object {},

--- a/packages/terra-menu/CHANGELOG.md
+++ b/packages/terra-menu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Removed dialog role to fix axe a11y violation.
+
 ## 6.91.0 - (April 4, 2024)
 
 * Changed

--- a/packages/terra-menu/src/Menu.jsx
+++ b/packages/terra-menu/src/Menu.jsx
@@ -199,6 +199,7 @@ class Menu extends React.Component {
         hookshotPostionFixed
         isHeaderDisabled
         isContentFocusDisabled
+        popupContentRole={null}
       >
         {slides}
       </Popup>

--- a/packages/terra-menu/src/_MenuContent.jsx
+++ b/packages/terra-menu/src/_MenuContent.jsx
@@ -451,13 +451,12 @@ class MenuContent extends React.Component {
     const contentWidth = this.props.isWidthBounded ? undefined : this.props.fixedWidth;
     /* eslint-disable jsx-a11y/no-noninteractive-element-interactions, react/forbid-dom-props */
     return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         ref={this.handleContainerRef}
         className={contentClass}
         style={{ height: menuHeight, width: contentWidth, position: contentPosition }}
         tabIndex="-1"
-        aria-modal="true"
-        role="dialog"
         onKeyDown={this.onKeyDown}
         // stop event propagation in case Menu oppened inside the layout component that has its own event handler for that event.
         // added for Menu Button support in terra-compact-interactive-list.

--- a/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
+++ b/packages/terra-menu/tests/jest/__snapshots__/Menu.test.jsx.snap
@@ -82,7 +82,7 @@ exports[`Menu correctly applies the theme context className 1`] = `
       isHeaderDisabled={true}
       isOpen={true}
       onRequestClose={[MockFunction]}
-      popupContentRole="dialog"
+      popupContentRole={null}
       targetRef={
         [MockFunction] {
           "calls": Array [
@@ -203,7 +203,6 @@ exports[`Menu correctly applies the theme context className 1`] = `
                   <div
                     class="content content orion-fusion-theme fixed-position"
                     data-terra-popup-content="true"
-                    role="dialog"
                   >
                     <div
                       class="inner"
@@ -211,9 +210,7 @@ exports[`Menu correctly applies the theme context className 1`] = `
                       style="width: 240px;"
                     >
                       <div
-                        aria-modal="true"
                         class="content orion-fusion-theme"
-                        role="dialog"
                         style="position: static;"
                         tabindex="-1"
                       >
@@ -295,7 +292,7 @@ exports[`Menu correctly applies the theme context className 1`] = `
               onContentResize={[Function]}
               onRequestClose={[Function]}
               onResize={[Function]}
-              popupContentRole="dialog"
+              popupContentRole={null}
               refCallback={[Function]}
             >
               <FocusTrap
@@ -328,7 +325,7 @@ exports[`Menu correctly applies the theme context className 1`] = `
                     outsideClickIgnoreClass="ignore-react-onclickoutside"
                     preventDefault={false}
                     refCallback={[Function]}
-                    role="dialog"
+                    role={null}
                     stopPropagation={false}
                     tabIndex={null}
                   >
@@ -350,14 +347,14 @@ exports[`Menu correctly applies the theme context className 1`] = `
                       outsideClickIgnoreClass="ignore-react-onclickoutside"
                       preventDefault={false}
                       refCallback={[Function]}
-                      role="dialog"
+                      role={null}
                       stopPropagation={false}
                       tabIndex={null}
                     >
                       <div
                         className="content content orion-fusion-theme fixed-position"
                         data-terra-popup-content={true}
-                        role="dialog"
+                        role={null}
                         tabIndex={null}
                       >
                         <div
@@ -426,11 +423,9 @@ exports[`Menu correctly applies the theme context className 1`] = `
                               title=""
                             >
                               <div
-                                aria-modal="true"
                                 className="content orion-fusion-theme"
                                 onFocus={[Function]}
                                 onKeyDown={[Function]}
-                                role="dialog"
                                 style={
                                   Object {
                                     "height": undefined,


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

- Sets aria-haspopup to boolean values
- Removed dialog role terra-menu


**Why it was changed:**

- aria-haspopup was set to dialog, changed to boolean.
- Dialog role causes axe a11y failure being an inappropriate role.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10322 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
