### PR TITLE
[terra-pills] Added debouncing for resize observer

### DIFF
--- a/packages/terra-pills/CHANGELOG.md
+++ b/packages/terra-pills/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed `terra-pills` Infinite loop in ResizeObserver callback with debounce.
+
 ## 1.24.0 - (April 4, 2024)
 
 * Changed

--- a/packages/terra-pills/src/FilterPills.jsx
+++ b/packages/terra-pills/src/FilterPills.jsx
@@ -94,6 +94,8 @@ const FilterPills = (props) => {
   const isPillDeleted = useRef(false);
   const isRollUpRemoved = useRef(false);
   const removedLabel = useRef();
+  const resizingDelayTimer = useRef(null);
+  const resizeTimer = 100;
 
   // Identifies the number of pills that needs to be hidden/rolled up
   const generateRollUp = useCallback(() => {
@@ -214,16 +216,18 @@ const FilterPills = (props) => {
   }, [children, isCollapsible, resetTabIndex, handleFocusOnRollUpTrigger, handlePillDeletion, generateRollUp]);
 
   useLayoutEffect(() => {
-    let observer = new ResizeObserver((entries) => {
-      handleResize(entries);
-    });
+    const debounceResize = (entries) => {
+      clearTimeout(resizingDelayTimer.current);
+      resizingDelayTimer.current = setTimeout(() => {
+        if (resizingDelayTimer.current) handleResize(entries);
+      }, resizeTimer);
+    };
+    const observer = new ResizeObserver(debounceResize);
     observer.observe(filterPillsRef.current.parentNode);
-
     return () => {
       observer.disconnect();
-      observer = null;
     };
-  }, [children, handleResize]);
+  }, [children, filterPillsRef, handleResize]);
 
   const focusNextNode = (pills, rollUpPill) => {
     const rollUpPillId = rollUpPill ? rollUpPill.getAttribute('id') : null;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Replaced direct invocation of `handleResize` inside `ResizeObserver` callback with a debounced function.

**Why it was changed:**
To prevent potential cyclic dependencies leading to infinite loops, ensuring that handleResize is called only after a specified delay, thus resolving the issue.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10369 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
