### PR TITLE
Headers Swedish old translations fixed

### DIFF
--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
- * Headers Swedish old translations replaced to match the new translations used elsewhere.
+ * Fixed Swedish translations for headers with new translations used elsewhere.
 
 ## 4.46.0 - (April 4, 2024)
 

--- a/packages/terra-notification-dialog/CHANGELOG.md
+++ b/packages/terra-notification-dialog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+ * Headers Swedish old translations replaced to match the new translations used elsewhere.
+
 ## 4.46.0 - (April 4, 2024)
 
 * Changed

--- a/packages/terra-notification-dialog/translations/sv-SE.json
+++ b/packages/terra-notification-dialog/translations/sv-SE.json
@@ -1,6 +1,6 @@
 {
-  "Terra.notification.dialog.hazard-low":	"Information",
-  "Terra.notification.dialog.error":	"Fel",
-  "Terra.notification.dialog.hazard-medium":	"Obs!",
-  "Terra.notification.dialog.hazard-high":	"Varning"
+  "Terra.notification.dialog.hazard-low": "Information",
+  "Terra.notification.dialog.error": "Fel",
+  "Terra.notification.dialog.hazard-medium": "Obs!",
+  "Terra.notification.dialog.hazard-high": "Varning"
 }

--- a/packages/terra-notification-dialog/translations/sv-SE.json
+++ b/packages/terra-notification-dialog/translations/sv-SE.json
@@ -1,6 +1,6 @@
 {
-  "Terra.notification.dialog.hazard-low": "Information",
-  "Terra.notification.dialog.error": "Fel",
-  "Terra.notification.dialog.hazard-medium": "Varning",
-  "Terra.notification.dialog.hazard-high": "Avisering"
+  "Terra.notification.dialog.hazard-low":	"Information",
+  "Terra.notification.dialog.error":	"Fel",
+  "Terra.notification.dialog.hazard-medium":	"Obs!",
+  "Terra.notification.dialog.hazard-high":	"Varning"
 }

--- a/packages/terra-notification-dialog/translations/sv.json
+++ b/packages/terra-notification-dialog/translations/sv.json
@@ -1,6 +1,6 @@
 {
   "Terra.notification.dialog.hazard-low":	"Information",
-  "Terra.notification.dialog.error":	"Fel",
-  "Terra.notification.dialog.hazard-medium":	"Obs!",
-  "Terra.notification.dialog.hazard-high":	"Varning"
+  "Terra.notification.dialog.error": "Fel",
+  "Terra.notification.dialog.hazard-medium": "Obs!",
+  "Terra.notification.dialog.hazard-high": "Varning"
 }

--- a/packages/terra-notification-dialog/translations/sv.json
+++ b/packages/terra-notification-dialog/translations/sv.json
@@ -1,6 +1,6 @@
 {
-  "Terra.notification.dialog.hazard-low": "Information",
-  "Terra.notification.dialog.error": "Fel",
-  "Terra.notification.dialog.hazard-medium": "Varning",
-  "Terra.notification.dialog.hazard-high": "Avisering"
+  "Terra.notification.dialog.hazard-low":	"Information",
+  "Terra.notification.dialog.error":	"Fel",
+  "Terra.notification.dialog.hazard-medium":	"Obs!",
+  "Terra.notification.dialog.hazard-high":	"Varning"
 }

--- a/packages/terra-notification-dialog/translations/sv.json
+++ b/packages/terra-notification-dialog/translations/sv.json
@@ -1,5 +1,5 @@
 {
-  "Terra.notification.dialog.hazard-low":	"Information",
+  "Terra.notification.dialog.hazard-low": "Information",
   "Terra.notification.dialog.error": "Fel",
   "Terra.notification.dialog.hazard-medium": "Obs!",
   "Terra.notification.dialog.hazard-high": "Varning"


### PR DESCRIPTION
### Summary
This PR replaces **terra-notification-dialog** headers Swedish translations for locales **sv** and **sv-SE** to match the new translations used elsewhere.



### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### New headers for for locales **sv** and **sv-SE**  locales.
<img width="536" alt="Screenshot 2024-04-15 at 9 43 41 AM" src="https://github.com/cerner/terra-framework/assets/119358186/4ea86bc7-d8c0-4473-9fe6-c8f19bd1c702">
<img width="529" alt="Screenshot 2024-04-15 at 9 43 50 AM" src="https://github.com/cerner/terra-framework/assets/119358186/0e737e07-8a76-4d7e-a980-9fbf01140ed2">
<img width="535" alt="Screenshot 2024-04-15 at 9 44 00 AM" src="https://github.com/cerner/terra-framework/assets/119358186/a71876b4-1fc5-4af7-96ad-8feb163a8ed5">
<img width="531" alt="Screenshot 2024-04-15 at 9 44 08 AM" src="https://github.com/cerner/terra-framework/assets/119358186/64892c8c-7841-40a0-b35a-6ef6b9600296">


### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**
UXPLATFORM-10362
