### PR TITLE
[terra-modal-manager] Added zIndex prop to handle nested modals.

### DIFF
--- a/packages/terra-application-layout/tests/jest/__snapshots__/ApplicationLayout.test.jsx.snap
+++ b/packages/terra-application-layout/tests/jest/__snapshots__/ApplicationLayout.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`ApplicationLayout Snapshot Tests renders the ApplicationLayout with giv
 <ModalManager
   closeOnOutsideClick={false}
   shouldTrapFocus={false}
+  zIndex="6000"
 >
   <withRouter(NavigationLayout)
     config={
@@ -311,6 +312,7 @@ exports[`ApplicationLayout Snapshot Tests renders the ApplicationLayout with onl
 <ModalManager
   closeOnOutsideClick={false}
   shouldTrapFocus={false}
+  zIndex="6000"
 >
   <withRouter(NavigationLayout)
     config={
@@ -428,6 +430,7 @@ exports[`ApplicationLayout Snapshot Tests when given nav items with icons matche
 <ModalManager
   closeOnOutsideClick={false}
   shouldTrapFocus={false}
+  zIndex="6000"
 >
   <withRouter(NavigationLayout)
     config={

--- a/packages/terra-framework-docs/CHANGELOG.md
+++ b/packages/terra-framework-docs/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Changed
   * Updated `terra-folder-tree` example styles.
 
+* Changed
+  * Updated `terra-modal-manager` example to consume `zIndex` prop.
+
 ## 1.85.0 - (May 1, 2024)
 
 * Changed

--- a/packages/terra-framework-docs/src/terra-dev-site/doc/modal-manager/example/ModalManagerExample.jsx
+++ b/packages/terra-framework-docs/src/terra-dev-site/doc/modal-manager/example/ModalManagerExample.jsx
@@ -284,6 +284,7 @@ const ModalManagerExample = ({ showDisclosureAccessory }) => (
           Disclosure Accessory
         </div>
       ) : undefined}
+      zIndex="7000"
     >
       <ContentComponent disclosureType="modal" />
     </ModalManager>

--- a/packages/terra-modal-manager/CHANGELOG.md
+++ b/packages/terra-modal-manager/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Added `zIndex` prop to handle nested modals.
+
 ## 6.76.0 - (April 4, 2024)
 
 * Changed

--- a/packages/terra-modal-manager/src/ModalManager.jsx
+++ b/packages/terra-modal-manager/src/ModalManager.jsx
@@ -15,6 +15,8 @@ export { disclosureType };
 
 const cx = classNamesBind.bind(styles);
 
+const zIndexes = ['6000', '7000', '8000', '9000'];
+
 const propTypes = {
   /**
    * The components to be rendered in the body of the ModalManager. These components will receive the
@@ -38,11 +40,16 @@ const propTypes = {
    * If set to true, then the outside click will get enabled.
    */
   closeOnOutsideClick: PropTypes.bool,
+  /**
+   * Z-Index layer to apply to the ModalContent and ModalOverlay. Valid values are the standard modal layer: '6000', and the max layer: '8000'.
+   */
+  zIndex: PropTypes.oneOf(zIndexes),
 };
 
 const defaultProps = {
   shouldTrapFocus: false,
   closeOnOutsideClick: false,
+  zIndex: '6000',
 };
 
 const heightFromSize = {
@@ -81,7 +88,7 @@ class ModalManager extends React.Component {
 
   renderModal(manager) {
     const {
-      children, disclosureAccessory, withDisclosureContainer, shouldTrapFocus, closeOnOutsideClick, ...customProps
+      children, disclosureAccessory, withDisclosureContainer, shouldTrapFocus, closeOnOutsideClick, zIndex, ...customProps
     } = this.props;
     const theme = this.context;
 
@@ -120,6 +127,7 @@ class ModalManager extends React.Component {
           ariaLabel={(headerDataForPresentedComponent) ? headerDataForPresentedComponent.title : customProps['aria-label'] || 'Modal'}
           setModalFocusElementRef={this.setModalFocusElementRef}
           shouldTrapFocus={shouldTrapFocus}
+          zIndex={zIndex}
         >
           <ContentContainer
             fill

--- a/packages/terra-modal-manager/src/ModalManager.jsx
+++ b/packages/terra-modal-manager/src/ModalManager.jsx
@@ -41,7 +41,7 @@ const propTypes = {
    */
   closeOnOutsideClick: PropTypes.bool,
   /**
-   * Z-Index layer to apply to the ModalContent and ModalOverlay. Valid values are the standard modal layer: '6000', and the max layer: '8000'.
+   * Z-Index layer to apply to the ModalContent and ModalOverlay. Valid values are the standard modal layer: '6000', and the max layer: '9000'.
    */
   zIndex: PropTypes.oneOf(zIndexes),
 };

--- a/packages/terra-modal-manager/tests/jest/ModalManager.test.jsx
+++ b/packages/terra-modal-manager/tests/jest/ModalManager.test.jsx
@@ -94,4 +94,15 @@ describe('ModalManager', () => {
     );
     expect(modalManager).toMatchSnapshot();
   });
+
+  it('should render the ModalManager with custom zIndex', () => {
+    const modalManager = (
+      <ModalManager zIndex="7000">
+        <TestContainer />
+      </ModalManager>
+    );
+
+    const result = enzymeIntl.mountWithIntl(modalManager);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
+++ b/packages/terra-modal-manager/tests/jest/__snapshots__/ModalManager.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`ModalManager correctly applies the theme context className 1`] = `
   <ModalManager
     closeOnOutsideClick={false}
     shouldTrapFocus={false}
+    zIndex="6000"
   >
     <withDisclosureManager(DisclosureManager)
       render={[Function]}
@@ -102,6 +103,7 @@ exports[`ModalManager should disclose content in Modal 1`] = `
     }
   }
   shouldTrapFocus={true}
+  zIndex="6000"
 >
   <withDisclosureManager(DisclosureManager)
     render={[Function]}
@@ -1350,6 +1352,7 @@ exports[`ModalManager should render the ModalManager with custom props 1`] = `
     }
   }
   shouldTrapFocus={false}
+  zIndex="6000"
 >
   <withDisclosureManager(DisclosureManager)
     render={[Function]}
@@ -1437,6 +1440,124 @@ exports[`ModalManager should render the ModalManager with custom props 1`] = `
 </ModalManager>
 `;
 
+exports[`ModalManager should render the ModalManager with custom zIndex 1`] = `
+<ModalManager
+  closeOnOutsideClick={false}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": null,
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
+  shouldTrapFocus={false}
+  zIndex="7000"
+>
+  <withDisclosureManager(DisclosureManager)
+    render={[Function]}
+    supportedDisclosureTypes={
+      Array [
+        "modal",
+      ]
+    }
+    trapNestedDisclosureRequests={true}
+  >
+    <DisclosureManager
+      render={[Function]}
+      supportedDisclosureTypes={
+        Array [
+          "modal",
+        ]
+      }
+      trapNestedDisclosureRequests={true}
+    >
+      <div
+        className="container"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {},
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": null,
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": "span",
+            "timeZone": null,
+          }
+        }
+      >
+        <withDisclosureManager(Component)>
+          <Component
+            disclosureManager={
+              DisclosureManagerDelegateInstance {
+                "disclose": [Function],
+              }
+            }
+          >
+            <button
+              type="button"
+            >
+              Hello World
+            </button>
+          </Component>
+        </withDisclosureManager(Component)>
+        <AbstractModal
+          ariaLabel="Modal"
+          classNameModal="modal-manager"
+          classNameOverlay={null}
+          closeOnEsc={true}
+          closeOnOutsideClick={false}
+          isCalledFromNotificationDialog={false}
+          isFullscreen={false}
+          isOpen={false}
+          onRequestClose={[Function]}
+          role="dialog"
+          rootSelector="#root"
+          setModalFocusElementRef={[Function]}
+          shouldTrapFocus={false}
+          zIndex="7000"
+        />
+      </div>
+    </DisclosureManager>
+  </withDisclosureManager(DisclosureManager)>
+</ModalManager>
+`;
+
 exports[`ModalManager should render the ModalManager with defaults 1`] = `
 <ModalManager
   closeOnOutsideClick={false}
@@ -1468,6 +1589,7 @@ exports[`ModalManager should render the ModalManager with defaults 1`] = `
     }
   }
   shouldTrapFocus={false}
+  zIndex="6000"
 >
   <withDisclosureManager(DisclosureManager)
     render={[Function]}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**

Added `zIndex` prop to allow consumers to set custom z-index to modals.

**Why it was changed:**
Custom zindex will allow consumers to have nested modals.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10380 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
