### PR TITLE
[terra-folder-tree] Fix axe invalid aria attribute and 400% browser zoom

### DIFF
--- a/packages/terra-folder-tree/CHANGELOG.md
+++ b/packages/terra-folder-tree/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Changed
   * Updated the radio button hover style to be distinct from row hover.
+  * Fixed axe issue for wrong aria-control value.
 
 ## 1.3.0 - (April 23, 2024)
 

--- a/packages/terra-folder-tree/src/FolderTree.jsx
+++ b/packages/terra-folder-tree/src/FolderTree.jsx
@@ -187,7 +187,7 @@ const FolderTree = ({
       />
       <Toolbar
         align="end"
-        ariaControls={title}
+        ariaControls={folderTreeID}
         ariaLabel={title}
       >
         <Button

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated `terra-folder-tree` example styles.
+
 ## 1.85.0 - (May 1, 2024)
 
 * Changed

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/folder-tree/Examples.2/BasicFolderTree.module.scss
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/folder-tree/Examples.2/BasicFolderTree.module.scss
@@ -1,6 +1,5 @@
 :local {
   .content-wrapper {
     position: relative;
-    width: 300px;
   }
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Updated aria-control label.
Removed default width for the folder tree example

**Why it was changed:**

In 400% browser zoom, some of the folders are hiding from the screen. Therefor user don't have access to some folders and they can't be accessed.
Axe issues - Invalid ARIA attribute value: aria-controls="Folder" in the toolbar 'expand all and collapse all' section

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [x] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10399- <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
