### PR TITLE
Added a note to the Multiple Row Selection example in terra-table

### DIFF
--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added a note about accessibility requirements for sorting or another action to the Multiple Row Selection example in `terra-table`.
+
 ## 1.84.0 - (April 23, 2024)
 
 * Changed

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/table/Examples/TableMultipleRowSelection.doc.mdx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/table/Examples/TableMultipleRowSelection.doc.mdx
@@ -1,3 +1,4 @@
+import { Notice } from "@cerner/terra-docs";
 import TableRowSelection from './TableRowSelection?dev-site-example';
 
 # Table - Multiple Row Selection
@@ -8,6 +9,10 @@ Row selection mode is controlled with a property and is off by default.
 When creating a table that supports multiple row selections, the consumer must set the property.
 This example demonstrates a table with full support for multiple row selections.
 Because the component is an accessible table, each row selection checkbox is a tab stop.
+
+<Notice variant="important" ariaLevel="2">
+This example demonstrates that the column header cell in the select box column can receive focus and trigger a callback. It can be used to support sorting of the table by selected and unselected rows. However, if sorting or another action is required, to comply with accessibility guidelines, a visual indication of the action must be provided in the column header cell. Cerner UX design standards do not currently support an icon to communicate column sortability. If your workflow requires support for sorting the checkbox column, work with a UX Designer to create a solution that meets accessibility requirements.
+</Notice>
 
 ### Required Properties
 * rowSelectionMode


### PR DESCRIPTION
### Summary

Added a note about accessibility requirements for sorting or another action to the Multiple Row Selection example in terra-table.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

The screenshot of the note:

<img width="1459" alt="Screenshot 2024-04-24 at 4 55 39 PM" src="https://github.com/cerner/terra-framework/assets/119358186/00d8b1f9-5076-46c3-90a6-ec2662a45608">

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

**This PR resolves:**

UXPLATFORM-10379